### PR TITLE
Fixes RIDER-8386 (unable to reference property in BlendOp)

### DIFF
--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
@@ -10,6 +10,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
         public const string IDS_BIND_COMMAND = "Bind command";
         public const string IDS_BIND_VALUE = "Bind value";
         public const string IDS_BLEND_FACTOR = "Blend factor";
+        public const string IDS_BLEND_OP_VALUE = "Blend op value";
         public const string IDS_BLEND_VALUE = "Blend value";
         public const string IDS_BLOCK_COMMAND = "Block command";
         public const string IDS_BLOCK_VALUE = "Block value";
@@ -31,6 +32,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
         public const string IDS_OPERATOR = "operator";
         public const string IDS_PASS_DEF = "pass definition";
         public const string IDS_PROPERTY_TYPE = "property type";
+        public const string IDS_REFERENCED_PROPERTY = "referenced property";
         public const string IDS_RENDER_STATE_COMMAND = "render state command";
         public const string IDS_REGULAR_PASS_CONTENTS = "Pass command";
         public const string IDS_SHADER_CONTENTS = "Shader contents";

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
@@ -1239,11 +1239,17 @@ blendOpValue
 :
   NUMERIC_LITERAL<RENDER_TARGET_INDEX, RenderTargetIndex>?
   // Treat Op enum value as an identifier, rather than a keyword
-  shaderLabIdentifier<OP_COLOR, OpColor>
+  (
+    shaderLabIdentifier<OP_COLOR, OpColor>
+    | referencedProperty<SHADER_LAB_REFERENCE, ReferencedProperty>
+  )
   (
     COMMA<COMMA, Comma>
-    shaderLabIdentifier<OP_ALPHA, OpAlpha>
-  )?
+    (
+      shaderLabIdentifier<OP_ALPHA, OpAlpha>
+      | referencedProperty<SHADER_LAB_REFERENCE, ReferencedProperty>
+    )
+  )? 
 ;
 
 alphaToMaskCommand

--- a/resharper/test/data/psi/shaderLab/parsing/BlendOp.shader
+++ b/resharper/test/data/psi/shaderLab/parsing/BlendOp.shader
@@ -1,0 +1,31 @@
+{caret}Shader "Test"
+{
+    Properties
+    {
+        _Op("_Op",Float) = 0
+	    _ColorOp("_ColorOp",Float) = 0
+	    _AlphaOp("_AlphaOp",Float) = 0
+    }
+    
+    SubShader
+    {    
+        BlendOp [_Op]
+	    BlendOp Min	
+
+	    BlendOp [_ColorOp], [_AlphaOp]
+	    BlendOp [_ColorOp], Min
+	    BlendOp Min, [_AlphaOp]
+	    BlendOp Min, Min
+
+	    BlendOp 1 [_ColorOp], [_AlphaOp]
+	    BlendOp 1 [_ColorOp], Min
+	    BlendOp 1 Min, [_AlphaOp]
+	    BlendOp 1 Min, Min
+	    BlendOp 1 [_Op]
+	    BlendOp 1 Min
+
+        Pass
+        {
+        }
+    }
+}

--- a/resharper/test/data/psi/shaderLab/parsing/BlendOp.shader.gold
+++ b/resharper/test/data/psi/shaderLab/parsing/BlendOp.shader.gold
@@ -1,0 +1,270 @@
+﻿Language: PsiLanguageType:SHADERLAB
+IShaderLabFile
+  IShaderCommand
+    ShaderLabTokenType+KeywordTokenElement(type:SHADER_KEYWORD, text:Shader)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    IShaderValue
+      ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"Test")
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+      IPropertiesCommand
+        ShaderLabTokenType+KeywordTokenElement(type:PROPERTIES_KEYWORD, text:Properties)
+        NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+        Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+        IPropertiesValue
+          ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_Op)
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"_Op")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:FLOAT_KEYWORD, text:Float)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IScalarPropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:0)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_ColorOp)
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"_ColorOp")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:FLOAT_KEYWORD, text:Float)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IScalarPropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:0)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_AlphaOp)
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"_AlphaOp")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:FLOAT_KEYWORD, text:Float)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IScalarPropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:0)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+          ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+      ISubShaderCommand
+        ShaderLabTokenType+KeywordTokenElement(type:SUB_SHADER_KEYWORD, text:SubShader)
+        NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+        Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+        ISubShaderValue
+          ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+          Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_Op)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          Whitespace(type:WHITESPACE, text:	) spaces: "	"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_ColorOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_AlphaOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_ColorOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_AlphaOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_ColorOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_AlphaOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_ColorOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_AlphaOp)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+              ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IReferencedProperty
+                ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                IShaderLabIdentifier
+                  Identifier(type:IDENTIFIER, text:_Op)
+                ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	    ) spaces: "	    "
+          IBlendOpCommand
+            ShaderLabTokenType+KeywordTokenElement(type:BLEND_OP_KEYWORD, text:BlendOp)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            IBlendOpValue
+              ShaderLabTokenType+GenericTokenElement(type:NUMERIC_LITERAL, text:1)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IShaderLabIdentifier
+                Identifier(type:IDENTIFIER, text:Min)
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+          IRegularPassDef
+            ShaderLabTokenType+KeywordTokenElement(type:PASS_KEYWORD, text:Pass)
+            NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+            Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+            IRegularPassValue
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+          ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+

--- a/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
+++ b/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
@@ -50,6 +50,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.Psi.ShaderLab.Parsing
         [TestCase("LOD")]
 
         [TestCase("Blending")]
+        [TestCase("BlendOp")] 
 
         [TestCase("LegacyLighting01")]
         [TestCase("LegacyLighting02")]


### PR DESCRIPTION
https://docs.unity3d.com/Manual/SL-Blend.html
`BlendOp N Op`
`BlendOp N OpColor, OpAlpha` 
Allows referencing properties when using `BlendOp`.

Checked in Unity 2017, BlendOp.shader compiles fine and was erroneously highlighted in Rider.
Fixes https://youtrack.jetbrains.com/issue/RIDER-8386