### PR TITLE
Improve local build process

### DIFF
--- a/resharper/src/build-local.ps1
+++ b/resharper/src/build-local.ps1
@@ -1,7 +1,8 @@
 param (
   [string]$Configuration = "Debug", # Release / Debug
-  [string]$GradleTask = "runIde" # runIde / buildPlugin
+  [switch]$RunIde = $True # If true, builds and runs the Rider plugin, else packages whole solution
 )
 
 Push-Location ((Split-Path $MyInvocation.InvocationName) + "\..\..\")
-Invoke-Expression ".\build.ps1 -Configuration $Configuration -GradleTask $GradleTask"
+$runIdeArg = if ($RunIde) {"-RunIde"} else {""}
+Invoke-Expression ".\build.ps1 -Configuration $Configuration $runIdeArg"


### PR DESCRIPTION
Changes `build-local.ps1` to make it quicker to get from the command line to a running plugin in Rider.

* Only builds the Rider project and not the ReSharper or test projects (tests can be built and run from within Visual Studio)
* Packages the Rider project
* Runs `gradlew runIde`

It also doesn't do nuget restore. If a full build is required, run `build.ps1` in the root dir.