### PR TITLE
Adding initial annotations for UnityEngine and UnityEditor not null items

### DIFF
--- a/src/resharper-unity/annotations/UnityEditor.xml
+++ b/src/resharper-unity/annotations/UnityEditor.xml
@@ -1,0 +1,6 @@
+<assembly name="UnityEditor">
+  <member name="P:UnityEditor.Editor.serializedObject">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  </member>
+</assembly>

--- a/src/resharper-unity/annotations/UnityEngine.xml
+++ b/src/resharper-unity/annotations/UnityEngine.xml
@@ -8,4 +8,7 @@
   <member name="P:UnityEngine.GameObject.transform">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
+  <member name="P:UnityEngine.Object.name">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
 </assembly>

--- a/src/resharper-unity/annotations/UnityEngine.xml
+++ b/src/resharper-unity/annotations/UnityEngine.xml
@@ -1,0 +1,11 @@
+<assembly name="UnityEngine">
+  <member name="P:UnityEngine.Component.transform">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:UnityEngine.Component.gameObject">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:UnityEngine.GameObject.transform">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+</assembly>

--- a/src/resharper-unity/resharper-unity.nuspec
+++ b/src/resharper-unity/resharper-unity.nuspec
@@ -35,5 +35,7 @@ From previous releases:
     <tags>resharper unity unity3d</tags>
   </metadata>
   <files>
+    <file src="annotations\UnityEngine.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEngine.xml" />
+    <file src="annotations\UnityEditor.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEditor.xml" />
   </files>
 </package>


### PR DESCRIPTION
I added the items that I know for certainty are not null.  Probably could be more added in the future but this gets the most common items that can never be null.