### PR TITLE
ShaderLab culture fixes

### DIFF
--- a/resharper/src/resharper-unity/ShaderLab/Feature/Services/VisualElements/VisualElementFactory.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Feature/Services/VisualElements/VisualElementFactory.cs
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Feature.Services.VisualEle
 
         private int GetColorValue(INumericValue value)
         {
-            double.TryParse(value.Constant.GetText(), NumberStyles.Any, CultureInfo.InvariantCulture, out var d);
+            double.TryParse(value.Constant.GetText(), NumberStyles.Float, CultureInfo.InvariantCulture, out var d);
             return (int) (255 * d);
         }
     }

--- a/resharper/src/resharper-unity/ShaderLab/Feature/Services/VisualElements/VisualElementFactory.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Feature/Services/VisualElements/VisualElementFactory.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using System.Globalization;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.VisualElements;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi;
@@ -44,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Feature.Services.VisualEle
 
         private int GetColorValue(INumericValue value)
         {
-            double.TryParse(value.Constant.GetText(), out var d);
+            double.TryParse(value.Constant.GetText(), NumberStyles.Any, CultureInfo.InvariantCulture, out var d);
             return (int) (255 * d);
         }
     }

--- a/resharper/src/resharper-unity/ShaderLab/Psi/Colors/ShaderLabColorReference.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Psi/Colors/ShaderLabColorReference.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Parsing;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Tree;
@@ -20,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Colors
             myColorPropertyValue = colorPropertyValue;
             myColorValue = colorValue;
             ColorElement = colorElement;
-            Owner = (ITreeNode) colorValue ?? colorPropertyValue;
+            Owner = (ITreeNode)colorValue ?? colorPropertyValue;
             ColorConstantRange = colorConstantRange;
 
             BindOptions = new ColorBindOptions
@@ -34,13 +35,23 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Colors
         {
             var languageService = ShaderLabLanguage.Instance.LanguageService();
             Assertion.AssertNotNull(languageService, "languageService != null");
-            var lexer = languageService.GetPrimaryLexerFactory().CreateLexer(new StringBuffer(
-                $"({colorElement.RGBColor.R/255.0:0.##}, {colorElement.RGBColor.G/255.0:0.##}, {colorElement.RGBColor.B/255.0:0.##}, {colorElement.RGBColor.A/255.0:0.##})"));
-            var parser = (IShaderLabParser) languageService.CreateParser(lexer, null, null);
+            var formattedString = GetFormattedString(colorElement);
+            var lexer = languageService.GetPrimaryLexerFactory().CreateLexer(new StringBuffer(formattedString));
+            var parser = (IShaderLabParser)languageService.CreateParser(lexer, null, null);
             var newLiteral = parser.ParseColorLiteral();
 
             myColorPropertyValue?.SetColor(newLiteral);
             myColorValue?.SetConstant(newLiteral);
+        }
+
+        private static string GetFormattedString(IColorElement colorElement)
+        {
+            return string.Format(CultureInfo.InvariantCulture,
+                "({0:0.##}, {1:0.##}, {2:0.##}, {3:0.##})",
+                colorElement.RGBColor.R / 255.0,
+                colorElement.RGBColor.G / 255.0,
+                colorElement.RGBColor.B / 255.0,
+                colorElement.RGBColor.A / 255.0);
         }
 
         public IEnumerable<IColorElement> GetColorTable()

--- a/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorHighlightingTests.cs
+++ b/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorHighlightingTests.cs
@@ -21,8 +21,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Psi.Colors
             return highlighting is ColorHighlighting;
         }
 
-        [Test] public void TestPropertyColor() { DoNamedTest2(); }
-        [Test] public void TestColorValues() { DoNamedTest2(); }
-        [Test] public void TestEdgeCasesAndErrors() { DoNamedTest2(); }
+        [SetCulture("en-US")] [Test] public void TestPropertyColorCultureEn() { DoOneTest("PropertyColor"); }
+        [SetCulture("de-DE")] [Test] public void TestPropertyColorCultureDe() { DoOneTest("PropertyColor"); }
+
+        [SetCulture("en-US")] [Test] public void TestColorValuesCultureEn() { DoOneTest("ColorValues"); }
+        [SetCulture("de-DE")] [Test] public void TestColorValuesCultureDe() { DoOneTest("ColorValues"); }
+
+        [SetCulture("en-US")] [Test] public void TestEdgeCasesAndErrorsCultureEn() { DoOneTest("EdgeCasesAndErrors"); }
+        [SetCulture("de-DE")] [Test] public void TestEdgeCasesAndErrorsCultureDe() { DoOneTest("EdgeCasesAndErrors"); }
     }
 }

--- a/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorPickerTests.cs
+++ b/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorPickerTests.cs
@@ -13,6 +13,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Psi.Colors
     {
         protected override string RelativeTestDataPath => @"ShaderLab\Intentions\QuickFixes\ColorPicker";
 
-        [Test] public void TestChangeColor() { DoNamedTest2(); }
+        [SetCulture("en-US")] [Test] public void TestChangeColorCultureEn() { DoOneTest("ChangeColor"); }
+        [SetCulture("de-DE")] [Test] public void TestChangeColorCultureDe() { DoOneTest("ChangeColor"); }
     }
 }


### PR DESCRIPTION
This PR fixes 2 section of the ShaderLab that did not properly handle culture variants with doubles when parsing and printing them. e.g. germany uses reversed dot notation (1,000.00) so `0.3` was parsed to `3` and made `ShaderLab.Psi.Colors.ShaderLabColorHighlightingTests.*` fail.

Furthermore `ShaderLab.Psi.Colors.ShaderLabColorPickerTests.TestChangeColor` had the reverse problem where doubles were formatted to `0,7` instead of `0.7`.

On top of the 2 fixes I also added culture specific tests so they run under both english and german.