### PR TITLE
Add attribute target usage annotations

### DIFF
--- a/resharper/src/resharper-unity/annotations/UnityEditor.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEditor.xml
@@ -11,6 +11,11 @@
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEditor.Editor</argument>
     </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>    <!-- AttributeTargets.Class -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEditor.CustomPreviewAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -26,6 +31,11 @@
   </member>
   <member name="T:UnityEditor.DrawGizmo">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>64</argument>   <!-- AttributeTargets.Method -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEditor.InitializeOnLoadAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -38,5 +48,30 @@
   </member>
   <member name="T:UnityEditor.PreferenceItem">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+
+  <member name="T:UnityEditor.Callbacks.DidReloadScripts">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>64</argument>   <!-- AttributeTargets.Method -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
+  </member>
+  <member name="T:UnityEditor.Callbacks.PostProcessBuildAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>64</argument>   <!-- AttributeTargets.Method -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
+  </member>
+  <member name="T:UnityEditor.Callbacks.PostProcessSceneAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>64</argument>   <!-- AttributeTargets.Method -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
   </member>
 </assembly>

--- a/resharper/src/resharper-unity/annotations/UnityEditor.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEditor.xml
@@ -66,6 +66,14 @@
       <argument>true</argument> <!-- inherited -->
     </attribute>
   </member>
+  <member name="T:UnityEditor.Callbacks.OnOpenAssetAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>64</argument>   <!-- AttributeTargets.Method -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
+  </member>
   <member name="T:UnityEditor.Callbacks.PostProcessBuildAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">

--- a/resharper/src/resharper-unity/annotations/UnityEditor.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEditor.xml
@@ -6,6 +6,14 @@
   <member name="T:UnityEditor.CallbackOrderAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
+  <member name="T:UnityEditor.CanEditMultipleObjects">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>    <!-- AttributeTargets.Class -->
+      <argument>true</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
+  </member>
   <member name="T:UnityEditor.CustomEditor">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">

--- a/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
@@ -354,6 +354,11 @@
   <!-- Attributes -->
   <member name="T:UnityEngine.AddComponentMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>    <!-- AttributeTargets.Class -->
+      <argument>false</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.ContextMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -378,6 +383,11 @@
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>      <!-- AttributeTargets.Class -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.HelpURLAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -387,11 +397,21 @@
   </member>
   <member name="T:UnityEngine.HideInInspector">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>256</argument>    <!-- AttributeTargets.Field -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.ImageEffectAllowedInSceneView">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>      <!-- AttributeTargets.Class -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
     </attribute>
   </member>
   <member name="T:UnityEngine.PreferBinarySerialization">
@@ -414,11 +434,19 @@
   </member>
   <member name="T:UnityEngine.SelectionBaseAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
   </member>
   <member name="T:UnityEngine.SerializeField">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
       <!-- ImplicitUseKindFlags.Assign -->
       <argument>2</argument>
+    </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>256</argument>    <!-- AttributeTargets.Field -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
     </attribute>
   </member>
 </assembly>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.xml
@@ -1,6 +1,5 @@
 <assembly name="UnityEngine">
 
-  
   <!-- Nullness -->
   <!--<member name="P:UnityEngine.Component.transform">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -354,6 +353,11 @@
   <!-- Attributes -->
   <member name="T:UnityEngine.AddComponentMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>    <!-- AttributeTargets.Class -->
+      <argument>false</argument> <!-- allowMultiple -->
+      <argument>true</argument> <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.ContextMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -378,6 +382,11 @@
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>      <!-- AttributeTargets.Class -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.GUITargetAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -390,11 +399,21 @@
   </member>
   <member name="T:UnityEngine.HideInInspector">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>256</argument>    <!-- AttributeTargets.Field -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
+    </attribute>
   </member>
   <member name="T:UnityEngine.ImageEffectAllowedInSceneView">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>4</argument>      <!-- AttributeTargets.Class -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
     </attribute>
   </member>
   <member name="T:UnityEngine.PreferBinarySerialization">
@@ -417,11 +436,19 @@
   </member>
   <member name="T:UnityEngine.SelectionBaseAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
   </member>
   <member name="T:UnityEngine.SerializeField">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
       <!-- ImplicitUseKindFlags.Assign -->
       <argument>2</argument>
+    </attribute>
+    <attribute ctor="M:System.AttributeUsageAttribute.#ctor(System.AttributeTargets,System.Boolean,System.Boolean)">
+      <argument>256</argument>    <!-- AttributeTargets.Field -->
+      <argument>false</argument>  <!-- allowMultiple -->
+      <argument>true</argument>   <!-- inherited -->
     </attribute>
   </member>
   <member name="T:UnityEngine.SharedBetweenAnimatorsAttribute">
@@ -429,5 +456,9 @@
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.StateMachineBehaviour</argument>
     </attribute>
+  </member>
+
+  <member name="T:AOT.MonoPInvokeCallbackAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
 </assembly>


### PR DESCRIPTION
Some Unity attributes don't set `AttributeTargets`, put they can only realistically be applied to certain targets. This adds the targets in as external annotations - ReSharper treats this as though they were "real" and shows a warning if the attributes are applied to the wrong target type.