### PR TITLE
Improve support for debugging remote players

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityDebuggerOutputListener.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityDebuggerOutputListener.kt
@@ -12,11 +12,20 @@ import com.jetbrains.rider.model.debuggerWorker.OutputSubject
 import com.jetbrains.rider.model.debuggerWorker.OutputType
 import com.jetbrains.rider.run.IDebuggerOutputListener
 
-class UnityDebuggerOutputListener(val project: Project) : IDebuggerOutputListener {
+class UnityDebuggerOutputListener(val project: Project, private val host: String, private val targetName: String, private val isEditor: Boolean)
+    : IDebuggerOutputListener {
+
     override fun onOutputMessageAvailable(message: OutputMessage) {
 
         if (message.subject == OutputSubject.ConnectionError) {
-            val text = "Unable to connect to Unity Editor.\nPlease check \"Editor Attaching\" in Unity's External Tools settings page.\n"
+            var text = "Unable to connect to $targetName"
+            text += if (isEditor) {
+                "\nPlease ensure 'Editor Attaching' is enabled in Unity's External Tools settings page.\n"
+            }
+            else {
+                "\nPlease ensure that the player has 'Script Debugging' enabled and that the host '$host' is reachable.\n"
+            }
+
             XDebuggerManagerImpl.NOTIFICATION_GROUP.createNotification(text, NotificationType.ERROR).notify(project)
 
             val debuggerManager = project.getComponent(XDebuggerManager::class.java)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachConfiguration.kt
@@ -10,7 +10,9 @@ import com.jetbrains.rider.debugger.IDotNetDebuggable
 import com.jetbrains.rider.run.configurations.remote.RemoteConfiguration
 import javax.swing.Icon
 
-class UnityLocalAttachConfiguration(override var port: Int, private val playerId: String, host: String = "127.0.0.1") : RemoteConfiguration, RunProfile, IDotNetDebuggable {
+class UnityAttachConfiguration(override var address: String, override var port: Int, private val playerId: String,
+                               private val isEditor: Boolean)
+    : RemoteConfiguration, RunProfile, IDotNetDebuggable {
 
     override fun getName(): String = playerId
     override fun getIcon(): Icon = AllIcons.Actions.StartDebugger
@@ -18,9 +20,8 @@ class UnityLocalAttachConfiguration(override var port: Int, private val playerId
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
         if (executor.id != DefaultDebugExecutor.EXECUTOR_ID)
             return null
-        return UnityLocalAttachProfileState(this, environment)
+        return UnityAttachProfileState(this, environment, playerId, isEditor)
     }
 
-    override var address: String = host
     override var listenPortForConnections: Boolean = false
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachEditorDebugger.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachEditorDebugger.kt
@@ -4,10 +4,11 @@ import com.intellij.execution.process.ProcessInfo
 import com.intellij.openapi.project.Project
 import com.intellij.xdebugger.attach.XLocalAttachDebugger
 
-class UnityAttachDebugger : XLocalAttachDebugger {
+class UnityAttachEditorDebugger : XLocalAttachDebugger {
     override fun getDebuggerDisplayName() = "Unity debugger"
 
     override fun attachDebugSession(project: Project, processInfo: ProcessInfo) {
-        UnityRunUtil.runAttach(processInfo.pid, project)
+        // We can safely assume that since it's a local process, it's the editor (standalone players are announced via UDP)
+        UnityRunUtil.attachToEditor(processInfo.pid, project)
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachEditorDebuggerProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachEditorDebuggerProvider.kt
@@ -5,10 +5,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.xdebugger.attach.*
 
-class UnityAttachDebuggerProvider : XAttachDebuggerProvider {
+class UnityAttachEditorDebuggerProvider : XAttachDebuggerProvider {
     override fun getAvailableDebuggers(project: Project, host: XAttachHost, process: ProcessInfo, userData: UserDataHolder): MutableList<XAttachDebugger> {
         if (UnityRunUtil.isUnityEditorProcess(process))
-            return mutableListOf(UnityAttachDebugger())
+            return mutableListOf(UnityAttachEditorDebugger())
         return mutableListOf()
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachProfileState.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachProfileState.kt
@@ -6,10 +6,11 @@ import com.jetbrains.rider.run.IDebuggerOutputListener
 import com.jetbrains.rider.run.configurations.remote.MonoConnectRemoteProfileState
 import com.jetbrains.rider.run.configurations.remote.RemoteConfiguration
 
-class UnityLocalAttachProfileState(remoteConfiguration: RemoteConfiguration, executionEnvironment: ExecutionEnvironment)
+class UnityAttachProfileState(private val remoteConfiguration: RemoteConfiguration, executionEnvironment: ExecutionEnvironment,
+                              private val targetName: String, private val isEditor: Boolean)
     : MonoConnectRemoteProfileState(remoteConfiguration, executionEnvironment) {
 
     override fun getDebuggerOutputEventsListener(): IDebuggerOutputListener {
-        return UnityDebuggerOutputListener(executionEnvironment.project)
+        return UnityDebuggerOutputListener(executionEnvironment.project, remoteConfiguration.address, targetName, isEditor)
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachRunProfile.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachRunProfile.kt
@@ -7,10 +7,12 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.jetbrains.rider.debugger.IDotNetDebuggable
 import com.jetbrains.rider.plugins.unity.util.UnityIcons
 
-class UnityLocalAttachRunProfile(private val configurationName: String, private val configuration: UnityLocalAttachConfiguration) : RemoteRunProfile, IDotNetDebuggable {
+class UnityAttachRunProfile(private val configurationName: String, private val configuration: UnityAttachConfiguration,
+                            private val targetName: String, private val isEditor: Boolean)
+    : RemoteRunProfile, IDotNetDebuggable {
 
     override fun getState(executor: Executor, executionEnvironment: ExecutionEnvironment): RunProfileState? {
-        return UnityLocalAttachProfileState(configuration, executionEnvironment)
+        return UnityAttachProfileState(configuration, executionEnvironment, targetName, isEditor)
     }
 
     override fun getName() = configurationName

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityPlayer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityPlayer.kt
@@ -1,5 +1,5 @@
 package com.jetbrains.rider.plugins.unity.run.attach
 
-data class UnityPlayer(val host: String, val port: Int, val flags: Long,
-                       val guid: Long, val editorId: Long, val version: Int,
-                       val id: String, val allowDebugging: Boolean, val debuggerPort: Int)
+data class UnityPlayer(val host: String, val port: Int, val debuggerPort: Int,
+                       val flags: Long, val guid: Long, val editorId: Long, val version: Int,
+                       val id: String, val allowDebugging: Boolean, val isEditor: Boolean)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityProcessListener.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityProcessListener.kt
@@ -2,18 +2,31 @@ package com.jetbrains.rider.plugins.unity.run.attach
 
 import com.intellij.execution.process.OSProcessUtil
 import com.intellij.openapi.diagnostic.Logger
-import com.jetbrains.rider.plugins.unity.util.convertPortToDebuggerPort
+import com.jetbrains.rider.plugins.unity.util.convertPidToDebuggerPort
 import java.net.*
 import java.util.*
 import java.util.regex.Pattern
 
-class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, private val onPlayerRemoved: (UnityPlayer?) -> Unit) {
+class UnityProcessListener(private val onPlayerAdded: (UnityPlayer) -> Unit, private val onPlayerRemoved: (UnityPlayer) -> Unit) {
 
     companion object {
         private val logger = Logger.getInstance(UnityProcessListener::class.java)
     }
 
-    private val unityPlayerDescriptorRegex = Pattern.compile("""\[IP] (?<ip>.*) \[Port] (?<port>.*) \[Flags] (?<flags>.*) \[Guid] (?<guid>.*) \[EditorId] (?<editorid>.*) \[Version] (?<version>.*) \[Id] (?<id>[^:]+)(:(?<debuggerPort>\\d+))? \[Debug] (?<debug>.*)""")
+    // As far as I can tell:
+    // * IP - where the process is running. On iPhone (and perhaps other devices) this can be the mobile data IP, which
+    //        might be unreachable from this subnet
+    // * port - NOT the debugging port. I think Unity connects to this to get player log information (maybe more?)
+    // * flags - ?
+    // * guid - ? If no debugging port is found (either as its own field, or part of id), then the debugging port is
+    //          `guid % 1000 + 56000`
+    // * editorId - ?
+    // * version - ?
+    // * id - a textual identifier, e.g. "OSXPlayer(Matts.MacBookPro.Local)". May also include debugging port, e.g.
+    //        `iPhonePlayer(Matts.iPhone7):56000`
+    // * Debug - 0 or 1 to show if debugging is enabled. Will not be able to attach if this is 0
+    // * [PackageName] .* - optional value. e.g. `iPhonePlayer`. I don't know how this is different to the value in id
+    private val unityPlayerDescriptorRegex = Pattern.compile("""\[IP] (?<ip>.*) \[Port] (?<port>.*) \[Flags] (?<flags>.*) \[Guid] (?<guid>.*) \[EditorId] (?<editorid>.*) \[Version] (?<version>.*) \[Id] (?<id>[^:]+)(:(?<debuggerPort>\d+))? \[Debug] (?<debug>.*)""")
 
     private val defaultHeartbeat = 30
 
@@ -24,6 +37,7 @@ class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, pr
     private val multicastSockets = mutableListOf<MulticastSocket>()
 
     private val unityPlayerDescriptorsHeartbeats = mutableMapOf<String, Int>()
+    private val unityPlayers = mutableMapOf<String, UnityPlayer>()
 
     private val refreshTimer: Timer
     private val socketsLock = Object()
@@ -57,18 +71,18 @@ class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, pr
         }
 
         OSProcessUtil.getProcessList().filter { UnityRunUtil.isUnityEditorProcess(it) }.map { processInfo ->
-            val port = convertPortToDebuggerPort(processInfo.pid)
-            UnityPlayer("127.0.0.1", port, 0, port.toLong(), port.toLong(), 0, processInfo.executableName, true, port)
+            val port = convertPidToDebuggerPort(processInfo.pid)
+            UnityPlayer("127.0.0.1", port, port, 0, port.toLong(), port.toLong(), 0, processInfo.executableName, true, true)
         }.forEach {
             onPlayerAdded(it)
         }
     }
 
-    private fun parseUnityPlayer(unityPlayerDescriptor: String): UnityPlayer? {
+    private fun parseUnityPlayer(unityPlayerDescriptor: String, hostAddress: String): UnityPlayer? {
         try {
             val matcher = unityPlayerDescriptorRegex.matcher(unityPlayerDescriptor)
             if (matcher.find()) {
-                val ip = matcher.group("ip")
+//                val ip = matcher.group("ip")
                 val port = matcher.group("port").toInt()
                 val flags = matcher.group("flags").toLong()
                 val guid = matcher.group("guid").toLong()
@@ -82,7 +96,17 @@ class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, pr
                 } catch (e: Exception) {
                     //ignore errors on debuggerPort matching or parsing
                 }
-                return UnityPlayer(ip, port, flags, guid, editorGuid, version, id, allowDebugging, debuggerPort)
+                if (debuggerPort == 0) {
+                    // It's not actually a pid, but it's what we have to do
+                    debuggerPort = convertPidToDebuggerPort(guid)
+                }
+
+                // We use hostAddress instead of ip because this is the address we actually received the mulitcast from.
+                // This is more accurate than what we're told, because the Unity process might be reporting the IP address
+                // of an interface that isn't reachable. For example, the iPhone player can report the local IP address
+                // of the mobile data network, which we can't reach from the current network (if we disable mobile data
+                // it works as expected)
+                return UnityPlayer(hostAddress, port, debuggerPort, flags, guid, editorGuid, version, id, allowDebugging, false)
             }
         } catch (e: Exception) {
             logger.warn("Failed to parse Unity Player: ${e.message}")
@@ -97,7 +121,7 @@ class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, pr
                 val currentPlayerTimeout = unityPlayerDescriptorsHeartbeats[playerDescriptor] ?: continue
                 if (currentPlayerTimeout <= 0) {
                     unityPlayerDescriptorsHeartbeats.remove(playerDescriptor)
-                    onPlayerRemoved(parseUnityPlayer(playerDescriptor))
+                    unityPlayers.remove(playerDescriptor)?.let { onPlayerRemoved(it) }
                 } else
                     unityPlayerDescriptorsHeartbeats[playerDescriptor] = currentPlayerTimeout - 1
             }
@@ -110,10 +134,14 @@ class UnityProcessListener(private val onPlayerAdded: (UnityPlayer?) -> Unit, pr
                         if (socket.isClosed)
                             continue
                         socket.receive(recv)
-                        val descriptor = String(buf)
-                        logger.trace("Get heartbeat on port ${socket.port}: $descriptor")
+                        val descriptor = String(buf, 0, recv.length - 1)
+                        val hostAddress = recv.address.hostAddress
+                        logger.trace("Get heartbeat on port ${socket.port} from $hostAddress: $descriptor")
                         if (!unityPlayerDescriptorsHeartbeats.containsKey(descriptor)) {
-                            onPlayerAdded(parseUnityPlayer(descriptor))
+                            parseUnityPlayer(descriptor, hostAddress)?.let {
+                                unityPlayers[descriptor] = it
+                                onPlayerAdded(it)
+                            }
                         }
                         unityPlayerDescriptorsHeartbeats[descriptor] = defaultHeartbeat
                     } catch (e: SocketTimeoutException) {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityRunUtil.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityRunUtil.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.process.ProcessInfo
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.openapi.project.Project
+import com.jetbrains.rider.plugins.unity.util.convertPidToDebuggerPort
 
 object UnityRunUtil {
 
@@ -20,14 +21,14 @@ object UnityRunUtil {
             !name.contains("UnityCrashHandler")
     }
 
-    fun runAttach(pid: Int, project: Project) {
-        val port = 56000 + pid % 1000
-        runAttach("localhost", port, pid.toString(), project)
+    fun attachToEditor(pid: Int, project: Project) {
+        val port = convertPidToDebuggerPort(pid)
+        attachToUnityProcess("localhost", port, "Unity Editor", project, true)
     }
 
-    fun runAttach(host: String, port: Int, playerId: String, project: Project) {
-        val configuration = UnityLocalAttachConfiguration(port, playerId, host)
-        val profile = UnityLocalAttachRunProfile(playerId, configuration)
+    fun attachToUnityProcess(host: String, port: Int, playerId: String, project: Project, isEditor: Boolean) {
+        val configuration = UnityAttachConfiguration(host, port, playerId, isEditor)
+        val profile = UnityAttachRunProfile(playerId, configuration, playerId, isEditor)
         val environment = ExecutionEnvironmentBuilder
             .create(project, DefaultDebugExecutor.getDebugExecutorInstance(), profile)
             .build()

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorProfileState.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorProfileState.kt
@@ -44,6 +44,6 @@ class UnityAttachToEditorProfileState(private val remoteConfiguration: UnityAtta
 
     override fun getDebuggerOutputEventsListener(): IDebuggerOutputListener {
         debugAttached.fire(true)
-        return UnityDebuggerOutputListener(project)
+        return UnityDebuggerOutputListener(project, remoteConfiguration.address, "Unity Editor", true)
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorRunConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorRunConfiguration.kt
@@ -10,10 +10,10 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
-import com.jetbrains.rider.plugins.unity.util.convertPortToDebuggerPort
 import com.jetbrains.rider.run.configurations.remote.DotNetRemoteConfiguration
 import com.jetbrains.rider.run.configurations.remote.RemoteConfiguration
 import com.jetbrains.rider.plugins.unity.run.attach.UnityRunUtil
+import com.jetbrains.rider.plugins.unity.util.convertPidToDebuggerPort
 import com.jetbrains.rider.use2
 import org.apache.commons.logging.LogFactory
 import org.jdom.Element
@@ -62,7 +62,7 @@ class UnityAttachToEditorRunConfiguration(project: Project, factory: UnityAttach
                 ?: findUnityEditorInstance(processList)
                 ?: throw RuntimeConfigurationError("Cannot find Unity Editor instance")
 
-        port = convertPortToDebuggerPort(pid!!)
+        port = convertPidToDebuggerPort(pid!!)
     }
 
     private fun checkValidEditorInstance(pid: Int?, processList: Array<ProcessInfo>): Int? {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityUtils.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityUtils.kt
@@ -1,9 +1,7 @@
 package com.jetbrains.rider.plugins.unity.util
 
-fun convertPortToDebuggerPort(port: Int): Int {
-    return port % 1000 + 56000
-}
+fun convertPidToDebuggerPort(port: Int) = convertPidToDebuggerPort(port.toLong())
 
-fun convertPortToDebuggerPort(port: Long): Int {
+fun convertPidToDebuggerPort(port: Long): Int {
     return (port % 1000).toInt() + 56000
 }

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -57,7 +57,7 @@
     <projectViewPane implementation="com.jetbrains.rider.plugins.unity.explorer.UnityExplorer" id="UnityExplorer" order="first, before SolutionExplorer"/>
     <projectModelViewUpdater implementation="com.jetbrains.rider.plugins.unity.explorer.UnityExplorerUpdater"/>
 
-    <xdebugger.attachDebuggerProvider implementation="com.jetbrains.rider.plugins.unity.run.attach.UnityAttachDebuggerProvider" />
+    <xdebugger.attachDebuggerProvider implementation="com.jetbrains.rider.plugins.unity.run.attach.UnityAttachEditorDebuggerProvider" />
   </extensions>
 
   <project-components>


### PR DESCRIPTION
* Fixes typo in regex to discover debugger port in iPhone players, e.g.
"iPhonePlayer(Matts-iPhone-7):56000"
* Shows players with debugging disabled in the dialog (but not selectable)
* Uses the IP address from the multicast message to work around issues with multiple interfaces. E.g. the iPhone reports the internal IP address of the mobile data network, which isn't reachable from the current network
* Provides better guidance when a player debug session fails to connect