### PR TITLE
Add annotations for modularised UnityEngine assemblies

### DIFF
--- a/resharper/src/resharper-unity/annotations/UnityEngine.AnimationModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.AnimationModule.xml
@@ -1,0 +1,10 @@
+<assembly name="UnityEngine.AnimationModule">
+
+  <member name="T:UnityEngine.SharedBetweenAnimatorsAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.StateMachineBehaviour</argument>
+    </attribute>
+  </member>
+
+</assembly>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
@@ -1,0 +1,424 @@
+<assembly name="UnityEngine.CoreModule">
+
+  <!-- Nullness -->
+  <!--<member name="P:UnityEngine.Component.transform">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>-->
+  <member name="P:UnityEngine.Component.gameObject">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <!--<member name="P:UnityEngine.GameObject.transform">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>-->
+  <member name="P:UnityEngine.Object.name">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+
+
+  <!-- UnityEngine.GameObject -->
+  <member name="M:UnityEngine.GameObject.AddComponent``1">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+        <!-- ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature -->
+        <argument>8</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+
+
+  <!-- UnityEngine.ScriptableObject -->
+  <member name="M:UnityEngine.ScriptableObject.CreateInstance``1">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+        <!-- ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature -->
+        <argument>8</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+
+
+  <!-- UnityEngine.Assertions.Assert -->
+  <member name="M:UnityEngine.Assertions.Assert.IsTrue(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsTrue(System.Boolean,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsFalse(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:true=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsFalse(System.Boolean,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:true=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreApproximatelyEqual(System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreApproximatelyEqual(System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreApproximatelyEqual(System.Single,System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreApproximatelyEqual(System.Single,System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotApproximatelyEqual(System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotApproximatelyEqual(System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotApproximatelyEqual(System.Single,System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotApproximatelyEqual(System.Single,System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreEqual``1(``0,``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreEqual``1(``0,``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreEqual``1(``0,``0,System.Collections.Generic.IEqualityComparer{``0})">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+    <parameter name="comparer">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreEqual(UnityEngine.Object,UnityEngine.Object,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotEqual``1(``0,``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotEqual``1(``0,``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotEqual``1(``0,``0,System.Collections.Generic.IEqualityComparer{``0})">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+    <parameter name="comparer">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.AreNotEqual(UnityEngine.Object,UnityEngine.Object,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:notnull =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:notnull =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNull(UnityEngine.Object,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:notnull =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:null =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:null =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Assert.IsNotNull(UnityEngine.Object,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:null =&gt; halt</argument>
+    </attribute>
+  </member>
+
+
+  <!-- UnityEngine.Assertions.Must -->
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeTrue(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeTrue(System.Boolean,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeFalse(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:true=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeFalse(System.Boolean,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>value:true=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeApproximatelyEqual(System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeApproximatelyEqual(System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeApproximatelyEqual(System.Single,System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeApproximatelyEqual(System.Single,System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeApproximatelyEqual(System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeApproximatelyEqual(System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeApproximatelyEqual(System.Single,System.Single,System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeApproximatelyEqual(System.Single,System.Single,System.Single,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeEqual``1(``0,``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeEqual``1(``0,``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeEqual``1(``0,``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeEqual``1(``0,``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>expected:notnull =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>expected:notnull =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>expected:null =&gt; halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>expected:null =&gt; halt</argument>
+    </attribute>
+  </member>
+
+
+  <!-- UnityEngine.Debug -->
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean,UnityEngine.Object)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.Object)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.Object,UnityEngine.Object)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.String,UnityEngine.Object)">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.AssertFormat(System.Boolean,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.AssertFormat(System.Boolean,UnityEngine.Object,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>condition:false=&gt;halt</argument>
+    </attribute>
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogAssertionFormat(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogAssertionFormat(UnityEngine.Object,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogErrorFormat(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogErrorFormat(UnityEngine.Object,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogFormat(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogFormat(UnityEngine.Object,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogWarningFormat(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.Debug.LogWarningFormat(UnityEngine.Object,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+
+
+  <!-- String formatting -->
+  <member name="M:UnityEngine.ILogger.LogFormat(UnityEngine.LogType,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>format</argument>
+    </attribute>
+  </member>
+  <member name="M:UnityEngine.UnityString.Format(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
+      <argument>fmt</argument>
+    </attribute>
+  </member>
+
+
+  <!-- Attributes -->
+  <member name="T:UnityEngine.AddComponentMenu">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.ContextMenu">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.ContextMenuItemAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.CreateAssetMenuAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.ScriptableObject</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.DisallowMultipleComponent">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.ExecuteInEditMode">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.HelpURLAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.HideInInspector">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.ImageEffectAllowedInSceneView">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.PreferBinarySerialization">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.ScriptableObject</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.PropertyAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.RequireComponent">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.Component</argument>
+    </attribute>
+  </member>
+  <member name="T:UnityEngine.RuntimeInitializeOnLoadMethodAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.SelectionBaseAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:UnityEngine.SerializeField">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+      <!-- ImplicitUseKindFlags.Assign -->
+      <argument>2</argument>
+    </attribute>
+  </member>
+</assembly>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.IMGUIModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.IMGUIModule.xml
@@ -1,0 +1,7 @@
+<assembly name="UnityEngine.IMGUIModule">
+
+  <member name="T:UnityEngine.GUITargetAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+
+</assembly>

--- a/resharper/src/resharper-unity/resharper-unity.rider.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.rider.nuspec
@@ -42,6 +42,7 @@
 <releaseNotes>
 &#8226; Parse pre-processor directives in ShaderLab (#186)
 &#8226; Parse property reference for BlendOp (RIDER-8386)
+&#8226; Add annotations for modularised UnityEngine assemblies (#207)
 &#8226; Unity3dRider: Fix path to Toolbox on Mac
 &#8226; Unity3dRider: Fix reference to nunit.framework.dll, as the Unity distributed version doesn't run tests correctly with Rider (#194)
 &#8226; Unity3dRider: Option to disable hippie completion (RIDER-5996)
@@ -159,9 +160,7 @@ From previous releases:
   </metadata>
   <files>
     <file src="..\..\build\resharper-unity.rider\bin\Release\net452\JetBrains.ReSharper.Plugins.Unity.dll" target="DotFiles" />
-    <file src="annotations\UnityEngine.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEngine.xml" />
-    <file src="annotations\UnityEngine.Networking.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEngine.Networking.xml" />
-    <file src="annotations\UnityEditor.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEditor.xml" />
-    <file src="annotations\UnityEditor.EditorTestsRunner.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEditor.EditorTestsRunner.xml" />
+    <file src="annotations\UnityEngine*.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations" />
+    <file src="annotations\UnityEditor*.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations" />
   </files>
 </package>

--- a/resharper/src/resharper-unity/resharper-unity.rider.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.rider.nuspec
@@ -41,6 +41,7 @@
 </description>
 <releaseNotes>
 &#8226; Parse pre-processor directives in ShaderLab (#186)
+&#8226; Parse CGINCLUDE blocks at any point in shader file (#188)
 &#8226; Parse property reference for BlendOp (RIDER-8386)
 &#8226; Add annotations for modularised UnityEngine assemblies (#207)
 &#8226; Unity3dRider: Fix path to Toolbox on Mac

--- a/resharper/src/resharper-unity/resharper-unity.wave08.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.wave08.nuspec
@@ -41,6 +41,7 @@
 </description>
 <releaseNotes>
 &#8226; Parse pre-processor directives in ShaderLab (#186)
+&#8226; Parse CGINCLUDE blocks at any point in shader file (#188)
 &#8226; Parse property reference for BlendOp (RIDER-8386)
 &#8226; Add annotations for modularised UnityEngine assemblies (#207)
 

--- a/resharper/src/resharper-unity/resharper-unity.wave08.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.wave08.nuspec
@@ -42,6 +42,7 @@
 <releaseNotes>
 &#8226; Parse pre-processor directives in ShaderLab (#186)
 &#8226; Parse property reference for BlendOp (RIDER-8386)
+&#8226; Add annotations for modularised UnityEngine assemblies (#207)
 
 From 2.0.2:
 &#8226; Add ability to disable advanced ShaderLab syntax (#183)
@@ -144,9 +145,7 @@ From previous releases:
   </metadata>
   <files>
     <file src="..\..\build\resharper-unity.wave08\bin\Release\net452\JetBrains.ReSharper.Plugins.Unity.dll" target="DotFiles" />
-    <file src="annotations\UnityEngine.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEngine.xml" />
-    <file src="annotations\UnityEngine.Networking.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEngine.Networking.xml" />
-    <file src="annotations\UnityEditor.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEditor.xml" />
-    <file src="annotations\UnityEditor.EditorTestsRunner.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations\UnityEditor.EditorTestsRunner.xml" />
+      <file src="annotations\UnityEngine*.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations" />
+      <file src="annotations\UnityEditor*.xml" target="DotFiles\Extensions\JetBrains.Unity\annotations" />
   </files>
 </package>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -93,7 +93,9 @@
 <![CDATA[
 <ul>
   <li>Parse pre-processor directives in ShaderLab (<a href="https://github.com/JetBrains/resharper-unity/issues/186">#186</a>)</li>
+  <li>Parse CGINCLUDE blocks at any point in shader file (<a href="https://github.com/JetBrains/resharper-unity/issues/188">#188</a>)</li>
   <li>Parse property references for BlendOp in ShaderLab files (<a href="https://youtrack.jetbrains.com/issue/RIDER-8386">RIDER-8386</a>)</li>
+  <li>Add annotations for modularised UnityEngine assemblies (<a href="https://github.com/JetBrains/resharper-unity/issues/207">#207</a>)</li>
   <li>Allow disabling simple word completion for .shader and .cginc files (<a href="https://youtrack.jetbrains.com/issue/RIDER-5996">RIDER-5996</a>)</li>
   <li>Choose path and set Rider as default editor from the Unity3dRider plugin</li>
   <li>Customise the target framework version in the Unity3dRider plugin options</li>


### PR DESCRIPTION
Unity 2017.2 splits UnityEngine.dll into separate modules, so the existing UnityEngine.dll annotations no longer work. This PR adds new annotation files for the new assemblies, based on the existing annotations.

Fixes #207