### PR TITLE
[WIP] Open external documentation for Unity symbols

### DIFF
--- a/resharper/src/resharper-unity/Feature/Services/QuickDoc/UnityExternalDocumentationContextProvider.cs
+++ b/resharper/src/resharper-unity/Feature/Services/QuickDoc/UnityExternalDocumentationContextProvider.cs
@@ -1,0 +1,125 @@
+﻿#if RIDER
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using JetBrains.DataFlow;
+using JetBrains.ReSharper.Daemon.CaretDependentFeatures;
+using JetBrains.ReSharper.Feature.Services.Contexts;
+using JetBrains.ReSharper.Host.Features;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.DataContext;
+using JetBrains.Rider.Model;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.QuickDoc
+{
+    [ContainsContextConsumer]
+    public class UnityExternalDocumentationContextProvider
+    {
+        private static readonly DeclaredElementPresenterStyle MSDN_STYLE =
+            new DeclaredElementPresenterStyle
+            {
+                ShowEntityKind = EntityKindForm.NONE,
+                ShowName = NameStyle.QUALIFIED,
+                ShowTypeParameters = TypeParameterStyle.CLR
+            };
+
+        [CanBeNull, AsyncContextConsumer]
+        public static Action ProcessDataContext(
+            [NotNull] Lifetime lifetime,
+            [NotNull, ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView,
+            SolutionModel solutionModel,
+            UnityApi unityApi)
+        {
+            var solution = solutionModel.TryGetCurrentSolution();
+            if (solution == null)
+                return null;
+
+            var unityName = GetUnityName(psiDocumentRangeView, unityApi);
+
+            // This is called only if the process finished while the context is still valid
+            return () =>
+            {
+                solution.CustomData.Data["UNITY_ExternalDocContext"] = unityName;
+            };
+        }
+
+        [NotNull]
+        private static string GetUnityName(IPsiDocumentRangeView psiDocumentRangeView, UnityApi unityApi)
+        {
+            var psiView = psiDocumentRangeView.View<CSharpLanguage>();
+            if (psiView.ContainingNodes.All(n => !n.IsFromUnityProject()))
+                return string.Empty;
+
+            if (!(FindDeclaredElement(psiView) is IClrDeclaredElement element))
+                return string.Empty;
+
+            var unityName = GetUnityEventFunctionName(element, unityApi);
+            if (unityName != null)
+                return unityName;
+
+            return GetFullyQualifiedUnityName(element);
+        }
+
+        [CanBeNull]
+        private static string GetUnityEventFunctionName([NotNull] IDeclaredElement element, UnityApi unityApi)
+        {
+            var method = element as IMethod;
+            if (method == null && element is IParameter parameter)
+                method = parameter.ContainingParametersOwner as IMethod;
+
+            if (method == null)
+                return null;
+
+            var unityEventFunction = unityApi.GetUnityEventFunction(method);
+            if (unityEventFunction == null)
+                return null;
+
+            return unityEventFunction.TypeName + "." + element.ShortName;
+        }
+
+        private static string GetFullyQualifiedUnityName(IClrDeclaredElement element)
+        {
+            var moduleName = element.Module.Name;
+            if (moduleName.StartsWith("UnityEngine") || moduleName.StartsWith("UnityEditor"))
+                return DeclaredElementPresenter.Format(KnownLanguage.ANY, MSDN_STYLE, element);
+            return string.Empty;
+        }
+
+        private static IDeclaredElement FindDeclaredElement([NotNull] IPsiView psiView)
+        {
+            var referenceExpression = psiView.GetSelectedTreeNode<IReferenceExpression>();
+            if (referenceExpression != null)
+            {
+                return referenceExpression.Reference.Resolve().DeclaredElement;
+            }
+
+            var identifier = psiView.GetSelectedTreeNode<ICSharpIdentifier>();
+            if (identifier != null)
+            {
+                var referenceName = ReferenceNameNavigator.GetByNameIdentifier(identifier);
+                if (referenceName != null)
+                    return referenceName.Reference.Resolve().DeclaredElement;
+
+                var declarationUnderCaret =
+                    FieldDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    PropertyDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    MethodDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    ConstructorDeclarationNavigator.GetByTypeName(identifier) ??
+                    CSharpTypeDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    EventDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    ConstantDeclarationNavigator.GetByNameIdentifier(identifier) ??
+                    VariableDeclarationNavigator.GetByNameIdentifier(identifier);
+
+                return declarationUnderCaret?.DeclaredElement;
+            }
+
+            var predefinedTypeUsage = psiView.GetSelectedTreeNode<IPredefinedTypeUsage>();
+            return predefinedTypeUsage?.ScalarPredefinedTypeName.Reference.Resolve().DeclaredElement;
+        }
+    }
+}
+
+#endif

--- a/resharper/src/resharper-unity/Help/ShowUnityHelp.cs
+++ b/resharper/src/resharper-unity/Help/ShowUnityHelp.cs
@@ -68,7 +68,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Help
                         // registry for HKEY_CURRENT_USER\Software\Unity Technologies\Installer
                         // and check the version under the children. Or we could just fall back
                         // to the online search
-                        return GetProgramFiles().Combine("Unity/Editor/Data/Documentation/en");
+                        return programFiles.Combine("Unity/Editor/Data/Documentation/en");
                     }
                     return FileSystemPath.Empty;
 

--- a/resharper/src/resharper-unity/Psi/Resolve/SyncVarHookReference.cs
+++ b/resharper/src/resharper-unity/Psi/Resolve/SyncVarHookReference.cs
@@ -88,7 +88,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.Resolve
             var literalAlterer = StringLiteralAltererUtil.CreateStringLiteralByExpression(myOwner);
             var constantValue = (string)myOwner.ConstantValue.Value;
             Assertion.AssertNotNull(constantValue, "constantValue != null");
-            literalAlterer.Replace(constantValue, element.ShortName, myOwner.GetPsiModule());
+            literalAlterer.Replace(constantValue, element.ShortName);
             var newOwner = literalAlterer.Expression;
             if (!myOwner.Equals(newOwner))
                 return newOwner.FindReference<SyncVarHookReference>() ?? this;

--- a/resharper/src/resharper-unity/Psi/Resolve/UnityEventFunctionReference.cs
+++ b/resharper/src/resharper-unity/Psi/Resolve/UnityEventFunctionReference.cs
@@ -94,7 +94,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Psi.Resolve
             var literalAlterer = StringLiteralAltererUtil.CreateStringLiteralByExpression(myOwner);
             var constantValue = (string)myOwner.ConstantValue.Value;
             Assertion.AssertNotNull(constantValue, "constantValue != null");
-            literalAlterer.Replace(constantValue, element.ShortName, myOwner.GetPsiModule());
+            literalAlterer.Replace(constantValue, element.ShortName);
             var newOwner = literalAlterer.Expression;
             if (!myOwner.Equals(newOwner))
                 return newOwner.FindReference<UnityEventFunctionReference>() ?? this;

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -4,12 +4,15 @@ import com.intellij.lang.documentation.DocumentationProvider
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.util.PathUtil
 import com.jetbrains.rider.projectView.solution
 
 class UnityDocumentationProvider : DocumentationProvider {
+
+    private val documentationRoot by lazy(this::findDefaultDocumentationRoot)
 
     override fun getUrlFor(p0: PsiElement?, p1: PsiElement?): MutableList<String>? {
         val data = p0?.project?.solution?.customData?.data
@@ -28,30 +31,14 @@ class UnityDocumentationProvider : DocumentationProvider {
         // We know context will be a fully qualified type or method name, starting
         // with either `UnityEngine.` or `UnityEditor.`
         val keyword = stripPrefix(context)
-        val documentationRoot = getDocumentationRoot()
         return getFileUri(documentationRoot, "/ScriptReference/$keyword.html")
             ?: getFileUri(documentationRoot, "/ScriptReference/${keyword.replace('.', '-')}.html")
             ?: "https://docs.unity3d.com/ScriptReference/30_search.html?q=$keyword"
     }
 
     private fun stripPrefix(context: String): String {
+        // 12 for `UnityEngine.` or `UnityEditor.`
         return context.drop(12)
-    }
-
-    private fun getDocumentationRoot(): String {
-        return when {
-            SystemInfo.isWindows -> {
-                // Unity is installed to `C:\Program Files\Unity`, on both 32 bit and 64 bit
-                // %PROGRAMFILES% differs if we're a 32 or 64 bit process
-                // %PROGRAMFILES(X86)% only exists if we're 64 bit, and is always in the form `C:\Program Files (x86)`
-                // %PROGRAMFILESW6432% is always in the form `C:\Program Files`
-                val envvar = System.getenv("ProgramW6432") ?: System.getenv("ProgramFiles")
-                PathUtil.toSystemDependentName(envvar).plus("/Unity/Editor/Data/Documentation/en")
-            }
-            SystemInfo.isMac -> "/Applications/Unity/Documentation/en"
-            SystemInfo.isUnix -> "/opt/Unity/Editor/Data/Documentation/en"
-            else -> ""
-        }
     }
 
     private fun getFileUri(documentationRoot: String, htmlPath: String): String? {
@@ -60,5 +47,42 @@ class UnityDocumentationProvider : DocumentationProvider {
         if (file != null && file.exists())
             return VfsUtil.pathToUrl(path)
         return null
+    }
+
+    private fun findDefaultDocumentationRoot(): String {
+        return when {
+            SystemInfo.isWindows -> {
+                // Unity is installed to `C:\Program Files\Unity`, on both 32 bit and 64 bit
+                // %PROGRAMFILES% differs if we're a 32 or 64 bit process
+                // %PROGRAMFILES(X86)% only exists if we're 64 bit, and is always in the form `C:\Program Files (x86)`
+                // %PROGRAMFILESW6432% is always in the form `C:\Program Files`
+                val envvar = System.getenv("ProgramW6432") ?: System.getenv("ProgramFiles")
+                PathUtil.toSystemDependentName(envvar) + "/Unity/Editor/Data/Documentation/en"
+            }
+            SystemInfo.isMac -> "/Applications/Unity/Documentation/en"
+            SystemInfo.isLinux -> {
+                // Unity 2017.3 is the first version to add support for local documentation.
+                // It will write to /opt if it has write permissions, otherwise, it writes to
+                // the user's home directory, but adds the version, e.g. ~/Unity-2017.3.0b1
+                val fileSystem = LocalFileSystem.getInstance()
+                fileSystem.findFileByPath("/opt")?.let {
+                    for (dir in getUnityChildDirs(it)) {
+                        fileSystem.findFileByPath(dir)?.let { return it.path }
+                    }
+                }
+                VfsUtil.getUserHomeDir()?.let {
+                    for (dir in getUnityChildDirs(it)) {
+                        fileSystem.findFileByPath(dir)?.let { return it.path }
+                    }
+                }
+                ""
+            }
+            else -> ""
+        }
+    }
+
+    private fun getUnityChildDirs(root: VirtualFile): List<String> {
+        return VfsUtil.getChildren(root, { virtualFile -> virtualFile.isDirectory && virtualFile.name.startsWith("Unity") })
+                .map { it.path + "/Editor/Data/Documentation/en" }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -7,8 +7,8 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
-import com.intellij.util.PathUtil
 import com.jetbrains.rider.projectView.solution
+import java.nio.file.Paths
 
 class UnityDocumentationProvider : DocumentationProvider {
 
@@ -57,7 +57,7 @@ class UnityDocumentationProvider : DocumentationProvider {
                 // %PROGRAMFILES(X86)% only exists if we're 64 bit, and is always in the form `C:\Program Files (x86)`
                 // %PROGRAMFILESW6432% is always in the form `C:\Program Files`
                 val envvar = System.getenv("ProgramW6432") ?: System.getenv("ProgramFiles")
-                PathUtil.toSystemDependentName(envvar) + "/Unity/Editor/Data/Documentation/en"
+                Paths.get(envvar).resolve("/Unity/Editor/Data/Documentation/en").toString()
             }
             SystemInfo.isMac -> "/Applications/Unity/Documentation/en"
             SystemInfo.isLinux -> {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -2,17 +2,18 @@ package com.jetbrains.rider.plugins.unity.quickDoc
 
 import com.intellij.lang.documentation.DocumentationProvider
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
+import com.intellij.util.SystemProperties
+import com.intellij.util.io.exists
 import com.jetbrains.rider.projectView.solution
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class UnityDocumentationProvider : DocumentationProvider {
 
-    private val documentationRoot by lazy(this::findDefaultDocumentationRoot)
+    private val documentationRoot by lazy(this::findFallbackDocumentationRoot)
 
     override fun getUrlFor(p0: PsiElement?, p1: PsiElement?): MutableList<String>? {
         val data = p0?.project?.solution?.customData?.data
@@ -31,8 +32,8 @@ class UnityDocumentationProvider : DocumentationProvider {
         // We know context will be a fully qualified type or method name, starting
         // with either `UnityEngine.` or `UnityEditor.`
         val keyword = stripPrefix(context)
-        return getFileUri(documentationRoot, "/ScriptReference/$keyword.html")
-            ?: getFileUri(documentationRoot, "/ScriptReference/${keyword.replace('.', '-')}.html")
+        return getFileUri(documentationRoot, "ScriptReference/$keyword.html")
+            ?: getFileUri(documentationRoot, "ScriptReference/${keyword.replace('.', '-')}.html")
             ?: "https://docs.unity3d.com/ScriptReference/30_search.html?q=$keyword"
     }
 
@@ -41,15 +42,17 @@ class UnityDocumentationProvider : DocumentationProvider {
         return context.drop(12)
     }
 
-    private fun getFileUri(documentationRoot: String, htmlPath: String): String? {
-        val path = documentationRoot + htmlPath
-        val file = LocalFileSystem.getInstance().findFileByPath(path)
-        if (file != null && file.exists())
-            return VfsUtil.pathToUrl(path)
+    private fun getFileUri(documentationRoot: Path?, htmlPath: String): String? {
+        if (documentationRoot == null)
+            return null
+        val path = documentationRoot.resolve(htmlPath)
+        if (path.exists()) {
+            return path.toUri().toASCIIString()
+        }
         return null
     }
 
-    private fun findDefaultDocumentationRoot(): String {
+    private fun findFallbackDocumentationRoot(): Path? {
         return when {
             SystemInfo.isWindows -> {
                 // Unity is installed to `C:\Program Files\Unity`, on both 32 bit and 64 bit
@@ -57,32 +60,22 @@ class UnityDocumentationProvider : DocumentationProvider {
                 // %PROGRAMFILES(X86)% only exists if we're 64 bit, and is always in the form `C:\Program Files (x86)`
                 // %PROGRAMFILESW6432% is always in the form `C:\Program Files`
                 val envvar = System.getenv("ProgramW6432") ?: System.getenv("ProgramFiles")
-                Paths.get(envvar).resolve("/Unity/Editor/Data/Documentation/en").toString()
+                Paths.get(envvar).resolve("/Unity/Editor/Data/Documentation/en")
             }
-            SystemInfo.isMac -> "/Applications/Unity/Documentation/en"
+            SystemInfo.isMac -> Paths.get("/Applications/Unity/Unity.app/Contents/Documentation/en")
             SystemInfo.isLinux -> {
                 // Unity 2017.3 is the first version to add support for local documentation.
                 // It will write to /opt if it has write permissions, otherwise, it writes to
                 // the user's home directory, but adds the version, e.g. ~/Unity-2017.3.0b1
-                val fileSystem = LocalFileSystem.getInstance()
-                fileSystem.findFileByPath("/opt")?.let {
-                    for (dir in getUnityChildDirs(it)) {
-                        fileSystem.findFileByPath(dir)?.let { return it.path }
-                    }
-                }
-                VfsUtil.getUserHomeDir()?.let {
-                    for (dir in getUnityChildDirs(it)) {
-                        fileSystem.findFileByPath(dir)?.let { return it.path }
-                    }
-                }
-                ""
+                val globalDocRoots = getUnityChildDirs(Paths.get("/opt"))
+                val homeDocRoots = getUnityChildDirs(Paths.get(SystemProperties.getUserHome()))
+                (globalDocRoots + homeDocRoots)
+                        .map { it.resolve("Editor/Data/Documentation/en") }
+                        .firstOrNull { it.exists() }
             }
-            else -> ""
+            else -> null
         }
     }
 
-    private fun getUnityChildDirs(root: VirtualFile): List<String> {
-        return VfsUtil.getChildren(root, { virtualFile -> virtualFile.isDirectory && virtualFile.name.startsWith("Unity") })
-                .map { it.path + "/Editor/Data/Documentation/en" }
-    }
+    private fun getUnityChildDirs(root: Path): Sequence<Path> = Files.newDirectoryStream(root, "Unity*").asSequence()
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -1,0 +1,64 @@
+package com.jetbrains.rider.plugins.unity.quickDoc
+
+import com.intellij.lang.documentation.DocumentationProvider
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.util.PathUtil
+import com.jetbrains.rider.projectView.solution
+
+class UnityDocumentationProvider : DocumentationProvider {
+
+    override fun getUrlFor(p0: PsiElement?, p1: PsiElement?): MutableList<String>? {
+        val data = p0?.project?.solution?.customData?.data
+        val context = data?.get("UNITY_ExternalDocContext")
+        if (!context.isNullOrBlank())
+            return arrayListOf(getUrlForContext(context!!))
+        return null
+    }
+
+    override fun getQuickNavigateInfo(p0: PsiElement?, p1: PsiElement?): String? = null
+    override fun getDocumentationElementForLookupItem(p0: PsiManager?, p1: Any?, p2: PsiElement?): PsiElement? = null
+    override fun generateDoc(p0: PsiElement?, p1: PsiElement?): String? = null
+    override fun getDocumentationElementForLink(p0: PsiManager?, p1: String?, p2: PsiElement?): PsiElement? = null
+
+    private fun getUrlForContext(context: String): String {
+        // We know context will be a fully qualified type or method name, starting
+        // with either `UnityEngine.` or `UnityEditor.`
+        val keyword = stripPrefix(context)
+        val documentationRoot = getDocumentationRoot()
+        return getFileUri(documentationRoot, "/ScriptReference/$keyword.html")
+            ?: getFileUri(documentationRoot, "/ScriptReference/${keyword.replace('.', '-')}.html")
+            ?: "https://docs.unity3d.com/ScriptReference/30_search.html?q=$keyword"
+    }
+
+    private fun stripPrefix(context: String): String {
+        return context.drop(12)
+    }
+
+    private fun getDocumentationRoot(): String {
+        return when {
+            SystemInfo.isWindows -> {
+                // Unity is installed to `C:\Program Files\Unity`, on both 32 bit and 64 bit
+                // %PROGRAMFILES% differs if we're a 32 or 64 bit process
+                // %PROGRAMFILES(X86)% only exists if we're 64 bit, and is always in the form `C:\Program Files (x86)`
+                // %PROGRAMFILESW6432% is always in the form `C:\Program Files`
+                val envvar = System.getenv("ProgramW6432") ?: System.getenv("ProgramFiles")
+                PathUtil.toSystemDependentName(envvar).plus("/Unity/Editor/Data/Documentation/en")
+            }
+            SystemInfo.isMac -> "/Applications/Unity/Documentation/en"
+            SystemInfo.isUnix -> "/opt/Unity/Editor/Data/Documentation/en"
+            else -> ""
+        }
+    }
+
+    private fun getFileUri(documentationRoot: String, htmlPath: String): String? {
+        val path = documentationRoot + htmlPath
+        val file = LocalFileSystem.getInstance().findFileByPath(path)
+        if (file != null && file.exists())
+            return VfsUtil.pathToUrl(path)
+        return null
+    }
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,10 @@
     <configurationType implementation="com.jetbrains.rider.plugins.unity.run.configurations.UnityDebugConfigurationType" />
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.UnityPluginOptionsPage" id="preferences.build.unityPlugin" />
 
+    <!-- This has to be first, as the default Rider handler returns an empty list instead of null, and IJ considers that handled -->
+    <lang.documentationProvider language="C#" implementationClass="com.jetbrains.rider.plugins.unity.quickDoc.UnityDocumentationProvider"
+                                order="first" />
+
     <!-- ShaderLab support -->
     <fileTypeFactory id="ShaderLab" implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.shaderLab.ShaderLabFileTypeFactory" />
     <lang.altEnter language="ShaderLab" implementationClass="com.jetbrains.rider.intentions.altEnter.ReSharperAltEnterActionHandler" />
@@ -100,6 +104,7 @@
   <change-notes>
 <![CDATA[
 <ul>
+  <li>Open local or web documentation for Unity symbols (<a href="https://github.com/JetBrains/resharper-unity/issues/98">#98</a>)</li>
   <li>Add context action to convert auto-property to property with serialized backing field (<a href="https://github.com/JetBrains/resharper-unity/issues/195">#195</a>)</li>
   <li>Add context action to mark field as serialized or non-serizable (<a href="https://github.com/JetBrains/resharper-unity/issues/191">#191</a>)</li>
   <li>Add inspection and quick fix for redundant SerializeField attribute</li>


### PR DESCRIPTION
An alternative approach, instead of waiting for an API in the protocol and in ReSharper.

Sets up a context consumer, similar to ReSharper's context highlighters that gets called when the context changes, e.g. the cursor is on a new symbol. If that symbol is a Unity symbol, pushes the fully qualified name into the `CustomData` protocol element. When the user calls the _External Documentation_ action, or clicks the icon in the QuickDoc popup, a new `DocumentationProvider` on the front end will check `CustomData` for the symbol name. If present, it generates a URL for the docs, either for locally installed docs, or Unity's search page.

Fixes #98 

Still to do:

- [x] Works and tested on Mac
- [x] Test on Windows
- [x] Verify path for local Linux docs