### PR TITLE
In-memory per-project settings

### DIFF
--- a/src/resharper-unity/.editorconfig
+++ b/src/resharper-unity/.editorconfig
@@ -1,0 +1,5 @@
+root=true
+
+[*.cs]
+indent_style=space
+indent_size=4

--- a/src/resharper-unity/ProjectModel/Properties/Flavours/UnityProjectFlavor.cs
+++ b/src/resharper-unity/ProjectModel/Properties/Flavours/UnityProjectFlavor.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using JetBrains.ProjectModel.Properties;
+
+namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Properties.Flavours
+{
+    [ProjectFlavor]
+    public class UnityProjectFlavor : IProjectFlavor
+    {
+        public static Guid UnityProjectFlavorGuid = new Guid("{E097FAD1-6243-4DAD-9C02-E9B9EFC3FFC1}");
+
+        public Guid Guid => UnityProjectFlavorGuid;
+        public string FlavorName => "Unity Project";
+    }
+}

--- a/src/resharper-unity/Settings/PerProjectSettings.cs
+++ b/src/resharper-unity/Settings/PerProjectSettings.cs
@@ -1,0 +1,49 @@
+﻿using JetBrains.Application;
+using JetBrains.Application.Settings;
+using JetBrains.Application.Settings.Storage;
+using JetBrains.Application.Settings.Store.Implementation;
+using JetBrains.DataFlow;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.DataContext;
+using JetBrains.ProjectModel.Settings.Storages;
+using JetBrains.ReSharper.Plugins.Unity.ProjectModel.Properties.Flavours;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Settings
+{
+    [SolutionComponent]
+    public class PerProjectSettings
+    {
+        public PerProjectSettings(Lifetime lifetime, IViewableProjectsCollection projects,
+                                  SettingsStorageProvidersCollection settingsStorageProviders, IShellLocks locks,
+                                  ILogger logger, InternKeyPathComponent interned)
+        {
+            projects.Projects.View(lifetime, (projectLifetime, project) =>
+            {
+                if (!project.HasFlavour<UnityProjectFlavor>())
+                    return;
+
+                CreateMountPoint(projectLifetime, project, settingsStorageProviders, locks, logger, interned);
+            });
+        }
+
+        private static void CreateMountPoint(Lifetime projectLifetime,
+                                             IProject project, SettingsStorageProvidersCollection settingsStorageProviders,
+                                             IShellLocks locks, ILogger logger,
+                                             InternKeyPathComponent interned)
+        {
+            var storageName = $"Project {project.Name} (Unity)";
+            var storage = SettingsStorageFactory.CreateStorage(projectLifetime, storageName, logger, interned);
+            var isAvailable = new IsAvailableByDataConstant<IProject>(projectLifetime,
+                ProjectModelDataConstants.Project, project, locks);
+
+            // Set at a priority less than the .csproj.dotSettings layer, so we can be overridden
+            var priority = ProjectModelSettingsStorageMountPointPriorityClasses.ProjectShared*0.9;
+            var mountPoint = new SettingsStorageMountPoint(storage, SettingsStorageMountPoint.MountPath.Default,
+                MountPointFlags.IsDefaultValues, priority, isAvailable, storageName);
+
+            settingsStorageProviders.MountPoints.Add(projectLifetime, mountPoint);
+            settingsStorageProviders.Storages.Add(projectLifetime, storage);
+        }
+    }
+}

--- a/src/resharper-unity/resharper-unity.csproj
+++ b/src/resharper-unity/resharper-unity.csproj
@@ -155,6 +155,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Settings\PerProjectSettings.cs" />
     <Compile Include="MessageHandlerGeneratorProvider.cs" />
     <Compile Include="MonoBehaviourEvent.cs" />
     <Compile Include="MonoBehaviourUtil.cs" />

--- a/src/resharper-unity/resharper-unity.csproj
+++ b/src/resharper-unity/resharper-unity.csproj
@@ -159,6 +159,7 @@
     <Compile Include="MonoBehaviourEvent.cs" />
     <Compile Include="MonoBehaviourUtil.cs" />
     <Compile Include="NamingConsistencyWarningSuppressor.cs" />
+    <Compile Include="ProjectModel\Properties\Flavours\UnityProjectFlavor.cs" />
     <Compile Include="UnityEnginePredefinedType.cs" />
     <Compile Include="UsageInspectionsSuppressor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Creates an in-memory per-project settings layer for each unity project. The layer is invisible, and cannot be edited, but can be overridden by the normal `.csproj.dotSettings` and `.csproj.dotSettings.user` files.

The following settings are written to the layer, to act as defaults:

* Disables the `Assets` and `Assets\Scripts` folders as namespace providers. ReSharper will no longer suggest `Assets` or `Scripts` should be part of the namespace (#6)
* Defaults Unity projects to C#5 (#5)