### PR TITLE
resolved issue #15

### DIFF
--- a/src/resharper-unity/Extensions.cs
+++ b/src/resharper-unity/Extensions.cs
@@ -1,0 +1,14 @@
+﻿using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.Impl;
+using JetBrains.ReSharper.Psi;
+
+namespace JetBrains.ReSharper.Plugins.Unity
+{
+    public static class Extensions
+    {
+        public static bool HasAttribute([NotNull] this IAttributesSet set, [NotNull] string attribute)
+        {
+            return set.HasAttributeInstance(new ClrTypeName(attribute), true);
+        }
+    }
+}

--- a/src/resharper-unity/resharper-unity.csproj
+++ b/src/resharper-unity/resharper-unity.csproj
@@ -136,6 +136,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Linq" />
     <Reference Include="System.Windows.Interactivity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.2.0.20140318.0\lib\System.Windows.Interactivity.dll</HintPath>
@@ -155,6 +156,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Settings\PerProjectSettings.cs" />
     <Compile Include="MessageHandlerGeneratorProvider.cs" />
     <Compile Include="MonoBehaviourEvent.cs" />


### PR DESCRIPTION
- suppressing ReSharper warnings about fields not being used or fields that can be made private on public fields in types annotated with System.SerializableAttribute, types derived from UnityEngine.UnityObject
- private fields annotated with UnityEngine.SerializeField attribute are not marked as unused when they are located inside of a type annotated with System.SerializableAttribute or a type derived from UnityEngine.UnityObject