### PR TITLE
Use Project version to directly install Basic/Full EditorPlugin

### DIFF
--- a/resharper/src/resharper-unity/ProjectExtensions.cs
+++ b/resharper/src/resharper-unity/ProjectExtensions.cs
@@ -14,6 +14,8 @@ namespace JetBrains.ReSharper.Plugins.Unity
     public static class ProjectExtensions
     {
         public const string AssetsFolder = "Assets";
+        public const string ProjectSettingsFolder = "ProjectSettings";
+        public const string LibraryFolder = "Library";
 
         private static readonly AssemblyNameInfo ourUnityEngineReferenceName = AssemblyNameInfoFactory.Create2("UnityEngine", null);
         private static readonly AssemblyNameInfo ourUnityEditorReferenceName = AssemblyNameInfoFactory.Create2("UnityEditor", null);
@@ -52,8 +54,12 @@ namespace JetBrains.ReSharper.Plugins.Unity
         [Obsolete("Assets folder can be found in other solutions. Use IsUnitySolution instead.")]
         public static bool IsSolutionGeneratedByUnity(FileSystemPath solutionDir)
         {
-            var assetsDir = solutionDir.CombineWithShortName(AssetsFolder);
-            return assetsDir.IsAbsolute && assetsDir.ExistsDirectory;
+            var assetsFolder = solutionDir.CombineWithShortName(AssetsFolder);
+            var projectSettingsFolder = solutionDir.CombineWithShortName(ProjectSettingsFolder);
+            var libraryFolder = solutionDir.CombineWithShortName(LibraryFolder);
+            return assetsFolder.IsAbsolute && assetsFolder.ExistsDirectory 
+                   && projectSettingsFolder.IsAbsolute && projectSettingsFolder.ExistsDirectory
+                   && libraryFolder.IsAbsolute && libraryFolder.ExistsDirectory;
         }
 
         private static bool ReferencesUnity(IProject project)

--- a/resharper/src/resharper-unity/Rider/UnityVersionDetector.cs
+++ b/resharper/src/resharper-unity/Rider/UnityVersionDetector.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using JetBrains.Annotations;
+using JetBrains.ProjectModel;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider
+{
+    [SolutionComponent]
+    public class UnityVersionDetector
+    {
+        private readonly ISolution mySolution;
+        private readonly ILogger myLog;
+
+        /// <summary>
+        /// Detects Unity version based on ProjectVersion.txt.
+        /// Works only for Unity-generated projects.
+        /// </summary>
+        /// <returns></returns>
+        [NotNull]
+        public Version GetUnityVersion()
+        {
+            var defaultVersion = new Version(0, 0);
+            var projectSettingsFolder = mySolution.SolutionFilePath.Directory.CombineWithShortName(ProjectExtensions.ProjectSettingsFolder);
+            var projectVersionFile = projectSettingsFolder.Combine("ProjectVersion.txt");
+            if (!projectVersionFile.ExistsFile)
+                return defaultVersion;
+            string line;
+
+            try
+            {
+                var unityVersionString = "0.0";
+                projectVersionFile.ReadTextStream(s =>
+                {
+                    while ((line = s.ReadLine()) != null)
+                    {
+                        if (line.StartsWith("m_EditorVersion:"))
+                            unityVersionString = line.Substring("m_EditorVersion:".Length).Trim();
+                    }
+                });
+
+                if (string.IsNullOrEmpty(unityVersionString))
+                    return defaultVersion;
+
+                var shortUnityVersionString = unityVersionString.Split(".".ToCharArray()).Take(2)
+                    .Aggregate((a, b) => a + "." + b);
+                return new Version(shortUnityVersionString);
+            }
+            catch (Exception e)
+            {
+                myLog.Log(LoggingLevel.ERROR, $"Failed to parse UnityVersion from {projectVersionFile}", e);
+            }
+
+            return defaultVersion;
+        }
+        
+        public UnityVersionDetector(ISolution solution, ILogger log)
+        {
+            mySolution = solution;
+            myLog = log;
+        }
+    }
+}


### PR DESCRIPTION
The worst problem might be, if we install full plugin in the old Unity. But it should not happen.
https://github.com/JetBrains/resharper-unity/issues/510