### PR TITLE
Allow ID = ID in tag declaration (RIDER-9214)

### DIFF
--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ParserMessages.cs
@@ -4,6 +4,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.ShaderLab.Parsing
 {
     public static class ParserMessages
     {
+        public const string IDS_TAG_DECLARATION = "Tag declaration";
         public const string IDS_TEXTURE_PROPERTY_VALUE_TEXTURE_DIMENSION = "Texture dimension";
         public const string IDS_ALPHA_TO_MASK_VALUE = "AlphaToMask value";
         public const string IDS_ALPHA_TEST_VALUE = "AlphaTest value";

--- a/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
+++ b/resharper/src/resharper-unity/Psi/ShaderLab/Parsing/ShaderLab.psi
@@ -1085,19 +1085,24 @@ tagsCommand
 
 tagsValue
 :
-  LBRACE<LBRACE, LBrace>
-  tagDeclaration<TAG_DECLARATIONS, Declarations>*
+  LBRACE<LBRACE, LBrace>  
+  tagDeclaration<TAG_DECLARATIONS, Declarations>*    
   RBRACE<RBRACE, RBrace>
 ;
 
 tagDeclaration
 :
-  STRING_LITERAL<SHADER_LAB_NAME, Name>
-  EQUALS<EQUALS, Equals>
-  STRING_LITERAL<SHADER_LAB_VALUE, Value>
+  (
+    STRING_LITERAL<SHADER_LAB_NAME, Name>
+    EQUALS<EQUALS, Equals>
+    STRING_LITERAL<SHADER_LAB_VALUE, Value>
+  )
+  | (
+      shaderLabIdentifier<SHADER_LAB_NAME, Name>  
+      EQUALS<EQUALS, Equals>
+      shaderLabIdentifier<SHADER_LAB_VALUE, Value>  
+    )
 ;
-
-
 
 // **************************************************************************
 //

--- a/resharper/test/data/psi/shaderLab/parsing/TagDeclaration.shader
+++ b/resharper/test/data/psi/shaderLab/parsing/TagDeclaration.shader
@@ -1,0 +1,15 @@
+{caret}Shader "Test"
+{    
+    SubShader{        
+        Pass{
+            Tags { LightMode = Vertex }
+            Tags { "LightMode" = "Vertex" }
+
+            // errors:
+            Tags { LightMode = "Vertex" }
+            Tags { "LightMode" = Vertex }
+            CGPROGRAM
+            ENDCG
+        }
+    }
+}

--- a/resharper/test/data/psi/shaderLab/parsing/TagDeclaration.shader.gold
+++ b/resharper/test/data/psi/shaderLab/parsing/TagDeclaration.shader.gold
@@ -1,0 +1,106 @@
+﻿Language: PsiLanguageType:SHADERLAB
+IShaderLabFile
+  IShaderCommand
+    ShaderLabTokenType+KeywordTokenElement(type:SHADER_KEYWORD, text:Shader)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    IShaderValue
+      ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"Test")
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+      Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+      NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+      Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+      ISubShaderCommand
+        ShaderLabTokenType+KeywordTokenElement(type:SUB_SHADER_KEYWORD, text:SubShader)
+        ISubShaderValue
+          ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+          Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+          NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+          Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+          IRegularPassDef
+            ShaderLabTokenType+KeywordTokenElement(type:PASS_KEYWORD, text:Pass)
+            IRegularPassValue
+              ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+              ITagsCommand
+                ShaderLabTokenType+KeywordTokenElement(type:TAGS_KEYWORD, text:Tags)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ITagsValue
+                  ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+                  Whitespace(type:WHITESPACE, text: ) spaces: " "
+                  ITagDeclaration
+                    IShaderLabIdentifier
+                      Identifier(type:IDENTIFIER, text:LightMode)
+                    Whitespace(type:WHITESPACE, text: ) spaces: " "
+                    ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+                    Whitespace(type:WHITESPACE, text: ) spaces: " "
+                    IShaderLabIdentifier
+                      Identifier(type:IDENTIFIER, text:Vertex)
+                  Whitespace(type:WHITESPACE, text: ) spaces: " "
+                  ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+              ITagsCommand
+                ShaderLabTokenType+KeywordTokenElement(type:TAGS_KEYWORD, text:Tags)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ITagsValue
+                  ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+                  Whitespace(type:WHITESPACE, text: ) spaces: " "
+                  ITagDeclaration
+                    ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"LightMode")
+                    Whitespace(type:WHITESPACE, text: ) spaces: " "
+                    ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+                    Whitespace(type:WHITESPACE, text: ) spaces: " "
+                    ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"Vertex")
+                  Whitespace(type:WHITESPACE, text: ) spaces: " "
+                  ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+              EndOfLineComment(type:END_OF_LINE_COMMENT, text:// errors:) spaces: "// errors:"
+              NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+              Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+              ITagsCommand
+                ShaderLabTokenType+KeywordTokenElement(type:TAGS_KEYWORD, text:Tags)
+                Whitespace(type:WHITESPACE, text: ) spaces: " "
+                ITagsValue
+                  ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+                  Whitespace(type:WHITESPACE, text: ) spaces: " "
+                  ITagDeclaration
+                    IShaderLabIdentifier
+                      Identifier(type:IDENTIFIER, text:LightMode)
+                    Whitespace(type:WHITESPACE, text: ) spaces: " "
+                    ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+  Whitespace(type:WHITESPACE, text: ) spaces: " "
+  ErrorElement:Identifier expected
+    ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"Vertex")
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+    NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+    Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+    ShaderLabTokenType+KeywordTokenElement(type:TAGS_KEYWORD, text:Tags)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    ShaderLabTokenType+FixedTokenElement(type:LBRACE, text:{)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    ShaderLabTokenType+GenericTokenElement(type:STRING_LITERAL, text:"LightMode")
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    ShaderLabTokenType+FixedTokenElement(type:EQUALS, text:=)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    Identifier(type:IDENTIFIER, text:Vertex)
+    Whitespace(type:WHITESPACE, text: ) spaces: " "
+    ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+    NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+    Whitespace(type:WHITESPACE, text:            ) spaces: "            "
+    ShaderLabTokenType+KeywordTokenElement(type:CG_PROGRAM, text:CGPROGRAM)
+    ShaderLabTokenType+GenericTokenElement(type:CG_CONTENT, text:\n            )
+    ShaderLabTokenType+KeywordTokenElement(type:CG_END, text:ENDCG)
+    NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+    Whitespace(type:WHITESPACE, text:        ) spaces: "        "
+    ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+    NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+    Whitespace(type:WHITESPACE, text:    ) spaces: "    "
+    ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+    NewLine(type:NEW_LINE, text:\n) spaces: "\n"
+    ShaderLabTokenType+FixedTokenElement(type:RBRACE, text:})
+

--- a/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
+++ b/resharper/test/src/Psi/ShaderLab/Parsing/ParserTests.cs
@@ -77,6 +77,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.Psi.ShaderLab.Parsing
         [TestCase("LegacyBindChannels")]
 
         [TestCase("Preprocessor")]
+        
+        [TestCase("TagDeclaration")]
 
         [TestCase("CgInclude")]
         [TestCase("GlslInclude")]


### PR DESCRIPTION
Right now we only allow tag declarations to have string literals as name and value. Actually, 
`Identifier = Identifier` is valid syntax too.

Fixes RIDER-9214 (at least the one on the user screenshot).

https://youtrack.jetbrains.com/issue/RIDER-9214