### PR TITLE
[WIP] Clean up and speed up build

### DIFF
--- a/resharper/src/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde.xml
+++ b/resharper/src/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GradleLauncher/bin/Debug/GradleLauncher.exe" />
+    <option name="PROGRAM_PARAMETERS" value="../../../../../rider/ runIde -P dotNetUpToDate=true" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GradleLauncher/bin/Debug" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/GradleLauncher/GradleLauncher.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="Console" />
+    <option name="PROJECT_TFM" value=".NETFramework,Version=v4.5" />
+    <method />
+  </configuration>
+</component>

--- a/resharper/src/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde.xml
+++ b/resharper/src/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde.xml
@@ -11,7 +11,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="Console" />
-    <option name="PROJECT_TFM" value=".NETFramework,Version=v4.5" />
+    <option name="PROJECT_TFM" value=".NETFramework,Version=v4.5.2" />
     <method />
   </configuration>
 </component>

--- a/resharper/src/GradleLauncher/GradleLauncher.csproj
+++ b/resharper/src/GradleLauncher/GradleLauncher.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GradleLauncher</RootNamespace>
+    <AssemblyName>GradleLauncher</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\unity\JetBrains.Rider.Unity.Editor\EditorPlugin\EditorPlugin.csproj">
+      <Project>{67cfb019-ce94-4251-8c3a-4dc70e4e4a52}</Project>
+      <Name>EditorPlugin</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\unity\JetBrains.Rider.Unity.Editor\EditorPlugin\EditorPluginFull.csproj">
+      <Project>{51b82b3c-294f-4751-8754-223c660172e4}</Project>
+      <Name>EditorPluginFull</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\resharper-unity\resharper-unity.rider.csproj">
+      <Project>{d8a177c3-8adf-4b53-aa48-bb5dc1150869}</Project>
+      <Name>resharper-unity.rider</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+</Project>

--- a/resharper/src/GradleLauncher/Program.cs
+++ b/resharper/src/GradleLauncher/Program.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GradleLauncher
+{
+    internal static class Program
+    {
+        public static void Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: GradleLauncher workingDirectory args");
+                return;
+            }
+
+            Environment.CurrentDirectory = args[0];
+            Console.WriteLine("Current directory: {0}", Environment.CurrentDirectory);
+
+            var args2 = args.ToList();
+            args2.RemoveAt(0);
+            var arguments = args2.ToArray();
+
+            if (Environment.OSVersion.Platform == PlatformID.Win32Windows)
+                ExecuteBatchFile("gradlew.bat", arguments);
+            else
+                ExecuteShellScript("./gradlew", arguments);
+        }
+
+        static void ExecuteBatchFile(string command, string[] args)
+        {
+            var commandline = $"/c {command} {args.FormatArgs()}";
+            ExecuteScriptProcessor("cmd.exe", commandline);
+
+        }
+
+        static void ExecuteShellScript(string command, string[] args)
+        {
+            var commandline = $"-c \"{command} {string.Join(" ", args)}\"";
+            ExecuteScriptProcessor("sh", commandline);
+        }
+
+        static void ExecuteScriptProcessor(string processor, string commandline)
+        {
+            Console.WriteLine($"Starting {processor} {commandline}");
+            var processInfo = new ProcessStartInfo(processor, commandline)
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false
+            };
+
+            using (var process = Process.Start(processInfo))
+                process.WaitForExit();
+        }
+
+        static string FormatArgs(this string[] args)
+        {
+            return string.Join(" ", args);
+        }
+    }
+}

--- a/resharper/src/GradleLauncher/Properties/AssemblyInfo.cs
+++ b/resharper/src/GradleLauncher/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GradleLauncher")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GradleLauncher")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("A94DBF29-8006-47D2-AEB6-8DCD6BD86A76")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/resharper/src/resharper-unity.sln
+++ b/resharper/src/resharper-unity.sln
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReSharper", "ReSharper", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EditorPluginFull", "..\..\unity\JetBrains.Rider.Unity.Editor\EditorPlugin\EditorPluginFull.csproj", "{51B82B3C-294F-4751-8754-223C660172E4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "zzGradleLauncher", "zzGradleLauncher", "{6A0FE4B5-F856-4881-8B5D-D4F8990CC26A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GradleLauncher", "GradleLauncher\GradleLauncher.csproj", "{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +59,10 @@ Global
 		{51B82B3C-294F-4751-8754-223C660172E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51B82B3C-294F-4751-8754-223C660172E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51B82B3C-294F-4751-8754-223C660172E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,5 +75,6 @@ Global
 		{849CDA2E-35FC-49A8-A755-C3216B72BAB9} = {9C7433E8-E8C8-4EAA-ADBC-A0B635734CF1}
 		{31338488-0C08-43C2-884F-A38485E2FA2F} = {9C7433E8-E8C8-4EAA-ADBC-A0B635734CF1}
 		{51B82B3C-294F-4751-8754-223C660172E4} = {27FAB5DF-2272-44E7-9BCE-41508F24C07B}
+		{A94DBF29-8006-47D2-AEB6-8DCD6BD86A76} = {6A0FE4B5-F856-4881-8B5D-D4F8990CC26A}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
**WORK IN PROGRESS. DO NOT MERGE**

This PR is cleaning up and speeding up the build. Specifically:

- [x] Remove all warnings
  - [x] Hide `[Obsolete]` warnings for `TreeNodeVisitor` (#422 is logged for a proper fix)
  - [x] Fix warnings about conflicting VS assemblies
  - [x] Use Rider's own syntax highlighting classes, removing warnings about conflicting class names
  - [x] Remove warnings for importing `ILRepacks.targets` more than once
- [ ] Speed up msbuild - it still takes about 14 seconds to build when nothing has changed (this might be a .NET Core SDK issue. .NET 2.1 is boasting about massive improvements here)
  - [x] Make ErrorsGen support incremental build - causes full recompile due to incorrect inputs in task
  - [x] Make ILRepack support incremental build
  - [x] Make `rdgen` support incremental build - up to date check cache is overwritten, meaning it's always generated, so we always compile
- [x] Improve building Rider plugin/improve gradle build
  - [x] EditorPlugin msbuild step uses same build configuration as rest of script, means no more unnecessary rebuild when building `resharper-unity.sln` if different
  - [x] Assembly version now comes purely from msbuild properties, passed from gradle script. No more generating `AssemblyInfo.cs` or modifying `Packaging.props`. Reduces unnecessary rebuilds
  - [x] Refactor to use task types for repeated tasks (e.g. dotnet restore, msbuild, nuget pack)
  - [x] Pass local Rider SDK version as a property instead of patching the .props file
  - [x] Remove patching of plugin.xml - the IntelliJ plugin is already doing that for us
  - [x] Create super fast path for building and running Rider with plugin
- [x] Create shared run configuration to allow running Rider with plugin directly from Rider
- [x] Improve Travis output
  - [x] Disable fancy gradle output formatting
  - [x] Initialise gradle wrapper before we start the actual build, separate the output
  - [x] Folding blocks of output

Stretch goals :)

- :x: Create shared run configuration to allow _debugging_ Rider with plugin directly from Rider - This requires a custom run configuration
- :x: Create shared run configuration to allow running/debugging ReSharper from Rider - didn't investigate
- :x: Add schema to the errors.xml files - didn't investigate
- :x: Ensure PsiGen works correctly with just the Rider project. See [RIDER-14366](https://youtrack.jetbrains.com/issue/RIDER-14366) - No changes to existing implementation

Notable differences:

* EditorPlugin will be built in Release mode. Was defaulting to Debug
* Gradle script won't do a rebuild if only the version number changes. I don't think this will cause a problem as we release from CI, and that will rebuild
* Removes the commented out stale nuget cache cleaner
* Removes the `SinceBuild` and `UntilBuild` parameters - they're not used. Can easily be added back and set in `patchPluginXml` task