### PR TITLE
Allow to see found Rider executables and make one  of them a Default External Editor

### DIFF
--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -550,8 +550,6 @@ All those problems will go away after Unity upgrades to mono4.";
       EditorGUILayout.EndVertical();
     }
 
-    public static bool RiderIsDefaultEditor { get; set; }
-
     #region SystemInfoRiderPlugin
     static class SystemInfoRiderPlugin
     {

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -463,7 +463,8 @@ namespace Plugins.Editor.JetBrains
       var alternatives = GetAllRiderPaths();
       if (alternatives.Any())
       {
-        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", Array.IndexOf(alternatives,RiderPath), alternatives)];
+        int index = Array.IndexOf(alternatives,RiderPath);
+        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alternatives)];
         if (GUILayout.Button("Set as a default editor"))
         {
           SetExternalScriptEditor(RiderPath);

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -83,7 +83,7 @@ namespace Plugins.Editor.JetBrains
             .Select(a=>a.FullName).ToArray();
           return newPathsMac;
       }
-      return null;
+      return new string[0];
     }
 
     public static bool TargetFrameworkVersion45

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -464,7 +464,8 @@ namespace Plugins.Editor.JetBrains
       if (alternatives.Any())
       {
         int index = Array.IndexOf(alternatives,RiderPath);
-        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alternatives)];
+        var alts = alternatives.Select(s => s.Replace("/",":")).ToArray(); // hack around https://fogbugz.unity3d.com/default.asp?940857_tirhinhe3144t4vn
+        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alts)]; 
         if (GUILayout.Button("Set as a default editor"))
         {
           SetExternalScriptEditor(RiderPath);

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -466,10 +466,17 @@ namespace Plugins.Editor.JetBrains
         int index = Array.IndexOf(alternatives,RiderPath);
         var alts = alternatives.Select(s => s.Replace("/",":")).ToArray(); // hack around https://fogbugz.unity3d.com/default.asp?940857_tirhinhe3144t4vn
         RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alts)];
-        if(EditorGUILayout.Toggle(new GUIContent("Rider is default editor"), Enabled))
-          SetExternalScriptEditor(RiderPath); 
+        if (EditorGUILayout.Toggle(new GUIContent("Rider is default editor"), Enabled))
+        {
+          SetExternalScriptEditor(RiderPath);
+          EditorGUILayout.HelpBox("Unckecking will restore default external editor.", MessageType.None);
+        }
         else
+        {
           SetExternalScriptEditor(string.Empty);
+          EditorGUILayout.HelpBox("Checking will set Rider as default external editor", MessageType.None);
+        }
+        
       }
 
       var help = @"For now target 4.5 is strongly recommended.

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -518,7 +518,7 @@ namespace Plugins.Editor.JetBrains
         }
         
       }
-
+      var help = @"For now target 4.5 is strongly recommended.
  - Without 4.5:
     - Rider will fail to resolve System.Linq on Mac/Linux
     - Rider will fail to resolve Firebase Analytics.

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -461,13 +461,14 @@ namespace Plugins.Editor.JetBrains
       EditorGUI.BeginChangeCheck();
 
       var alternatives = GetAllRiderPaths();
-      GUI.enabled = alternatives.Any();
-      RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", Array.IndexOf(alternatives,RiderPath), alternatives)];
-      if (GUILayout.Button("Set as a default editor"))
+      if (alternatives.Any())
       {
-        SetExternalScriptEditor(RiderPath);
+        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", Array.IndexOf(alternatives,RiderPath), alternatives)];
+        if (GUILayout.Button("Set as a default editor"))
+        {
+          SetExternalScriptEditor(RiderPath);
+        }  
       }
-      GUI.enabled = true;
 
       var help = @"For now target 4.5 is strongly recommended.
  - Without 4.5:

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -465,11 +465,11 @@ namespace Plugins.Editor.JetBrains
       {
         int index = Array.IndexOf(alternatives,RiderPath);
         var alts = alternatives.Select(s => s.Replace("/",":")).ToArray(); // hack around https://fogbugz.unity3d.com/default.asp?940857_tirhinhe3144t4vn
-        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alts)]; 
-        if (GUILayout.Button("Set as a default editor"))
-        {
-          SetExternalScriptEditor(RiderPath);
-        }  
+        RiderPath = alternatives[EditorGUILayout.Popup("Rider executable:", index==-1?0:index, alts)];
+        if(EditorGUILayout.Toggle(new GUIContent("Rider is default editor"), Enabled))
+          SetExternalScriptEditor(RiderPath); 
+        else
+          SetExternalScriptEditor(string.Empty);
       }
 
       var help = @"For now target 4.5 is strongly recommended.
@@ -502,6 +502,8 @@ All those problems will go away after Unity upgrades to mono4.";
       
       EditorGUILayout.EndVertical();
     }
+
+    public static bool RiderIsDefaultEditor { get; set; }
 
     #region SystemInfoRiderPlugin
     static class SystemInfoRiderPlugin


### PR DESCRIPTION
On MAC there is a bug in Unity - Recently used external app disappears from the list of possibilities, when you select other Editor.
So on Rider settings Tab we provide am alternative UI to help find and set Rider as default editor.