### PR TITLE
Fix colour property handling in shaders

### DIFF
--- a/resharper/src/resharper-unity/ShaderLab/Psi/Colors/ShaderLabColorReference.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Psi/Colors/ShaderLabColorReference.cs
@@ -13,15 +13,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Colors
 {
     public class ShaderLabColorReference : IColorReference
     {
-        private readonly IColorPropertyValue myColorPropertyValue;
+        private readonly IVectorPropertyValue myVectorPropertyValue;
         private readonly IColorValue myColorValue;
 
-        public ShaderLabColorReference(IColorElement colorElement, IColorPropertyValue colorPropertyValue, IColorValue colorValue, DocumentRange colorConstantRange)
+        public ShaderLabColorReference(IColorElement colorElement, IVectorPropertyValue vectorpertyValue,
+            IColorValue colorValue, DocumentRange colorConstantRange)
         {
-            myColorPropertyValue = colorPropertyValue;
+            myVectorPropertyValue = vectorpertyValue;
             myColorValue = colorValue;
             ColorElement = colorElement;
-            Owner = (ITreeNode)colorValue ?? colorPropertyValue;
+            Owner = (ITreeNode) colorValue ?? vectorpertyValue;
             ColorConstantRange = colorConstantRange;
 
             BindOptions = new ColorBindOptions
@@ -38,9 +39,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Colors
             var formattedString = GetFormattedString(colorElement);
             var lexer = languageService.GetPrimaryLexerFactory().CreateLexer(new StringBuffer(formattedString));
             var parser = (IShaderLabParser)languageService.CreateParser(lexer, null, null);
-            var newLiteral = parser.ParseColorLiteral();
+            var newLiteral = parser.ParseVectorLiteral();
 
-            myColorPropertyValue?.SetColor(newLiteral);
+            // One of these will be null
+            myVectorPropertyValue?.SetVector(newLiteral);
             myColorValue?.SetConstant(newLiteral);
         }
 

--- a/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/IShaderLabParser.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/IShaderLabParser.cs
@@ -5,6 +5,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Parsing
 {
     internal interface IShaderLabParser : IParser
     {
-        IColorLiteral ParseColorLiteral();
+        IVectorLiteral ParseVectorLiteral();
     }
 }

--- a/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/ShaderLab.psi
+++ b/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/ShaderLab.psi
@@ -735,15 +735,15 @@ boolLiteral
   | falseLiteral{SHADER_LAB_KEYWORD, Keyword}
 ;
 
-colorLiteral
+vectorLiteral
 :
   LPAREN<LPAREN, LParen>
-  colorLiteralValues
+  vectorLiteralValues
   RPAREN<RPAREN, RParen>
 ;
 
-// Private and error handling to allow resync on colorLiteralValue::RPAREN
-private errorhandling colorLiteralValues
+// Private and error handling to allow resync on vectorLiteralValue::RPAREN
+private errorhandling vectorLiteralValues
 :
   LIST numericValue<NUMBER, Numbers> SEP COMMA<COMMA, Comma>
 ;
@@ -793,7 +793,7 @@ numericValue
 
 colorValue
 :
-  colorLiteral<SHADER_LAB_CONSTANT, Constant>
+  vectorLiteral<SHADER_LAB_CONSTANT, Constant>
   | variableReference<SHADER_LAB_REFERENCE, VariableReference>
 ;
 
@@ -1036,7 +1036,7 @@ errorhandling rangePropertyType
 interface propertyValue
 :
   scalarPropertyValue
-  | colorPropertyValue
+  | vectorPropertyValue
   | texturePropertyValue
   | errorPropertyValue
 ;
@@ -1046,9 +1046,9 @@ scalarPropertyValue
   NUMERIC_LITERAL<SHADER_LAB_VALUE, Number>
 ;
 
-colorPropertyValue
+vectorPropertyValue
 :
-  colorLiteral<SHADER_LAB_VALUE, Color>
+  vectorLiteral<SHADER_LAB_VALUE, Vector>
 ;
 
 texturePropertyValue

--- a/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/ShaderLabParser.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Psi/Parsing/ShaderLabParser.cs
@@ -48,13 +48,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Parsing
             });
         }
 
-        IColorLiteral IShaderLabParser.ParseColorLiteral()
+        IVectorLiteral IShaderLabParser.ParseVectorLiteral()
         {
             return myIntern.DoWithIdentifierIntern(intern =>
             {
-                var element = ParseColorLiteral();
+                var element = ParseVectorLiteral();
                 InsertMissingTokens(element, intern);
-                return (IColorLiteral) element;
+                return (IVectorLiteral) element;
             });
         }
 

--- a/resharper/test/data/ShaderLab/Daemon/Stages/Colors/EdgeCasesAndErrors.shader
+++ b/resharper/test/data/ShaderLab/Daemon/Stages/Colors/EdgeCasesAndErrors.shader
@@ -6,5 +6,7 @@ Shader "Test" {
     _MyColour4 ("Invalid values", Color) = (0, foo, bar, oink)
     _MyColour5 ("Missing values", Color) = (0)
     _MyColour6 ("Too many values", Color) = (1, 1, 1, 1, 1)
+    _MyColour7 ("Out of range values", Color) = (0, 0, 32767, 32767)
+    _MyVector ("Out of range values. Also, vector", Vector) = (0, 0, 32767, 32767)
   }
 }

--- a/resharper/test/data/ShaderLab/Daemon/Stages/Colors/EdgeCasesAndErrors.shader.gold
+++ b/resharper/test/data/ShaderLab/Daemon/Stages/Colors/EdgeCasesAndErrors.shader.gold
@@ -6,6 +6,8 @@
     _MyColour4 ("Invalid values", Color) = (0, foo, bar, oink)
     _MyColour5 ("Missing values", Color) = (0)
     _MyColour6 ("Too many values", Color) = (1, 1, 1, 1, 1)
+    _MyColour7 ("Out of range values", Color) = (|0, 0, 32767, 32767|(2))
+    _MyVector ("Out of range values. Also, vector", Vector) = (0, 0, 32767, 32767)
   }
 }
 
@@ -16,3 +18,6 @@ HEX:  FF, 4C, 66, 99' (E) ''
 (1): : (T) '|   | 
 ARGB:  255, 76, 102, 153
 HEX:  FF, 4C, 66, 99' (E) ''
+(2): : (T) '|   | 
+ARGB:  255, 0, 0, 255
+HEX:  FF, 0, 0, FF' (E) ''

--- a/resharper/test/data/ShaderLab/Daemon/Stages/Colors/PropertyColor.shader
+++ b/resharper/test/data/ShaderLab/Daemon/Stages/Colors/PropertyColor.shader
@@ -1,5 +1,6 @@
 Shader "Test" {
   Properties {
     _MyColour ("This is a colour", Color) = (0.3, 0.4, 0.6, 1)
+    _MyVector ("This is a vector", Vector) = (0.7, 0.3, 0.5, 1)
   }
 }

--- a/resharper/test/data/ShaderLab/Daemon/Stages/Colors/PropertyColor.shader.gold
+++ b/resharper/test/data/ShaderLab/Daemon/Stages/Colors/PropertyColor.shader.gold
@@ -1,6 +1,7 @@
 ﻿Shader "Test" {
   Properties {
     _MyColour ("This is a colour", Color) = (|0.3, 0.4, 0.6, 1|(0))
+    _MyVector ("This is a vector", Vector) = (0.7, 0.3, 0.5, 1)
   }
 }
 

--- a/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorHighlightingTests.cs
+++ b/resharper/test/src/ShaderLab/Psi/Colors/ShaderLabColorHighlightingTests.cs
@@ -21,13 +21,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Psi.Colors
             return highlighting is ColorHighlighting;
         }
 
+        [Test] public void TestPropertyColor() { DoNamedTest2(); }
+        [Test] public void TestColorValues() { DoNamedTest2(); }
+        [Test] public void TestEdgeCasesAndErrors() { DoNamedTest2(); }
+
         [SetCulture("en-US")] [Test] public void TestPropertyColorCultureEn() { DoOneTest("PropertyColor"); }
-        [SetCulture("de-DE")] [Test] public void TestPropertyColorCultureDe() { DoOneTest("PropertyColor"); }
-
         [SetCulture("en-US")] [Test] public void TestColorValuesCultureEn() { DoOneTest("ColorValues"); }
-        [SetCulture("de-DE")] [Test] public void TestColorValuesCultureDe() { DoOneTest("ColorValues"); }
-
         [SetCulture("en-US")] [Test] public void TestEdgeCasesAndErrorsCultureEn() { DoOneTest("EdgeCasesAndErrors"); }
+
+        [SetCulture("de-DE")] [Test] public void TestPropertyColorCultureDe() { DoOneTest("PropertyColor"); }
+        [SetCulture("de-DE")] [Test] public void TestColorValuesCultureDe() { DoOneTest("ColorValues"); }
         [SetCulture("de-DE")] [Test] public void TestEdgeCasesAndErrorsCultureDe() { DoOneTest("EdgeCasesAndErrors"); }
     }
 }


### PR DESCRIPTION
Round to valid colour ARGB values, only parse for colours, not vector

Fixes #384