### PR TITLE
Improve heuristics for detecting Unity-generated project on frontend

### DIFF
--- a/resharper/src/resharper-unity/ProjectExtensions.cs
+++ b/resharper/src/resharper-unity/ProjectExtensions.cs
@@ -34,7 +34,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return project != null && (project.HasFlavour<UnityProjectFlavor>() || ReferencesUnity(project));
         }
 
-        public static bool IsProjectCompiledByUnity([CanBeNull] this IProject project)
+        public static bool IsUnityGeneratedProject([CanBeNull] this IProject project)
         {
             return project != null && project.HasSubItems("Assets") && IsUnityProject(project);
         }

--- a/resharper/src/resharper-unity/Settings/PerProjectSettings.cs
+++ b/resharper/src/resharper-unity/Settings/PerProjectSettings.cs
@@ -120,7 +120,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
 
         private void InitLanguageLevelSettings(IProject project, SettingsStorageMountPoint mountPoint)
         {
-            if (!project.IsProjectCompiledByUnity())
+            if (!project.IsUnityGeneratedProject())
                 return; // https://github.com/JetBrains/resharper-unity/issues/150
 
             // Make sure ReSharper doesn't suggest code changes that won't compile in Unity

--- a/rider/src/main/kotlin/com/jetbrains/rider/UnityReferenceDiscoverer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/UnityReferenceDiscoverer.kt
@@ -13,6 +13,7 @@ class UnityReferenceDiscoverer(project: Project) : LifetimedProjectComponent(pro
     private val myProjectModelView = project.solution.projectModelView
     private val myEventDispatcher = EventDispatcher.create(UnityReferenceListener::class.java)
     var isUnityProject = false
+    var isUnityGeneratedProject = false
 
     init {
         application.invokeLater {
@@ -34,10 +35,18 @@ class UnityReferenceDiscoverer(project: Project) : LifetimedProjectComponent(pro
         if (descriptor is RdAssemblyReferenceDescriptor && descriptor.name == "UnityEngine") {
             myEventDispatcher.multicaster.hasUnityReference()
             isUnityProject = true
+            isUnityGeneratedProject = hasAssetsFolder(project)
         }
     }
 
     fun addUnityReferenceListener(listener: UnityReferenceListener) {
         myEventDispatcher.addListener(listener)
+    }
+
+    companion object {
+        fun hasAssetsFolder (project:Project):Boolean {
+            val assetsFolder = project.baseDir?.findChild("Assets")
+            return assetsFolder != null
+        }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
@@ -3,6 +3,7 @@ package com.jetbrains.rider.plugins.unity.explorer
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
 import com.intellij.ui.stripe.ErrorStripe
+import com.jetbrains.rider.UnityReferenceDiscoverer
 import com.jetbrains.rider.addProjectReference.AddReferenceAction
 import com.jetbrains.rider.plugins.unity.util.UnityIcons
 import com.jetbrains.rider.projectView.ProjectModelDataKeys
@@ -24,8 +25,7 @@ class UnityExplorer(project: Project) : FileSystemViewPaneBase(project) {
     }
 
     override fun isInitiallyVisible(): Boolean {
-        val assetsFolder = project.baseDir?.findChild("Assets")
-        return assetsFolder != null
+        return UnityReferenceDiscoverer.hasAssetsFolder(project)
     }
 
     override fun createRootNode(): FileSystemNodeBase {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/UnityUIManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/UnityUIManager.kt
@@ -34,7 +34,7 @@ class UnityUIManager(private val unityReferenceDiscoverer: UnityReferenceDiscove
             WindowManager.getInstance().removeListener(this)
         }
         solutionLifecycleHost.isBackendLoaded.advise(componentLifetime) {
-            if (it && unityReferenceDiscoverer.isUnityProject) {
+            if (it && unityReferenceDiscoverer.isUnityGeneratedProject) {
                 isUnityUI.value = true
             }
         }


### PR DESCRIPTION
Check Assets folder and UnityEngine reference to hide Nuget toolwindow.