### PR TITLE
 add app_path and app_content_path to EditorInstance.json

### DIFF
--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -279,7 +279,7 @@ namespace Plugins.Editor.JetBrains
   ""process_id"": {0},
   ""version"": ""{1}"",
   ""app_path"": ""{2}"",
-  ""app_contents_path"": ""{3}"",
+  ""app_contents_path"": ""{3}""
 }}", Process.GetCurrentProcess().Id, Application.unityVersion, EditorApplication.applicationPath, EditorApplication.applicationContentsPath));
 
       AppDomain.CurrentDomain.DomainUnload += (sender, args) =>

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -279,8 +279,13 @@ namespace Plugins.Editor.JetBrains
   ""process_id"": {0},
   ""version"": ""{1}"",
   ""app_path"": ""{2}"",
-  ""app_contents_path"": ""{3}""
-}}", Process.GetCurrentProcess().Id, Application.unityVersion, EditorApplication.applicationPath, EditorApplication.applicationContentsPath));
+  ""app_contents_path"": ""{3}"",
+  ""attach_allowed"": ""{4}""
+}}", Process.GetCurrentProcess().Id, Application.unityVersion,
+        EditorApplication.applicationPath, 
+        EditorApplication.applicationContentsPath,
+        EditorPrefs.GetBool("AllowAttachedDebuggingOfEditor", true)
+        ));
 
       AppDomain.CurrentDomain.DomainUnload += (sender, args) =>
       {

--- a/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/resharper/src/resharper-unity/Unity3dRider/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -265,13 +265,11 @@ namespace Plugins.Editor.JetBrains
     }
 
     /// <summary>
-    /// Creates and deletes Library/EditorInstance.json containing version and process ID
+    /// Creates and deletes Library/EditorInstance.json containing info about unity instance
     /// </summary>
     /// <param name="projectDirectory">Path to the project root directory</param>
     private static void InitializeEditorInstanceJson(string projectDirectory)
     {
-      // Only manage EditorInstance.json for 4.x and 5.x - it's a native feature for 2017.x
-#if !UNITY_2017_1_OR_NEWER
       Log(LoggingLevel.Verbose, "Writing Library/EditorInstance.json");
 
       var library = Path.Combine(projectDirectory, "Library");
@@ -279,15 +277,16 @@ namespace Plugins.Editor.JetBrains
 
       File.WriteAllText(editorInstanceJsonPath, string.Format(@"{{
   ""process_id"": {0},
-  ""version"": ""{1}""
-}}", Process.GetCurrentProcess().Id, Application.unityVersion));
+  ""version"": ""{1}"",
+  ""app_path"": ""{2}"",
+  ""app_contents_path"": ""{3}"",
+}}", Process.GetCurrentProcess().Id, Application.unityVersion, EditorApplication.applicationPath, EditorApplication.applicationContentsPath));
 
       AppDomain.CurrentDomain.DomainUnload += (sender, args) =>
       {
         Log(LoggingLevel.Verbose, "Deleting Library/EditorInstance.json");
         File.Delete(editorInstanceJsonPath);
       };
-#endif
     }
 
     /// <summary>


### PR DESCRIPTION
I am a bit confused that 
path to documentation is done both on backend in 
ShowUnityHelp.GetDocumentationRoot()
and on frontend in
UnityDocumentationProvider

Thus I would rather not touch it myself.