### PR TITLE
Fix Unity event function before attributed fields

### DIFF
--- a/resharper/src/resharper-unity.sln.DotSettings
+++ b/resharper/src/resharper-unity.sln.DotSettings
@@ -14,10 +14,12 @@
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue"></s:String>
 	<s:Int64 x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MsbuildVersion/@EntryValue">983040</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fgb/@KeyIndexDefined">True</s:Boolean>

--- a/resharper/src/resharper-unity/resharper-unity.resharper.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.resharper.nuspec
@@ -160,7 +160,7 @@ From previous releases:
     <copyright>Copyright 2017 JetBrains, s.r.o</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="Wave" version="[9.0]" />
+      <dependency id="Wave" version="[11.0]" />
     </dependencies>
     <tags>resharper unity unity3d</tags>
   </metadata>

--- a/resharper/src/resharper-unity/resharper-unity.rider.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.rider.nuspec
@@ -181,7 +181,7 @@ From previous releases:
     <copyright>Copyright 2017 JetBrains, s.r.o</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="Wave" version="[8.0]" />
+      <dependency id="Wave" version="[11.0]" />
     </dependencies>
     <tags>resharper unity unity3d</tags>
   </metadata>

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour07.cs
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour07.cs
@@ -1,0 +1,9 @@
+// ${COMPLETE_ITEM:private OnAnimatorIK(int) { ... }}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+    OnAnima{caret}
+
+    [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour07.cs.gold
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour07.cs.gold
@@ -1,0 +1,12 @@
+﻿// ${COMPLETE_ITEM:private OnAnimatorIK(int) { ... }}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  private void OnAnimatorIK(int layerIndex)
+  {
+    throw new System.NotImplementedException();{caret}
+  }
+
+  [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour08.cs
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour08.cs
@@ -1,0 +1,9 @@
+// ${COMPLETE_ITEM:OnAnimatorIK(int) { ... }}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+    void OnAnima{caret}
+
+    [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour08.cs.gold
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour08.cs.gold
@@ -1,0 +1,12 @@
+﻿// ${COMPLETE_ITEM:OnAnimatorIK(int) { ... }}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  private void OnAnimatorIK(int layerIndex)
+  {
+    throw new System.NotImplementedException();{caret}
+  }
+
+  [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour09.cs
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour09.cs
@@ -1,0 +1,11 @@
+// ${COMPLETE_ITEM:OnAnimatorIK(int) { ... }}
+using UnityEngine;
+using JetBrains.Annotations;
+
+public class A : MonoBehaviour
+{
+    [NotNull]
+    void OnAnima{caret}
+
+    [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/Action/MonoBehaviour09.cs.gold
+++ b/resharper/test/data/codeCompletion/Action/MonoBehaviour09.cs.gold
@@ -1,0 +1,14 @@
+﻿// ${COMPLETE_ITEM:OnAnimatorIK(int) { ... }}
+using UnityEngine;
+using JetBrains.Annotations;
+
+public class A : MonoBehaviour
+{
+  [NotNull]
+  private void OnAnimatorIK(int layerIndex)
+  {
+    throw new System.NotImplementedException();{caret}
+  }
+
+  [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/List/MonoBehaviour07.cs
+++ b/resharper/test/data/codeCompletion/List/MonoBehaviour07.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+    OnAnima{caret}
+
+    [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/List/MonoBehaviour07.cs.gold
+++ b/resharper/test/data/codeCompletion/List/MonoBehaviour07.cs.gold
@@ -1,0 +1,9 @@
+﻿# 2 ITEMS #
+
++ private OnAnimatorIK(int) { ... }
+private OnAnimatorMove() { ... }
+# AUTOMATIC #
+# 2 ITEMS #
+
++ private OnAnimatorIK(int) { ... }
+private OnAnimatorMove() { ... }

--- a/resharper/test/data/codeCompletion/List/MonoBehaviour08.cs
+++ b/resharper/test/data/codeCompletion/List/MonoBehaviour08.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+    void OnAnima{caret}
+
+    [SerializeField] public int Value;
+}

--- a/resharper/test/data/codeCompletion/List/MonoBehaviour08.cs.gold
+++ b/resharper/test/data/codeCompletion/List/MonoBehaviour08.cs.gold
@@ -1,0 +1,11 @@
+﻿# 3 ITEMS #
+
++ OnAnimatorIK(int) { ... }
+OnAnimatorMove() { ... }
+OnAnimaVoid
+# AUTOMATIC #
+# 3 ITEMS #
+
++ OnAnimatorIK(int) { ... }
+OnAnimatorMove() { ... }
+OnAnimaVoid

--- a/resharper/test/src/Feature/Services/CodeCompletion/UnityEventFunctionCompletionActionTest.cs
+++ b/resharper/test/src/Feature/Services/CodeCompletion/UnityEventFunctionCompletionActionTest.cs
@@ -15,5 +15,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.Feature.Services.CodeCompletio
         [Test] public void MonoBehaviour04() { DoNamedTest(); }
         [Test] public void MonoBehaviour05() { DoNamedTest(); }
         [Test] public void MonoBehaviour06() { DoNamedTest(); }
+        [Test] public void MonoBehaviour07() { DoNamedTest(); }
+        [Test] public void MonoBehaviour08() { DoNamedTest(); }
+        [Test] public void MonoBehaviour09() { DoNamedTest(); }
     }
 }

--- a/resharper/test/src/Feature/Services/CodeCompletion/UnityEventFunctionCompletionListTest.cs
+++ b/resharper/test/src/Feature/Services/CodeCompletion/UnityEventFunctionCompletionListTest.cs
@@ -20,6 +20,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.Feature.Services.CodeCompletio
         [Test] public void MonoBehaviour04() { DoNamedTest(); }
         [Test] public void MonoBehaviour05() { DoNamedTest(); }
         [Test] public void MonoBehaviour06() { DoNamedTest(); }
+        [Test] public void MonoBehaviour07() { DoNamedTest(); }
+        [Test] public void MonoBehaviour08() { DoNamedTest(); }
         [Test] public void UnityEditor01() { DoNamedTest(); }
     }
 }


### PR DESCRIPTION
Fixes code completion of event functions in situations like:

```cs
{
  OnAnim{caret}

  [SerializeField] public int Value;
}
```

ReSharper would think that the attribute of the following field as actually an indexer in a property declaration, or an array specifier in a field declaration.

This PR adds tests and fixes completion.

Fixes #259 
