### PR TITLE
Misc msbuild fixes

### DIFF
--- a/resharper/Directory.Build.targets
+++ b/resharper/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <ItemGroup>
+      <!-- The JetBrains.Psi.Features.Tasks package incorrectly includes $(PsiGenToolsDir)/TokenGenerator.exe 
+           in the inputs, but that file doesn't exist - $(PsiGenToolsDir)..\TokenGenerator.exe does.
+           This is a workaround that ignores changes to the .exe and the .targets. See RSRP-465228 -->
+    <GenerateTokenGeneratorInputs Remove="@(GenerateTokenGeneratorInputs)" />
+    <GenerateTokenGeneratorInputs Include="@(TokenGenerator)" />
+  </ItemGroup>
+</Project>

--- a/resharper/src/resharper-unity/resharper-unity.rider.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.rider.csproj
@@ -98,13 +98,4 @@
       <FileWrites Include="%(ParserGenOutputSrc.FullPath)" />
     </ItemGroup>
   </Target>
-  <ItemGroup>
-    <!-- The JetBrains.Psi.Features.Tasks 108.0.20170615.212549-eap08 package incorrectly
-         includes $(PsiGenToolsDir)/TokenGenerator.exe in the inputs, but that file doesn't
-         exist - $(PsiGenToolsDir)/../TokenGenerator.exe does.
-         This is a workaround that ignores changes to the .exe and the .targets
-         See RSRP-465228 -->
-    <GenerateTokenGeneratorInputs Remove="@(GenerateTokenGeneratorInputs)" />
-    <GenerateTokenGeneratorInputs Include="@(TokenGenerator)" />
-  </ItemGroup>
 </Project>

--- a/resharper/src/resharper-unity/resharper-unity.rider.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.rider.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET452;JET_MODE_ASSERT;RIDER</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET452;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RIDER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;NET452;RIDER</DefineConstants>

--- a/resharper/src/resharper-unity/resharper-unity.wave09.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.wave09.csproj
@@ -54,7 +54,7 @@
   <!-- References -->
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="2017.2.0" />
-    <PackageReference Include="JetBrains.Psi.Features.VisualStudio" Version="109.0.20170824.1323" />
+    <PackageReference Include="JetBrains.Psi.Features.VisualStudio" Version="109.0.20170824.132357" />
     <Reference Include="PresentationCore" Condition=" '$(OS)' != 'Unix' " />
     <Reference Include="PresentationFramework" Condition=" '$(OS)' != 'Unix' " />
     <Reference Include="WindowsBase" Condition=" '$(OS)' != 'Unix' " />

--- a/resharper/src/resharper-unity/resharper-unity.wave09.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.wave09.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET452;JET_MODE_ASSERT;WAVE09</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET452;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;WAVE09</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;NET452;WAVE09</DefineConstants>

--- a/resharper/test/src/tests.rider.csproj
+++ b/resharper/test/src/tests.rider.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Tests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET461;JET_MODE_ASSERT;RIDER</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET461;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RIDER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;NET461;RIDER</DefineConstants>

--- a/resharper/test/src/tests.wave09.csproj
+++ b/resharper/test/src/tests.wave09.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Tests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET461;JET_MODE_ASSERT;WAVE09</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET461;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;WAVE09</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;NET461;WAVE09</DefineConstants>

--- a/resharper/test/src/tests.wave09.csproj
+++ b/resharper/test/src/tests.wave09.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2017.2.0" />
-    <PackageReference Include="JetBrains.Psi.Features.VisualStudio" Version="109.0.20170824.1323" />
+    <PackageReference Include="JetBrains.Psi.Features.VisualStudio" Version="109.0.20170824.132357" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\resharper-unity\resharper-unity.wave09.csproj" />


### PR DESCRIPTION
Couple of fixes to the msbuild files:

* Work around unnecessary rebuilds due to SDK bug (see [RSRP-465228](https://youtrack.jetbrains.com/issue/RSRP-465228))
* Fix a warning about an incorrect version on dotnet restore
* Add `JET_MODE_REPORT_EXCEPTIONS` for debug builds - will give more useful data in exceptions during debug and test