### PR TITLE
Allow to set desired TargetFrameworkVersion in Unity

### DIFF
--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -239,16 +239,7 @@ namespace Plugins.Editor.JetBrains
         .FirstOrDefault(); // Processing csproj files, which are not Unity-generated #56
       if (targetFrameworkVersion != null)
       {
-        var version = new Version(targetFrameworkVersion.Value.Substring(1));
-        if (RiderPlugin.TargetFrameworkVersion45)
-        {
-          if (version < new Version(4, 5))
-            targetFrameworkVersion.SetValue("v4.5");
-        }
-        else
-        {
-          targetFrameworkVersion.SetValue("v3.5");
-        }
+        targetFrameworkVersion.SetValue(RiderPlugin.TargetFrameworkVersion);
       }
     }
 

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderAssetPostprocessor.cs
@@ -239,7 +239,7 @@ namespace Plugins.Editor.JetBrains
         .FirstOrDefault(); // Processing csproj files, which are not Unity-generated #56
       if (targetFrameworkVersion != null)
       {
-        targetFrameworkVersion.SetValue(RiderPlugin.TargetFrameworkVersion);
+        targetFrameworkVersion.SetValue("v"+RiderPlugin.TargetFrameworkVersion);
       }
     }
 

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -104,17 +104,13 @@ namespace Plugins.Editor.JetBrains
       get { return EditorPrefs.GetString("Rider_TargetFrameworkVersion", EditorPrefs.GetBool("Rider_TargetFrameworkVersion45", true)?"4.5":"3.5"); }
       set
       {
-        var isVersion = true;
         try
         {
           new Version(value); // mono 2.6 doesn't support Version.TryParse
-        }
-        catch (Exception)
-        {
-          isVersion = false;
-        }
-        if (isVersion)
           EditorPrefs.SetString("Rider_TargetFrameworkVersion", value);
+        }
+        catch (ArgumentException){} // can't put loggin here because ot fire on every symbol
+        catch (FormatException){}
       }
     }
 

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -102,7 +102,20 @@ namespace Plugins.Editor.JetBrains
     public static string TargetFrameworkVersion
     {
       get { return EditorPrefs.GetString("Rider_TargetFrameworkVersion", EditorPrefs.GetBool("Rider_TargetFrameworkVersion45", true)?"4.5":"3.5"); }
-      set { EditorPrefs.SetString("Rider_TargetFrameworkVersion", value); }
+      set
+      {
+        var isVersion = true;
+        try
+        {
+          new Version(value); // mono 2.6 doesn't support Version.TryParse
+        }
+        catch (Exception)
+        {
+          isVersion = false;
+        }
+        if (isVersion)
+          EditorPrefs.SetString("Rider_TargetFrameworkVersion", value);
+      }
     }
 
     public enum LoggingLevel

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -99,10 +99,10 @@ namespace Plugins.Editor.JetBrains
         return riderPath;
     }
 
-    public static bool TargetFrameworkVersion45
+    public static string TargetFrameworkVersion
     {
-      get { return EditorPrefs.GetBool("Rider_TargetFrameworkVersion45", true); }
-      set { EditorPrefs.SetBool("Rider_TargetFrameworkVersion45", value); }
+      get { return EditorPrefs.GetString("Rider_TargetFrameworkVersion", EditorPrefs.GetBool("Rider_TargetFrameworkVersion45", true)?"4.5":"3.5"); }
+      set { EditorPrefs.SetString("Rider_TargetFrameworkVersion", value); }
     }
 
     public enum LoggingLevel
@@ -467,16 +467,17 @@ namespace Plugins.Editor.JetBrains
       
       EditorGUI.BeginChangeCheck();
 
-      var help = @"For now target 4.5 is strongly recommended.
+      var help = @"TargetFramework >= 4.5 is strongly recommended.
  - Without 4.5:
     - Rider will fail to resolve System.Linq on Mac/Linux
     - Rider will fail to resolve Firebase Analytics.
  - With 4.5 Rider will show ambiguous references in UniRx.
 All those problems will go away after Unity upgrades to mono4.";
-      TargetFrameworkVersion45 =
-        EditorGUILayout.Toggle(
-          new GUIContent("TargetFrameworkVersion 4.5",
-            help), TargetFrameworkVersion45);
+           
+      TargetFrameworkVersion =
+        EditorGUILayout.TextField(
+          new GUIContent("TargetFrameworkVersion",
+            help), TargetFrameworkVersion);
       EditorGUILayout.HelpBox(help, MessageType.None);
 
       EditorGUI.EndChangeCheck();


### PR DESCRIPTION
Consider VS2017 MSBuild + dotnet framework targetpack 4.7 will not load project with TargetFrameworkVersion = 4.5, so we need to allow customization.
Unfortunately proper detection of installed targets packs is complicated.