### PR TITLE
Ensure we only sync the solution when needed.

### DIFF
--- a/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/ModificationPostProcessor.cs
+++ b/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/ModificationPostProcessor.cs
@@ -1,0 +1,36 @@
+using UnityEditor;
+
+namespace JetBrains.Rider.Unity.Editor
+{
+  public class ModificationPostProcessor : UnityEditor.AssetModificationProcessor
+  {
+    public const string ModifiedSource = "com.jetbrains.rider.modifiedsourcefile";
+    
+    private static void OnWillCreateAsset(string path)
+    {
+      var isCs = path.EndsWith(".cs.meta");
+      if (isCs)
+        EditorPrefs.SetBool(ModifiedSource, true);
+    }
+
+    private static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions options)
+    {
+      var isCs = assetPath.EndsWith(".cs.meta") || assetPath.EndsWith(".cs");
+
+      if (isCs)
+        EditorPrefs.SetBool(ModifiedSource, true);
+
+      return AssetDeleteResult.DidNotDelete;
+    }
+
+    private static AssetMoveResult OnWillMoveAsset(string fromPath, string toPath)
+    {
+      var isCs = fromPath.EndsWith(".cs");
+
+      if (isCs)
+        EditorPrefs.SetBool(ModifiedSource, true);
+
+      return AssetMoveResult.DidNotMove;
+    }
+  }
+}

--- a/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/OnOpenAssetHandler.cs
+++ b/unity/JetBrains.Rider.Unity.Editor/EditorPlugin/OnOpenAssetHandler.cs
@@ -45,8 +45,14 @@ namespace JetBrains.Rider.Unity.Editor
             )))
         return false;
 
-      UnityUtils.SyncSolution(); // added to handle opening file, which was just recently created.
+      var shouldSync = EditorPrefs.GetBool(ModificationPostProcessor.ModifiedSource, false);
+      myLogger.Verbose("shouldSync: {0}", shouldSync);
+      
+      if(shouldSync)
+        UnityUtils.SyncSolution(); // added to handle opening file, which was just recently created.
 
+      EditorPrefs.SetBool(ModificationPostProcessor.ModifiedSource, false);
+      
       var model = myModel.Maybe.ValueOrDefault;
       if (model != null)
       {
@@ -66,7 +72,6 @@ namespace JetBrains.Rider.Unity.Editor
 
       var args = string.Format("{0}{1}{0} --line {2} {0}{3}{0}", "\"", mySlnFile, line, assetFilePath);
       return CallRider(args);
-
     }
 
     public bool CallRider(string args)


### PR DESCRIPTION
You are currently forcing a sync everytime the user clicks on a cs file or a log entry. This seems fine, but doesn't happen in Visual Studio, i've tried to mitigate that with these changes, and you should now, only sync the project when needed. (Provided I've caught all the cases)

This is currently, when a cs file has been created, deleted or renamed.
It might be worthwhile considering other situations in the future (assembdefs, rsp, etc)