### PR TITLE
Fix exception that sometimes happens in UsageInspectionsSuppressor

### DIFF
--- a/resharper/src/resharper-unity.sln.DotSettings
+++ b/resharper/src/resharper-unity.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HSV/@EntryIndexedValue">HSV</s:String>
@@ -14,6 +15,8 @@
 	<s:Int64 x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MsbuildVersion/@EntryValue">983040</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>

--- a/resharper/src/resharper-unity/ProjectExtensions.cs
+++ b/resharper/src/resharper-unity/ProjectExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.API;
 using JetBrains.Metadata.Utils;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel.Properties.Flavours;
@@ -39,16 +40,17 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         private static bool ReferencesUnity(IProject project)
         {
-            return ReferencesAssembly(project, ourUnityEngineReferenceName)
-                   || ReferencesAssembly(project, ourUnityEditorReferenceName)
-                   || ReferencesAssembly(project, ourUnityEngineCoreModuleReferenceName)
-                   || ReferencesAssembly(project, ourUnityEngineSharedInternalsModuleReferenceName);
+            var targetFrameworkId = project.GetCurrentTargetFrameworkId();
+            return ReferencesAssembly(project, targetFrameworkId, ourUnityEngineReferenceName)
+                   || ReferencesAssembly(project, targetFrameworkId, ourUnityEditorReferenceName)
+                   || ReferencesAssembly(project, targetFrameworkId, ourUnityEngineCoreModuleReferenceName)
+                   || ReferencesAssembly(project, targetFrameworkId, ourUnityEngineSharedInternalsModuleReferenceName);
         }
 
-        private static bool ReferencesAssembly(IProject project, AssemblyNameInfo name)
-        {
+        private static bool ReferencesAssembly(IProject project, TargetFrameworkId targetFrameworkId, AssemblyNameInfo name)
+        {            
             return ReferencedAssembliesService.IsProjectReferencingAssemblyByName(project,
-                project.GetCurrentTargetFrameworkId(), name, out var _);
+                targetFrameworkId, name, out var _);
         }
     }
 }


### PR DESCRIPTION
Handles [an exception](https://youtrack.jetbrains.com/v2/issue/RIDER-11332) that happens sometimes when failing to retrieve CurrentTargetFrameworkId for a project.

I was unable to reproduce the exception, but it is a popular one on a tracker. I think that the proper way to fix this would be to replace all of the `ProjectExtensions` that check for Unity assembly references with something more clever that will not be prone to such errors. Anyway, this fix should at least prevent users from seeing Unity plugin exception on non-Unity projects.