### PR TITLE
Add context action to convert auto-property to property with serialized backing field

### DIFF
--- a/resharper/src/resharper-unity/Feature/Services/ContextActions/AttributeUtil.cs
+++ b/resharper/src/resharper-unity/Feature/Services/ContextActions/AttributeUtil.cs
@@ -1,0 +1,25 @@
+﻿using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.API;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Modules;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
+{
+    public static class AttributeUtil
+    {
+        public static void AddAttribute([CanBeNull] IFieldDeclaration fieldDeclaration, IClrTypeName attributeTypeName,
+            IPsiModule psiModule, CSharpElementFactory elementFactory)
+        {
+            if (fieldDeclaration == null) return;
+
+            var typeElement = TypeFactory.CreateTypeByCLRName(attributeTypeName, psiModule).GetTypeElement();
+            if (typeElement != null)
+            {
+                var attribute = elementFactory.CreateAttribute(typeElement);
+                fieldDeclaration.AddAttributeAfter(attribute, null);
+            }
+        }
+    }
+}

--- a/resharper/src/resharper-unity/Feature/Services/ContextActions/AutoPropertyToSerializedBackingFieldAction.cs
+++ b/resharper/src/resharper-unity/Feature/Services/ContextActions/AutoPropertyToSerializedBackingFieldAction.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.ContextActions;
+using JetBrains.ReSharper.Feature.Services.CSharp.Analyses.Bulbs;
+using JetBrains.ReSharper.Feature.Services.CSharp.Util;
+using JetBrains.ReSharper.Intentions.CSharp.ContextActions;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
+{
+    [ContextAction(Group = UnityContextActions.GroupID,
+        Name = "Replace auto-property with property and serialized backing field",
+        Description = "Replaces auto-property in a Unity type with a property that utilizes a backing field that is marked with the 'UnityEngine.SerializeField' attribute.",
+        Priority = 2)]
+    public class AutoPropertyToSerializedBackingFieldAction : ContextActionBase
+    {
+        public const string ActionText = "To property with serialized backing field";
+
+        private readonly ICSharpContextActionDataProvider myDataProvider;
+
+        public AutoPropertyToSerializedBackingFieldAction(ICSharpContextActionDataProvider dataProvider)
+        {
+            myDataProvider = dataProvider;
+        }
+
+        public override string Text => ActionText;
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            var propertyDeclaration = myDataProvider.GetSelectedElement<IPropertyDeclaration>();
+            if (propertyDeclaration == null) return false;
+
+            if (InterfaceDeclarationNavigator.GetByPropertyDeclaration(propertyDeclaration) != null) return false;
+
+            if (!CSharpAutoPropertyUtil.IsPropertyHeaderSelected(propertyDeclaration, myDataProvider.SelectedTreeRange)) return false;
+            if (!CSharpAutoPropertyUtil.IsEmptyOrNotImplemented(propertyDeclaration)) return false;
+
+            return IsAvailable(propertyDeclaration);
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            var propertyDeclaration = myDataProvider.GetSelectedElement<IPropertyDeclaration>();
+            return Execute(propertyDeclaration, myDataProvider.Solution, myDataProvider.ElementFactory);
+        }
+
+        public static bool IsAvailable([CanBeNull] IPropertyDeclaration propertyDeclaration)
+        {
+            if (propertyDeclaration == null)
+                return false;
+
+            if (!propertyDeclaration.IsFromUnityProject())
+                return false;
+
+            if (AutomaticToBackingFieldAction.IsAvailable(propertyDeclaration))
+            {
+                var unityApi = propertyDeclaration.GetSolution().GetComponent<UnityApi>();
+                var containingType = propertyDeclaration.DeclaredElement?.GetContainingType();
+                return containingType != null && unityApi.IsUnityType(containingType);
+            }
+
+            return false;
+        }
+
+        public static Action<ITextControl> Execute([CanBeNull] IPropertyDeclaration propertyDeclaration, ISolution solution, CSharpElementFactory elementFactory)
+        {
+            if (propertyDeclaration == null)
+                return null;
+
+            var fieldDeclaration = AutomaticToBackingFieldAction.Execute(propertyDeclaration);
+            AttributeUtil.AddAttribute(fieldDeclaration, KnownTypes.SerializeField, propertyDeclaration.GetPsiModule(), elementFactory);
+            return AutomaticToBackingFieldAction.PostExecute(propertyDeclaration, fieldDeclaration, solution);
+        }
+    }
+}

--- a/resharper/src/resharper-unity/Feature/Services/ContextActions/MarkFieldNonSerializedAction.cs
+++ b/resharper/src/resharper-unity/Feature/Services/ContextActions/MarkFieldNonSerializedAction.cs
@@ -3,7 +3,6 @@ using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Feature.Services.CSharp.Analyses.Bulbs;
-using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.TextControl;
@@ -11,7 +10,7 @@ using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
 {
-    [ContextAction(Group = CSharpContextActions.GroupID,
+    [ContextAction(Group = UnityContextActions.GroupID,
         Name = "Annotate field with 'NonSerialized' attribute",
         Description =
             "Adds 'NonSerializedAttribute' to a field in a known Unity type, marking the field as not serialized by Unity")]
@@ -22,21 +21,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
         public MarkFieldNonSerializedAction(ICSharpContextActionDataProvider dataProvider)
         {
             myDataProvider = dataProvider;
-        }
-
-        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
-        {
-            var fieldDeclaration = myDataProvider.GetSelectedElement<IFieldDeclaration>();
-            if (fieldDeclaration != null)
-            {
-                var typeElement = TypeFactory.CreateTypeByCLRName(PredefinedType.NONSERIALIZED_ATTRIBUTE_CLASS, myDataProvider.PsiModule).GetTypeElement();
-                if (typeElement == null)
-                    return null;
-                var attribute = myDataProvider.ElementFactory.CreateAttribute(typeElement);
-                fieldDeclaration.AddAttributeAfter(attribute, null);
-            }
-
-            return null;
         }
 
         public override string Text => "Annotate field with 'NonSerialized' attribute";
@@ -54,6 +38,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
 
             var field = fieldDeclaration.DeclaredElement;
             return field != null && unityApi.IsUnityField(field);
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            var fieldDeclaration = myDataProvider.GetSelectedElement<IFieldDeclaration>();
+            AttributeUtil.AddAttribute(fieldDeclaration, PredefinedType.NONSERIALIZED_ATTRIBUTE_CLASS,
+                myDataProvider.PsiModule, myDataProvider.ElementFactory);
+
+            return null;
         }
     }
 }

--- a/resharper/src/resharper-unity/Feature/Services/ContextActions/UnityContextActions.cs
+++ b/resharper/src/resharper-unity/Feature/Services/ContextActions/UnityContextActions.cs
@@ -1,0 +1,9 @@
+﻿using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions
+{
+    public static class UnityContextActions
+    {
+        public const string GroupID = CSharpContextActions.GroupID + " (Unity)";
+    }
+}

--- a/resharper/src/resharper-unity/Feature/Services/QuickFixes/UseSerializedBackingFieldFix.cs
+++ b/resharper/src/resharper-unity/Feature/Services/QuickFixes/UseSerializedBackingFieldFix.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Daemon.CSharp.Errors;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.QuickFixes
+{
+    [MutuallyExclusiveAction(typeof(AutoPropertyToSerializedBackingFieldAction))]
+    [QuickFix]
+    public class UseSerializedBackingFieldFix : QuickFixBase
+    {
+        [CanBeNull] private readonly IPropertyDeclaration myPropertyDeclaration;
+
+        public UseSerializedBackingFieldFix([NotNull] NonAbstractAccessorWithoutBodyError error)
+        {
+            myPropertyDeclaration = error.TypeMemberDeclaration as IPropertyDeclaration;
+        }
+
+        public UseSerializedBackingFieldFix([NotNull] AutoPropertyMustOverrideAllAccessorsError error)
+        {
+            myPropertyDeclaration = error.Property as IPropertyDeclaration;
+        }
+
+        public override string Text => AutoPropertyToSerializedBackingFieldAction.ActionText;
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            return AutoPropertyToSerializedBackingFieldAction.IsAvailable(myPropertyDeclaration);
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            if (myPropertyDeclaration == null) return null;
+            return AutoPropertyToSerializedBackingFieldAction.Execute(myPropertyDeclaration, solution,
+                CSharpElementFactory.GetInstance(myPropertyDeclaration));
+        }
+    }
+}

--- a/resharper/src/resharper-unity/resharper-unity.resharper.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.resharper.nuspec
@@ -17,8 +17,9 @@
 &#8226; Inspections and Quick Fixes for incorrect event function method signature and return types.
 &#8226; Support for undocumented functions such as OnValidate and OnPreGeneratingCSProjectFiles.
 &#8226; Warns if a coroutine return value is unused.
-&#8226; Context action to convert event function method signature to/from coroutine.
 &#8226; Context actions to add SerializeField or NonSerialized attributes to fields.
+&#8226; Context action to convert auto-property to property with serialized backing field.
+&#8226; Context action to convert event function method signature to/from coroutine.
 &#8226; Use Generate Code to create event functions, with parameters.
 &#8226; Start typing for automatic completion of event function declarations in a class.
 &#8226; Event function descriptions for methods and parameters displayed in tooltips and QuickDoc
@@ -49,6 +50,7 @@
 &#8226; Unity specific file templates.
 </description>
 <releaseNotes>
+&#8226; Add context action to convert auto-property to property with serialized backing field (#195)
 &#8226; Add context action to mark field as serialized or non-serizable (#191)
 &#8226; Add inspection and quick fix for redundant SerializeField attribute
 &#8226; Add inspections and quick fixes for method signature of methods with Unity attributes (#248)

--- a/resharper/src/resharper-unity/resharper-unity.rider.nuspec
+++ b/resharper/src/resharper-unity/resharper-unity.rider.nuspec
@@ -18,6 +18,7 @@
 &#8226; Support for undocumented functions such as OnValidate and OnPreGeneratingCSProjectFiles.
 &#8226; Warns if a coroutine return value is unused.
 &#8226; Context actions to add SerializeField or NonSerialized attributes to fields.
+&#8226; Context action to convert auto-property to property with serialized backing field.
 &#8226; Context action to convert event function method signature to/from coroutine.
 &#8226; Use Generate Code to create event functions, with parameters.
 &#8226; Start typing for automatic completion of event function declarations in a class.
@@ -49,6 +50,7 @@
 &#8226; Unity specific file templates.
 </description>
 <releaseNotes>
+&#8226; Add context action to convert auto-property to property with serialized backing field (#195)
 &#8226; Add context action to mark field as serialized or non-serizable (#191)
 &#8226; Add inspection and quick fix for redundant SerializeField attribute
 &#8226; Add inspections and quick fixes for method signature of methods with Unity attributes (#248)

--- a/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Availability01.cs
+++ b/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Availability01.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+    public int MyAuto{on}Prop1 { get; set; }
+
+    private int _myProp1;
+    public int My{off}Prop1
+    {
+        get { return _myProp1; }
+        set { _myProp1 = value; }
+    }
+}
+
+public interface IFoo
+{
+    int My{off}Prop1 { get; set; }
+}
+
+public class Foo2
+{
+    public int MyAuto{off}Prop1 { get; set; }
+}

--- a/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Availability02.cs
+++ b/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Availability02.cs
@@ -1,0 +1,7 @@
+using System;
+using UnityEngine;
+
+public class BrokenClass : MonoBehaviour
+{
+    public int MyAuto{on}Prop1 { get; 
+}

--- a/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Test01.cs
+++ b/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Test01.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+    public int MyAuto{caret}Prop1 { get; set; }
+}

--- a/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Test01.cs.gold
+++ b/resharper/test/data/intentions/ContextActions/AutoPropertyToSerializedBackingField/Test01.cs.gold
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+  [SerializeField] private int myMyAutoProp1;
+
+  public int MyAutoProp1{caret}
+  {
+    get { return myMyAutoProp1; }
+    set { myMyAutoProp1 = value; }
+  }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test01.cs
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test01.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+    public int Prop { get;{caret} }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test01.cs.gold
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test01.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+    public int Prop { get|;|(0) }
+}
+
+------------------------------------------------
+0: Accessor must declare a body because 'property' is not marked as abstract or extern. Auto-properties must define both 'get' and 'set' accessors.
+QUICKFIXES:
+Make property 'Prop' abstract
+To property with serialized backing field
+Add accessor body
+To property with backing field
+Enable C# 6.0 support for this project

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test02.cs
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test02.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+public abstract class Base : MonoBehaviour
+{
+    public abstract int Prop { get; set; }
+}
+
+public class Derived : Base
+{
+    public override int Pr{caret}op { get; }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test02.cs.gold
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Availability/Test02.cs.gold
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+public abstract class Base : MonoBehaviour
+{
+    public abstract int Prop { get; set; }
+}
+
+public class Derived : Base
+{
+    public override int |Prop|(0) { get; }
+}
+
+------------------------------------------------
+0: Auto-property must override all accessors of the overridden property
+QUICKFIXES:
+To property with serialized backing field
+To property with backing field
+Add setter accessor for 'Prop'

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test01.cs
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test01.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+    public int Prop { get;{caret} }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test01.cs.gold
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test01.cs.gold
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+public class Foo : MonoBehaviour
+{
+  [SerializeField] private readonly int myProp;
+
+  public int Prop
+  {
+    get { return {selstart}myProp{selend}; }
+  }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test02.cs
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test02.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+public abstract class Base : MonoBehaviour
+{
+    public abstract int Prop { get; set; }
+}
+
+public class Derived : Base
+{
+    public override int Pr{caret}op { get; }
+}

--- a/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test02.cs.gold
+++ b/resharper/test/data/intentions/QuickFixes/UseSerializedBackingField/Test02.cs.gold
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public abstract class Base : MonoBehaviour
+{
+    public abstract int Prop { get; set; }
+}
+
+public class Derived : Base
+{
+  [SerializeField] private readonly int myProp;
+
+  public override int Prop
+  {
+    get { return {selstart}myProp{selend}; }
+  }
+}

--- a/resharper/test/src/Intentions/ContextActions/AutoPropertyToSerializedBackingFieldTests.cs
+++ b/resharper/test/src/Intentions/ContextActions/AutoPropertyToSerializedBackingFieldTests.cs
@@ -1,0 +1,25 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.Plugins.Unity.Feature.Services.ContextActions;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.Intentions.ContextActions
+{
+    [TestUnity]
+    public class AutoPropertyToSerializedBackingFieldAvailabilityTest
+        : ContextActionAvailabilityTestBase<AutoPropertyToSerializedBackingFieldAction>
+    {
+        protected override string ExtraPath => @"AutoPropertyToSerializedBackingField";
+
+        [Test] public void TestAvailability01() { DoNamedTest2(); }
+        [Test] public void TestAvailability02() { DoNamedTest2(); }
+    }
+
+    [TestUnity]
+    public class AutoPropertyToSerializedBackingFieldExecutionTest
+        : ContextActionExecuteTestBase<AutoPropertyToSerializedBackingFieldAction>
+    {
+        protected override string ExtraPath => "AutoPropertyToSerializedBackingField";
+
+        [Test] public void Test01() { DoNamedTest(); }
+    }
+}

--- a/resharper/test/src/Intentions/QuickFixes/UseSerializedBackingFieldFixTests.cs
+++ b/resharper/test/src/Intentions/QuickFixes/UseSerializedBackingFieldFixTests.cs
@@ -1,0 +1,28 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.Plugins.Unity.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.TestFramework;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.Intentions.QuickFixes
+{
+    [TestUnity]
+    [CSharpLanguageLevel(CSharpLanguageLevel.CSharp40)]
+    public class UseSerializedBackingFieldFixAvailabilityTests : QuickFixAvailabilityTestBase
+    {
+        protected override string RelativeTestDataPath=> @"Intentions\QuickFixes\UseSerializedBackingField\Availability";
+
+        [Test] public void Test01() { DoNamedTest(); }
+        [Test, CSharpLanguageLevel(CSharpLanguageLevel.CSharp60)] public void Test02() { DoNamedTest(); }
+    }
+
+    [TestUnity]
+    [CSharpLanguageLevel(CSharpLanguageLevel.CSharp40)]
+    public class UseSerializedBackingFieldFixRemoveTests : CSharpQuickFixTestBase<UseSerializedBackingFieldFix>
+    {
+        protected override string RelativeTestDataPath=> @"Intentions\QuickFixes\UseSerializedBackingField";
+
+        [Test] public void Test01() { DoNamedTest(); }
+        [Test, CSharpLanguageLevel(CSharpLanguageLevel.CSharp60)] public void Test02() { DoNamedTest(); }
+    }
+}

--- a/resharper/test/src/tests.resharper.csproj
+++ b/resharper/test/src/tests.resharper.csproj
@@ -11,7 +11,7 @@
     <DefineConstants>TRACE;RELEASE;NET461;RESHARPER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="$(ReSharperSDKVersion)" />    
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="$(ReSharperSDKVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\resharper-unity\resharper-unity.resharper.csproj" />

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -60,6 +60,8 @@
   <li>Inspections and Quick Fixes for incorrect event function method signature and return types.</li>
   <li>Support for undocumented functions such as <code>OnValidate</code> and <code>OnPreGeneratingCSProjectFiles</code>.</li>
   <li>Warns if a coroutine return value is unused.</li>
+  <li>Context actions to add SerializeField or NonSerialized attributes to fields.</li>
+  <li>Context action to convert auto-property to property with serialized backing field.</li>
   <li>Context action to convert event function method signature to/from coroutine.</li>
   <li>Use Generate Code to create event functions, with parameters.</li>
   <li>Start typing for automatic completion of event function declarations in a class.</li>
@@ -98,6 +100,7 @@
   <change-notes>
 <![CDATA[
 <ul>
+  <li>Add context action to convert auto-property to property with serialized backing field (<a href="https://github.com/JetBrains/resharper-unity/issues/195">#195</a>)</li>
   <li>Add context action to mark field as serialized or non-serizable (<a href="https://github.com/JetBrains/resharper-unity/issues/191">#191</a>)</li>
   <li>Add inspection and quick fix for redundant SerializeField attribute</li>
   <li>Add inspections and quick fixes for method signature of methods with Unity attributes (<a href="https://github.com/JetBrains/resharper-unity/issues/248">#248</a>)</li>


### PR DESCRIPTION
Also moves existing (three) context actions to new "C# (Unity)" group of context actions.

Fixes #195 
