### PR TITLE
Use in-memory csproj modification API in 2017.4+

### DIFF
--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -25,6 +25,9 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
     // simply won't get called
     public static string OnGeneratedCSProject(string path, string contents)
     {
+      if (!PluginEntryPoint.Enabled)
+        return contents;
+
       ourLogger.Verbose("Post-processing {0} (in memory)", path);
       var doc = XDocument.Parse(contents);
       if (UpgradeProjectFile(path, doc))


### PR DESCRIPTION
Use a new Unity 2017.4+ API to modify the .csproj files in memory. Unity will only save to the file if the contents have changed.