### PR TITLE
Enable editing Unity specific file templates

### DIFF
--- a/resharper/src/resharper-unity/CSharp/Feature/Services/LiveTemplates/Rider/UnityFileTemplatesOptionsPage.cs
+++ b/resharper/src/resharper-unity/CSharp/Feature/Services/LiveTemplates/Rider/UnityFileTemplatesOptionsPage.cs
@@ -1,0 +1,28 @@
+using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.Application.UI.Options;
+using JetBrains.DataFlow;
+using JetBrains.IDE.UI;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Settings;
+using JetBrains.ReSharper.LiveTemplates.UI;
+using JetBrains.ReSharper.Plugins.Unity.Resources;
+using JetBrains.Rider.Model;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplates.Rider
+{
+    [ZoneMarker(typeof(IRiderModelZone))]
+    [OptionsPage("RiderUnityFileTemplatesSettings", "Unity", typeof(LogoThemedIcons.UnityLogo))]
+    public class UnityFileTemplatesOptionsPage : RiderFileTemplatesOptionPageBase
+    {
+        public UnityFileTemplatesOptionsPage(Lifetime lifetime,
+                                             OptionsSettingsSmartContext optionsSettingsSmartContext,
+                                             StoredTemplatesProvider storedTemplatesProvider,
+                                             UnityProjectScopeCategoryUIProvider uiProvider,
+                                             ScopeCategoryManager scopeCategoryManager,
+                                             TemplatesUIFactory uiFactory, IconHostBase iconHostBase)
+            : base(lifetime, uiProvider, optionsSettingsSmartContext, storedTemplatesProvider, scopeCategoryManager,
+                uiFactory, iconHostBase, "CSHARP")
+        {
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/settings/templates/UnityFileTemplatesOptionPage.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/settings/templates/UnityFileTemplatesOptionPage.kt
@@ -1,0 +1,6 @@
+package com.jetbrains.rider.settings.templates
+
+import com.jetbrains.rider.settings.simple.SimpleOptionsPage
+
+class UnityFileTemplatesOptionPage: SimpleOptionsPage("Unity", "RiderUnityFileTemplatesSettings") {
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,8 @@
 
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.UnityPluginOptionsPage" id="preferences.build.unityPlugin" />
 
+    <projectConfigurable parentId="FileTemplatesSettingsId" instance="com.jetbrains.rider.settings.templates.UnityFileTemplatesOptionPage" groupWeight="-120" />
+
     <!-- This has to be first, as the default Rider handler returns an empty list instead of null, and IJ considers that handled -->
     <lang.documentationProvider language="C#" implementationClass="com.jetbrains.rider.plugins.unity.quickDoc.UnityDocumentationProvider"
                                 order="first" />


### PR DESCRIPTION
Adds a "Unity" page to Rider's File Templates section, allowing editing/adding/deleting Unity specific file templates.