### PR TITLE
RIDER-8917  parse texture property values

### DIFF
--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
@@ -4,6 +4,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
 {
     public static class ParserMessages
     {
+        public const string IDS_TEXTURE_PROPERTY_VALUE_TEXTURE_DIMENSION = "Texture dimension";
         public const string IDS_ALPHA_TO_MASK_VALUE = "AlphaToMask value";
         public const string IDS_ALPHA_TEST_VALUE = "AlphaTest value";
         public const string IDS_ATTRIBUTE_PARAMETER_VALUE = "parameter value";

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
@@ -334,6 +334,13 @@ options {
   | BACK_KEYWORD
   | FRONT_KEYWORD
   | LIGHTMAP_MODE_KEYWORD
+  | TEXGEN_KEYWORD
+
+  | CUBE_REFLECT_KEYWORD
+  | CUBE_NORMAL_KEYWORD
+  | OBJECT_LINEAR_KEYWORD
+  | EYE_LINEAR_KEYWORD
+  | SPHERE_MAP_KEYWORD
 
   | BAD_CHARACTER
 ;
@@ -476,6 +483,13 @@ options {
   | BACK_KEYWORD
   | FRONT_KEYWORD
   | LIGHTMAP_MODE_KEYWORD
+  | TEXGEN_KEYWORD
+
+  | CUBE_REFLECT_KEYWORD
+  | CUBE_NORMAL_KEYWORD
+  | OBJECT_LINEAR_KEYWORD
+  | EYE_LINEAR_KEYWORD
+  | SPHERE_MAP_KEYWORD
 
   | BAD_CHARACTER
 ;
@@ -620,6 +634,13 @@ options {
   | BACK_KEYWORD
   | FRONT_KEYWORD
   | LIGHTMAP_MODE_KEYWORD
+  | TEXGEN_KEYWORD
+
+  | CUBE_REFLECT_KEYWORD
+  | CUBE_NORMAL_KEYWORD
+  | OBJECT_LINEAR_KEYWORD
+  | EYE_LINEAR_KEYWORD
+  | SPHERE_MAP_KEYWORD
 ;
 
 
@@ -822,11 +843,35 @@ texturePropertyValue
 :
   STRING_LITERAL<SHADER_LAB_NAME, Name>
   (
-    LBRACE<LBRACE, LBrace>
-    LIGHTMAP_MODE_KEYWORD<SHADER_LAB_KEYWORD, LightmapModeKeyword>?
+    LBRACE<LBRACE, LBrace>    
+    (
+      texturePropertyValueTextureDimension
+      | texturePropertyValueTexGen
+      | matrixCommand // Legacy
+      | LIGHTMAP_MODE_KEYWORD<SHADER_LAB_KEYWORD, LightmapModeKeyword>
+    )?
     errorTexturePropertyBlockValues
     RBRACE<RBRACE, RBrace>
   )?
+;
+
+texturePropertyValueTextureDimension
+:
+  TEXTURE_2D_KEYWORD
+  | TEXTURE_3D_KEYWORD
+  | CUBE_KEYWORD
+;
+
+texturePropertyValueTexGen // Legacy 5.0
+:
+  TEXGEN_KEYWORD
+  (
+    CUBE_REFLECT_KEYWORD
+    | CUBE_NORMAL_KEYWORD
+    | OBJECT_LINEAR_KEYWORD
+    | EYE_LINEAR_KEYWORD
+    | SPHERE_MAP_KEYWORD
+  )
 ;
 
 // The spec says there shouldn't be anything here. Use a custom parse function to eat 

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.NodeSets.cs
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.NodeSets.cs
@@ -123,7 +123,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
                 OFF_KEYWORD,
                 BACK_KEYWORD,
                 FRONT_KEYWORD,
-                LIGHTMAP_MODE_KEYWORD
+                LIGHTMAP_MODE_KEYWORD,
+                TEXGEN_KEYWORD,
+                
+                CUBE_REFLECT_KEYWORD,
+                CUBE_NORMAL_KEYWORD,
+                OBJECT_LINEAR_KEYWORD,
+                EYE_LINEAR_KEYWORD,
+                SPHERE_MAP_KEYWORD
               );
         }
     }

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.Tokens.generated.cs
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.Tokens.generated.cs
@@ -291,6 +291,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
     public static readonly TokenNodeType ANY_KEYWORD = new KeywordTokenNodeType("ANY_KEYWORD", ANY_KEYWORD_NODE_TYPE_INDEX, representation: "Any");
     public const int LIGHTMAP_MODE_KEYWORD_NODE_TYPE_INDEX = 1120;
     public static readonly TokenNodeType LIGHTMAP_MODE_KEYWORD = new KeywordTokenNodeType("LIGHTMAP_MODE_KEYWORD", LIGHTMAP_MODE_KEYWORD_NODE_TYPE_INDEX, representation: "LightmapMode");
+    public const int TEXGEN_KEYWORD_NODE_TYPE_INDEX = 1121;
+    public static readonly TokenNodeType TEXGEN_KEYWORD = new KeywordTokenNodeType("TEXGEN_KEYWORD", TEXGEN_KEYWORD_NODE_TYPE_INDEX, representation: "TexGen");
 
-    private const int LAST_GENERATED_TOKEN_TYPE_INDEX = 1121;  }
+    //TexGenModeKeywords
+    public const int CUBE_REFLECT_KEYWORD_NODE_TYPE_INDEX = 1122;
+    public static readonly TokenNodeType CUBE_REFLECT_KEYWORD = new KeywordTokenNodeType("CUBE_REFLECT_KEYWORD", CUBE_REFLECT_KEYWORD_NODE_TYPE_INDEX, representation: "CubeReflect");
+    public const int CUBE_NORMAL_KEYWORD_NODE_TYPE_INDEX = 1123;
+    public static readonly TokenNodeType CUBE_NORMAL_KEYWORD = new KeywordTokenNodeType("CUBE_NORMAL_KEYWORD", CUBE_NORMAL_KEYWORD_NODE_TYPE_INDEX, representation: "CubeNormal");
+    public const int OBJECT_LINEAR_KEYWORD_NODE_TYPE_INDEX = 1124;
+    public static readonly TokenNodeType OBJECT_LINEAR_KEYWORD = new KeywordTokenNodeType("OBJECT_LINEAR_KEYWORD", OBJECT_LINEAR_KEYWORD_NODE_TYPE_INDEX, representation: "ObjectLinear");
+    public const int EYE_LINEAR_KEYWORD_NODE_TYPE_INDEX = 1125;
+    public static readonly TokenNodeType EYE_LINEAR_KEYWORD = new KeywordTokenNodeType("EYE_LINEAR_KEYWORD", EYE_LINEAR_KEYWORD_NODE_TYPE_INDEX, representation: "EyeLinear");
+    public const int SPHERE_MAP_KEYWORD_NODE_TYPE_INDEX = 1126;
+    public static readonly TokenNodeType SPHERE_MAP_KEYWORD = new KeywordTokenNodeType("SPHERE_MAP_KEYWORD", SPHERE_MAP_KEYWORD_NODE_TYPE_INDEX, representation: "SphereMap");
+
+    private const int LAST_GENERATED_TOKEN_TYPE_INDEX = 1127;  }
 }

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.Tokens.xml
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLabTokenType.Tokens.xml
@@ -202,5 +202,14 @@
     <Keyword name="MATRIX_KEYWORD" representation="Matrix" />
     <Keyword name="ANY_KEYWORD" representation="Any" />
     <Keyword name="LIGHTMAP_MODE_KEYWORD" representation="LightmapMode" />
+    <Keyword name="TEXGEN_KEYWORD" representation="TexGen" />    
   </Keywords>
+
+  <TexGenModeKeywords NodeType="KeywordTokenNodeType">
+    <Keyword name="CUBE_REFLECT_KEYWORD" representation="CubeReflect" />
+    <Keyword name="CUBE_NORMAL_KEYWORD" representation="CubeNormal" />
+    <Keyword name="OBJECT_LINEAR_KEYWORD" representation="ObjectLinear" />
+    <Keyword name="EYE_LINEAR_KEYWORD" representation="EyeLinear" />
+    <Keyword name="SPHERE_MAP_KEYWORD" representation="SphereMap" />
+  </TexGenModeKeywords>
 </ShaderLabTokens>

--- a/resharper/test/data/psi/shaderLab/parsing/PropertiesTextureValue.shader
+++ b/resharper/test/data/psi/shaderLab/parsing/PropertiesTextureValue.shader
@@ -1,0 +1,17 @@
+{caret}Shader "RIDER-8917" {
+	Properties {	     
+		_RenderTexture2 ("RenderTexture2", 2D) = "black" { 2D }
+		_RenderTexture3 ("RenderTexture3", 2D) = "black" { 3D }
+		_RenderTextureCube ("RenderTextureCube", 2D) = "black" { Cube }
+		
+		_RenderTextureTexGenCubeReflect ("RenderTextureTexGenCubeReflect", 2D) = "black" { TexGen CubeReflect }
+		_RenderTextureTexGenCubeNormal ("RenderTextureTexGenCubeNormal", 2D) = "black" { TexGen CubeNormal }
+		_RenderTextureTexGenObjectLinear ("RenderTextureTexGenObjectLinear", 2D) = "black" { TexGen ObjectLinear }
+		_RenderTextureTexGenEyeLinear ("RenderTextureTexGenEyeLinear", 2D) = "black" { TexGen EyeLinear }
+		_RenderTextureTexGenSphereMap ("RenderTextureTexGenSphereMap", 2D) = "black" { TEXGEN SphereMap }
+		
+		_RenderTextureMatrix ("RenderTextureMatrix", 2D) = "black" { Matrix [_Color] }
+		
+		_RenderTextureLightMap ("RenderTextureLigthMap", 2D) = "black" { LIGHTMAPMODE }				
+	}
+}

--- a/resharper/test/data/psi/shaderLab/parsing/PropertiesTextureValue.shader.gold
+++ b/resharper/test/data/psi/shaderLab/parsing/PropertiesTextureValue.shader.gold
@@ -1,0 +1,295 @@
+﻿Language: PsiLanguageType:SHADERLAB
+IShaderLabFile
+  IShaderCommand
+    ShaderLabTokenType+KeywordTokenElement(type:SHADER_KEYWORD, text:Shader)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    IShaderValue
+      ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RIDER-8917")
+      Whitespace(type:WHITESPACE, text: ) spaces: " "
+      ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      Whitespace(type:WHITESPACE, text:	) spaces: "	"
+      IPropertiesCommand
+        ShaderLabTokenType+KeywordTokenElement(type:PROPERTIES_KEYWORD, text:Properties)
+        Whitespace(type:WHITESPACE, text: ) spaces: " "
+        IPropertiesValue
+          ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+          Whitespace(type:WHITESPACE, text:	     ) spaces: "	     "
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTexture2)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTexture2")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTextureDimension
+                ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTexture3)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTexture3")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTextureDimension
+                ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_3D_KEYWORD, text:3D)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureCube)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureCube")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTextureDimension
+                ShaderLabTokenType+KeywordTokenElement(type:CUBE_KEYWORD, text:Cube)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureTexGenCubeReflect)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureTexGenCubeReflect")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTexGen
+                ShaderLabTokenType+KeywordTokenElement(type:TEXGEN_KEYWORD, text:TexGen)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ShaderLabTokenType+KeywordTokenElement(type:CUBE_REFLECT_KEYWORD, text:CubeReflect)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureTexGenCubeNormal)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureTexGenCubeNormal")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTexGen
+                ShaderLabTokenType+KeywordTokenElement(type:TEXGEN_KEYWORD, text:TexGen)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ShaderLabTokenType+KeywordTokenElement(type:CUBE_NORMAL_KEYWORD, text:CubeNormal)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureTexGenObjectLinear)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureTexGenObjectLinear")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTexGen
+                ShaderLabTokenType+KeywordTokenElement(type:TEXGEN_KEYWORD, text:TexGen)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ShaderLabTokenType+KeywordTokenElement(type:OBJECT_LINEAR_KEYWORD, text:ObjectLinear)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureTexGenEyeLinear)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureTexGenEyeLinear")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTexGen
+                ShaderLabTokenType+KeywordTokenElement(type:TEXGEN_KEYWORD, text:TexGen)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ShaderLabTokenType+KeywordTokenElement(type:EYE_LINEAR_KEYWORD, text:EyeLinear)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureTexGenSphereMap)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureTexGenSphereMap")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ITexturePropertyValueTexGen
+                ShaderLabTokenType+KeywordTokenElement(type:TEXGEN_KEYWORD, text:TEXGEN)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ShaderLabTokenType+KeywordTokenElement(type:SPHERE_MAP_KEYWORD, text:SphereMap)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureMatrix)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureMatrix")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              IMatrixCommand
+                ShaderLabTokenType+KeywordTokenElement(type:MATRIX_KEYWORD, text:Matrix)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                IReferencedProperty
+                  ShaderLabTokenType+FixedTokenElement(type:LBRACK, text:[)
+                  IShaderLabIdentifier
+                    Identifier(type:IDENTIFIER, text:_Color)
+                  ShaderLabTokenType+FixedTokenElement(type:RBRACK, text:])
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:		) spaces: "		"
+          IPropertyDeclaration
+            IShaderLabIdentifier
+              Identifier(type:IDENTIFIER, text:_RenderTextureLightMap)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:LPAREN, text:()
+            ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"RenderTextureLigthMap")
+            ShaderLabTokenType+FixedTokenElement(type:COMMA, text:,)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ISimplePropertyType
+              ShaderLabTokenType+KeywordTokenElement(type:TEXTURE_2D_KEYWORD, text:2D)
+            ShaderLabTokenType+FixedTokenElement(type:RPAREN, text:))
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITESPACE, text: ) spaces: " "
+            ITexturePropertyValue
+              ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"black")
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+KeywordTokenElement(type:LIGHTMAP_MODE_KEYWORD, text:LIGHTMAPMODE)
+              Whitespace(type:WHITESPACE, text: ) spaces: " "
+              ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+          Whitespace(type:WHITESPACE, text:				) spaces: "				"
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:	) spaces: "	"
+          ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+

--- a/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
+++ b/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
@@ -21,6 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.Psi.ShaderLab.Parsing
         [TestCase("Properties")]
         [TestCase("PropertiesWithAttributes")]
         [TestCase("PropertiesWithErrors")]
+        [TestCase("PropertiesTextureValue")]
 
         [TestCase("FallbackNamed")]
         [TestCase("FallbackNone")]


### PR DESCRIPTION
Allows for parsing of several texture property values in addition to `LigthMapMode`:
* TexGen (legacy Unity 5.0, does nothing now and shows warning in Editor)
* Matrix (legacy, does nothing now and shows warning in Editor)
* Texture dimension

Fixes https://youtrack.jetbrains.com/issue/RIDER-8917