### PR TITLE
Rewrite Refresh rules to use transactions instead of PM changes

### DIFF
--- a/resharper/src/resharper-unity/Rider/UnityPluginDetector.cs
+++ b/resharper/src/resharper-unity/Rider/UnityPluginDetector.cs
@@ -32,6 +32,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
         [NotNull]
         public InstallationInfo GetInstallationInfo(FileSystemPath previousInstallationDir)
         {
+            myLogger.Verbose("GetInstallationInfo.");
             try
             {
                 var assetsDir = mySolution.SolutionFilePath.Directory.CombineWithShortName(ProjectExtensions.AssetsFolder);


### PR DESCRIPTION
fix "Auto Refresh from Rider - should fire after refactoring, but fires in the middle #535"