### PR TITLE
Suppress naming consistency checks for MonoBehaviours events

### DIFF
--- a/src/resharper-unity/NamingConsistencyWarningSuppressor.cs
+++ b/src/resharper-unity/NamingConsistencyWarningSuppressor.cs
@@ -1,0 +1,34 @@
+﻿using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Naming.Impl;
+using JetBrains.ReSharper.Psi.Naming.Interfaces;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity
+{
+    [NamingConsistencyChecker(typeof(CSharpLanguage))]
+    public class NamingConsistencyWarningSuppressor : INamingConsistencyChecker
+    {
+        public bool IsApplicable(IPsiSourceFile sourceFile) => true;
+
+        public void Check(IDeclaration declaration, INamingPolicyProvider namingPolicyProvider, out bool isFinalResult, out NamingConsistencyCheckResult result)
+        {
+            
+            var methodDeclaration = declaration as IMethodDeclaration;
+            if (methodDeclaration != null && MonoBehaviourUtil.IsEventHandler(methodDeclaration.DeclaredName))
+            {
+                var containingTypeElement = methodDeclaration.GetContainingTypeDeclaration().DeclaredElement;
+                if (containingTypeElement != null && MonoBehaviourUtil.IsMonoBehaviourType(containingTypeElement, methodDeclaration.GetPsiModule()))
+                {
+                    result = NamingConsistencyCheckResult.OK;
+                    isFinalResult = true;
+                    return;
+                }
+            }
+
+            result = null;
+            isFinalResult = false;
+        }
+    }
+}

--- a/src/resharper-unity/resharper-unity.csproj
+++ b/src/resharper-unity/resharper-unity.csproj
@@ -157,6 +157,7 @@
   <ItemGroup>
     <Compile Include="MessageHandlerGeneratorProvider.cs" />
     <Compile Include="MonoBehaviourUtil.cs" />
+    <Compile Include="NamingConsistencyWarningSuppressor.cs" />
     <Compile Include="UsageInspectionsSuppressor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZoneMarker.cs" />


### PR DESCRIPTION
This PR suppresses naming warnings on MonoBehaviour's event handlers.

(eg. AnimatorIK has a warning suggesting to rename it to AnimatorIk with the default rules, thus breaking code if applied)