### PR TITLE
Change reference to nunit.framework.dll

### DIFF
--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -103,7 +103,9 @@ namespace Plugins.Editor.JetBrains
         if (hintPath != null)
         {
           string unityAppBaseFolder = Path.GetDirectoryName(EditorApplication.applicationPath);
-          hintPath.Value = Path.Combine(unityAppBaseFolder, "Data/Managed/nunit.framework.dll");
+          var path = Path.Combine(unityAppBaseFolder, "Data/Managed/nunit.framework.dll");
+          if (new FileInfo(path).Exists)
+            hintPath.Value = path;
         }
       }
     }

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -67,6 +67,7 @@ namespace Plugins.Editor.JetBrains
       XNamespace xmlns = projectContentElement.Name.NamespaceName; // do not use var
 
       FixTargetFrameworkVersion(projectContentElement, xmlns);
+      FixSystemXml(projectContentElement, xmlns);
       SetLangVersion(projectContentElement, xmlns);
       ChangeNunitReference(new FileInfo(projectFile).DirectoryName, projectContentElement, xmlns);
       
@@ -76,6 +77,18 @@ namespace Plugins.Editor.JetBrains
       SetXCodeDllReference("UnityEditor.iOS.Extensions.Common.dll", xmlns, projectContentElement);
 #endif
       doc.Save(projectFile);
+    }
+    
+    private static void FixSystemXml(XElement projectContentElement, XNamespace xmlns)
+    {
+      var el = projectContentElement
+        .Elements(xmlns+"ItemGroup")
+        .Elements(xmlns+"Reference")
+        .FirstOrDefault(a => a.Attribute("Include").Value=="System.XML");
+      if (el != null)
+      {
+        el.Attribute("Include").Value = "System.Xml";
+      }
     }
 
     private static void ChangeNunitReference(string baseDir, XElement projectContentElement, XNamespace xmlns)

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -69,7 +69,11 @@ namespace Plugins.Editor.JetBrains
       FixTargetFrameworkVersion(projectContentElement, xmlns);
       FixSystemXml(projectContentElement, xmlns);
       SetLangVersion(projectContentElement, xmlns);
+      // Unity_5_6_OR_NEWER switched to nunit 3.5
+      // Fix helps only for Windows, on mac and linux I get https://youtrack.jetbrains.com/issue/RSRP-459932
+#if UNITY_5_6_OR_NEWER && UNITY_STANDALONE_WIN
       ChangeNunitReference(new FileInfo(projectFile).DirectoryName, projectContentElement, xmlns);
+#endif
       
 #if !UNITY_2017_1_OR_NEWER // Unity 2017.1 and later has this features by itself 
       SetManuallyDefinedComilingSettings(projectFile, projectContentElement, xmlns);

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -90,7 +90,7 @@ namespace Plugins.Editor.JetBrains
         if (hintPath != null)
         {
           string unityAppBaseFolder = Path.GetDirectoryName(EditorApplication.applicationPath);
-          hintPath.Value = Path.Combine(unityAppBaseFolder, "Managed/nunit.framework.dll");
+          hintPath.Value = Path.Combine(unityAppBaseFolder, "Data/Managed/nunit.framework.dll");
         }
       }
     }

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -4,10 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml;
 using System.Xml.Linq;
 using UnityEditor;
-using Debug = UnityEngine.Debug;
 
 namespace Plugins.Editor.JetBrains
 {
@@ -53,32 +51,6 @@ namespace Plugins.Editor.JetBrains
       File.WriteAllText(slnFile, sb.ToString());
     }
 
-    private static void AddPackagesConfig(string currentDirectory)
-    {
-      if (!Directory.GetFiles(currentDirectory, "packages.config").Any())
-      {
-        XmlDocument doc = new XmlDocument();
-        XmlNode docNode = doc.CreateXmlDeclaration("1.0", "utf-8", null);
-        doc.AppendChild(docNode);
-
-        XmlNode packages = doc.CreateElement("packages");
-        doc.AppendChild(packages);
-
-        XmlNode packagElement = doc.CreateElement("package");
-        var idAttribute = doc.CreateAttribute("id");
-        idAttribute.Value = "NUnit";
-        packagElement.Attributes.Append(idAttribute);
-        var version = doc.CreateAttribute("version");
-        version.Value = "3.5.0";
-        packagElement.Attributes.Append(version);
-        var targetFramework = doc.CreateAttribute("targetFramework");
-        targetFramework.Value = "net35";
-        packagElement.Attributes.Append(targetFramework);
-        packages.AppendChild(packagElement);
-        doc.Save(Path.Combine(currentDirectory, "packages.config"));
-      }
-    }
-
     private static string GetFileNameWithoutExtension(string path)
     {
       if (string.IsNullOrEmpty(path))
@@ -114,11 +86,11 @@ namespace Plugins.Editor.JetBrains
         .FirstOrDefault(a => a.Attribute("Include").Value=="nunit.framework");
       if (el != null)
       {
-        AddPackagesConfig(baseDir);
         var hintPath = el.Elements(xmlns + "HintPath").FirstOrDefault();
         if (hintPath != null)
         {
-          hintPath.Value = @"packages\NUnit.3.5.0\lib\net35\nunit.framework.dll";
+          string unityAppBaseFolder = Path.GetDirectoryName(EditorApplication.applicationPath);
+          hintPath.Value = Path.Combine(unityAppBaseFolder, "Managed/nunit.framework.dll");
         }
       }
     }


### PR DESCRIPTION
Original reference is 
C:/Program Files/Unity 2017.2.0b3/Editor/Data/UnityExtensions/Unity/TestRunner/net35/unity-custom/nunit.framework.dll
Updated one is 
C:/Program Files/Unity 2017.2.0b3/Editor\Data/Managed/nunit.framework.dll
See comparison 
https://youtrack.jetbrains.com/_persistent/image2.png?file=74-435202&c=true&updated=1501665019076

Original one has System.Web.UI type, and thus doesn't play fine with Re# unit test runner.