### PR TITLE
replaced localhost usage on FE with 127.0.0.1

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorConfiguration.kt
@@ -26,7 +26,7 @@ class UnityAttachToEditorConfiguration(project: Project, factory: UnityAttachToE
 
     // Note that we don't serialise these - they will change between sessions, possibly during a session
     override var port: Int = -1
-    override var address: String = "localhost"
+    override var address: String = "127.0.0.1"
     var pid: Int? = null
 
     override fun clone(): RunConfiguration {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToPlayerConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToPlayerConfiguration.kt
@@ -5,7 +5,7 @@ import com.jetbrains.rider.plugins.unity.util.UnityIcons
 import com.jetbrains.rider.run.configurations.remote.RemoteConfiguration
 import javax.swing.Icon
 
-class UnityAttachToPlayerConfiguration(private val configurationName : String, debuggerPort : Int, host: String = "localhost") : RemoteConfiguration {
+class UnityAttachToPlayerConfiguration(private val configurationName : String, debuggerPort : Int, host: String = "127.0.0.1") : RemoteConfiguration {
     override var port: Int = debuggerPort
     override var address: String = host
     override var listenPortForConnections: Boolean = false

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/attach/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/attach/UnityProcessPickerDialog.kt
@@ -92,7 +92,7 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
     }
 
     private fun enterCustomIp() {
-        val hostField = JTextField("localhost")
+        val hostField = JTextField("127.0.0.1")
         val portField = PortField(0)
 
         val panel = panel {


### PR DESCRIPTION
Should fix #262.

```
19:45:01.123 |E| DebuggerWorker                | Unable to start debug session Could not resolve host 'localhost'

--- EXCEPTION #1/2 [SocketException]
Message = “Could not resolve host 'localhost'”
ExceptionPath = Root.InnerException
NativeErrorCode = 11001
ClassName = System.Net.Sockets.SocketException
HResult = E_FAIL=EFail=80004005
Source = System
StackTraceString = “
  at System.Net.Dns.Error_11001 (System.String hostName) [0x00015] in <22f1a38c4c7d45529e36fef933c973df>:0 
    at System.Net.Dns.hostent_to_IPHostEntry (System.String originalHostName, System.String h_name, System.String[] h_aliases, System.String[] h_addrlist) [0x00068] in <22f1a38c4c7d45529e36fef933c973df>:0 
    at System.Net.Dns.GetHostByName (System.String hostName) [0x00027] in <22f1a38c4c7d45529e36fef933c973df>:0 
    at System.Net.Dns.GetHostEntry (System.String hostNameOrAddress) [0x00052] in <22f1a38c4c7d45529e36fef933c973df>:0 
    at System.Net.Dns.GetHostAddresses (System.String hostNameOrAddress) [0x00056] in <22f1a38c4c7d45529e36fef933c973df>:0 
    at JetBrains.Debugger.Worker.Mono.MonoDebugSession.DoRun () [0x00017] in <f046287d9fac4684a9bcf06a53f27147>:0 
    at JetBrains.Debugger.Worker.DebugSessionBase.Run () [0x00027] in <f046287d9fac4684a9bcf06a53f27147>:0 
    at JetBrains.Debugger.Worker.DebuggerWorker+<>c__DisplayClass8.<OnSessionCreated>b__6 () [0x00000] in <f046287d9fac4684a9bcf06a53f27147>:0
”```