### PR TITLE
Fix bug to only highlight ShaderLab property usage if caret is on name

### DIFF
--- a/resharper/src/resharper-unity/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsageContextHighlighterAvailability.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsageContextHighlighterAvailability.cs
@@ -4,9 +4,11 @@ using JetBrains.ReSharper.Psi;
 
 namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
 {
+    // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global - derived in Rider
     [ShellComponent]
     public class ShaderLabUsageContextHighlighterAvailability
     {
+        // ReSharper disable once UnusedParameter.Global
         public virtual bool IsAvailable([NotNull] IPsiSourceFile psiSourceFile)
         {
             // Always available in ReSharper - R# doesn't have an option for this,

--- a/resharper/src/resharper-unity/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsagesContextHighlighter.cs
+++ b/resharper/src/resharper-unity/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsagesContextHighlighter.cs
@@ -3,7 +3,6 @@ using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.DataFlow;
 using JetBrains.ReSharper.Daemon.CaretDependentFeatures;
-using JetBrains.ReSharper.Daemon.CSharp.ContextHighlighters;
 using JetBrains.ReSharper.Feature.Services.Contexts;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Feature.Services.Navigation.Requests;
@@ -61,7 +60,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
             if (referenceName != null)
                 return referenceName.Reference.Resolve().DeclaredElement;
 
-            declarationUnderCaret = psiView.GetSelectedTreeNode<IPropertyDeclaration>();
+            var identifier = psiView.GetSelectedTreeNode<IShaderLabIdentifier>();
+            declarationUnderCaret = PropertyDeclarationNavigator.GetByName(identifier);
             return declarationUnderCaret?.DeclaredElement;
         }
 

--- a/resharper/test/data/ShaderLab/ContextHighlighters/PropertyUsage/PropertyUsage01.shader
+++ b/resharper/test/data/ShaderLab/ContextHighlighters/PropertyUsage/PropertyUsage01.shader
@@ -4,8 +4,8 @@ Shader "Foo"
 	{
 		_C{caret:Color}olor ("Color", Color) = (1,1,1,1)
 		_Src{caret:SrcBlend}Blend ("SrcBlend", Int) = 5.0
-		_DstBlend ("DstBlend", Int) = 10.0
-		_ZWrite ("ZWrite", Int) = 1.0
+		_DstBlend ("Ds{caret:Nothing}tBlend", Int) = 10.0
+		_ZWrite ("ZWrite", I{caret:StillNothing}nt) = 1.0
 		_ZTest ("ZTest", Int) = 4.0
 		_Cull ("Cull", Int) = 0.0
 		_Z{caret:ZBias}Bias ("ZBias", Float) = 0.0


### PR DESCRIPTION
Previously, it would highlight if the caret was anywhere in the property declaration