### PR TITLE
Improve "attach and play" run configurations

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/AttachToUnityProcessAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/AttachToUnityProcessAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.jetbrains.rider.plugins.unity.util.UnityIcons
 import com.jetbrains.rider.plugins.unity.run.attach.UnityProcessPickerDialog
 
-class AttachToUnityProcessAction : AnAction("Attach to Unity Process…", "", UnityIcons.Icons.AttachEditorDebugConfiguration) {
+class AttachToUnityProcessAction : AnAction("Attach to Unity Process…", "", UnityIcons.Actions.AttachToUnity) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project?: return
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityDebuggerOutputListener.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityDebuggerOutputListener.kt
@@ -16,7 +16,7 @@ class UnityDebuggerOutputListener(val project: Project) : IDebuggerOutputListene
     override fun onOutputMessageAvailable(message: OutputMessage) {
 
         if (message.subject == OutputSubject.ConnectionError) {
-            val text = "\nCheck \"Editor Attaching\" in Unity settings.\n"
+            val text = "Unable to connect to Unity Editor.\nPlease check \"Editor Attaching\" in Unity's External Tools settings page.\n"
             XDebuggerManagerImpl.NOTIFICATION_GROUP.createNotification(text, NotificationType.ERROR).notify(project)
 
             val debuggerManager = project.getComponent(XDebuggerManager::class.java)
@@ -24,7 +24,7 @@ class UnityDebuggerOutputListener(val project: Project) : IDebuggerOutputListene
 
             if (debugProcess != null) {
                 val console = debugProcess.console
-                (console as? ConsoleView)?.print(text, when (message.type) {
+                (console as? ConsoleView)?.print("\n" + text, when (message.type) {
                     OutputType.Info -> ConsoleViewContentType.NORMAL_OUTPUT
                     OutputType.Warning -> ConsoleViewContentType.LOG_WARNING_OUTPUT
                     OutputType.Error -> ConsoleViewContentType.ERROR_OUTPUT

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityLocalAttachRunProfile.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityLocalAttachRunProfile.kt
@@ -14,5 +14,5 @@ class UnityLocalAttachRunProfile(private val configurationName: String, private 
     }
 
     override fun getName() = configurationName
-    override fun getIcon() = UnityIcons.Icons.AttachEditorDebugConfiguration
+    override fun getIcon() = UnityIcons.RunConfigurations.AttachToUnityParentConfiguration
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/ProcessesPanel.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/ProcessesPanel.kt
@@ -6,7 +6,6 @@ import com.intellij.ui.AnActionButton
 import com.intellij.ui.PanelWithButtons
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.table.JBTable
-import com.jetbrains.rider.util.reactive.AddRemove
 import java.awt.Dimension
 import javax.swing.JButton
 import javax.swing.JComponent
@@ -65,13 +64,12 @@ class ProcessesPanel : PanelWithButtons() {
             }
         }
 
-        vm.editorProcesses.advise(vm.lifetime,
-            {
-                if (it.newValueOpt == null)
-                    dataModel.fireTableRowsDeleted(it.index, it.index)
-                else
-                    dataModel.fireTableRowsInserted(it.index, it.index)
-            })
+        vm.editorProcesses.advise(vm.lifetime) {
+            if (it.newValueOpt == null)
+                dataModel.fireTableRowsDeleted(it.index, it.index)
+            else
+                dataModel.fireTableRowsInserted(it.index, it.index)
+        }
 
         table = JBTable(dataModel)
         with(table!!) {
@@ -90,7 +88,7 @@ class ProcessesPanel : PanelWithButtons() {
 
             updateSelection(this)
 
-            vm.pid.advise(vm.lifetime, { it.let { updateSelection(this) } })
+            vm.pid.advise(vm.lifetime) { it.let { updateSelection(this) } }
         }
 
         return ToolbarDecorator.createDecorator(table!!)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorFactory.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorFactory.kt
@@ -2,6 +2,7 @@ package com.jetbrains.rider.plugins.unity.run.configurations
 
 import com.intellij.execution.configurations.ConfigurationType
 import com.intellij.openapi.project.Project
+import com.jetbrains.rider.plugins.unity.util.UnityIcons
 import com.jetbrains.rider.run.configurations.DotNetConfigurationFactoryBase
 
 open class UnityAttachToEditorFactory(type: ConfigurationType)
@@ -9,16 +10,21 @@ open class UnityAttachToEditorFactory(type: ConfigurationType)
 
     override fun createTemplateConfiguration(project: Project) = UnityAttachToEditorRunConfiguration(project, this)
     override fun isConfigurationSingletonByDefault() = true
-    override fun getName(): String {
-        return "Unity Debug"
-    }
+    override fun getName() = "Debug Unity Editor"
+    override fun getIcon() = UnityIcons.RunConfigurations.AttachAndDebug
+
+    // This value gets written to the config file. By default it defers to getName, which is what happened pre-2018.3.
+    // Keep the "Unity Debug" value so that we can load configs created by earlier versions, and earlier versions can
+    // load this config
+    override fun getId() = "Unity Debug"
 }
 
 class UnityAttachToEditorAndPlayFactory(type: ConfigurationType)
     : UnityAttachToEditorFactory(type) {
 
     override fun createTemplateConfiguration(project: Project) = UnityAttachToEditorRunConfiguration(project, this, true)
-    override fun getName(): String {
-        return "Unity Debug and Play"
-    }
+    override fun isConfigurationSingletonByDefault() = true
+    override fun getName() = "Debug Unity Editor (play mode)"
+    override fun getId() = "UNITY_ATTACH_AND_PLAY"
+    override fun getIcon() = UnityIcons.RunConfigurations.AttachDebugAndPlay
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorSettingsEditor.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorSettingsEditor.kt
@@ -19,7 +19,7 @@ class UnityAttachToEditorSettingsEditor(project: Project) : SettingsEditor<Unity
 
         // This doesn't work, because this editor seems to be wrapped, and any listeners
         // subscribe to the wrapper, not this class, so firing this doesn't do any good.
-        viewModel.pid.advise(lifetimeDefinition.lifetime, { fireEditorStateChanged() })
+        viewModel.pid.advise(lifetimeDefinition.lifetime) { fireEditorStateChanged() }
     }
 
     override fun checkEditorData(configuration: UnityAttachToEditorRunConfiguration) {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityDebugConfigurationType.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityDebugConfigurationType.kt
@@ -3,30 +3,18 @@ package com.jetbrains.rider.plugins.unity.run.configurations
 import com.intellij.execution.configurations.ConfigurationTypeBase
 import com.jetbrains.rider.plugins.unity.util.UnityIcons
 
-// "UNITY_DEBUG_RUN_CONFIGURATION" is used for a historical reason to avoid undef configuration when updated from old plugin to new one
+// We need to keep "UNITY_DEBUG_RUN_CONFIGURATION" for backwards compatibility - a user can run a newer EAP side by side
+// with 2018.1 and still load the standard attach/debug run config. The new attach/debug/play config will still come up
+// as "Unknown", but we can't help that
 class UnityDebugConfigurationType : ConfigurationTypeBase("UNITY_DEBUG_RUN_CONFIGURATION",
-    "Attach Unity", "Attach to Unity process and debug",
-    UnityIcons.Icons.AttachEditorDebugConfiguration) {
+    "Attach to Unity Editor", "Attach to Unity process and debug",
+    UnityIcons.RunConfigurations.AttachToUnityParentConfiguration) {
 
     val attachToEditorFactory = UnityAttachToEditorFactory(this)
-    // TODO: Add AttachToPlayer factory
-    // val attachToPlayerFactory = UnityAttachToPlayerFactory(this)
-
-    init {
-        addFactory(attachToEditorFactory)
-        // addFactory(attachToPlayerFactory)
-    }
-}
-
-class UnityDebugAndPlayConfigurationType : ConfigurationTypeBase("UNITY_ATTACH_RUN_CONFIGURATION",
-    "Attach Unity and Play", "Attach to UnityEditor and Play",
-    UnityIcons.Icons.AttachAndPlayEditorDebugConfiguration) {
-
     val attachToEditorAndPlayFactory = UnityAttachToEditorAndPlayFactory(this)
 
     init {
+        addFactory(attachToEditorFactory)
         addFactory(attachToEditorAndPlayFactory)
     }
 }
-
-

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityIcons.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityIcons.kt
@@ -12,12 +12,6 @@ class UnityIcons {
 
             // TODO: Proper icons!
             @JvmField
-            val AttachEditorDebugConfiguration = UnityLogo
-
-            @JvmField
-            val AttachAndPlayEditorDebugConfiguration = UnityLogo
-
-            @JvmField
             val ImportantActions = UnityLogo
         }
     }
@@ -100,6 +94,17 @@ class UnityIcons {
 
             val OpenEditorLog = FilterEditModeMessages
             val OpenPlayerLog = FilterPlayModeMessages
+
+            val AttachToUnity = Icons.UnityLogo
+        }
+    }
+
+    class RunConfigurations {
+        companion object {
+            // TODO: Proper icons!
+            val AttachToUnityParentConfiguration = Icons.UnityLogo
+            val AttachAndDebug = AttachToUnityParentConfiguration
+            val AttachDebugAndPlay = AttachToUnityParentConfiguration
         }
     }
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,6 @@
     <configurationType implementation="com.jetbrains.rider.plugins.unity.run.configurations.UnityDebugConfigurationType" />
     <postStartupActivity implementation="com.jetbrains.rider.plugins.unity.ui.UnityUIMinimizer"/>
 
-    <configurationType implementation="com.jetbrains.rider.plugins.unity.run.configurations.UnityDebugAndPlayConfigurationType" />
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.UnityPluginOptionsPage" id="preferences.build.unityPlugin" />
 
     <!-- This has to be first, as the default Rider handler returns an empty list instead of null, and IJ considers that handled -->


### PR DESCRIPTION
Changes the current "Attach and play" from a separate run configuration type to an additional factory for the existing "Attach" type. Should be merged before 2018.2, as it changes the serialised IDs of the new configuration type.