### PR TITLE
Fix C# projects not being modified with old runtime

### DIFF
--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -57,7 +57,7 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
     // This method is for pre-2017.4, and is called after the file has been written to disk
     public static void OnGeneratedCSProjectFiles()
     {
-      if (!PluginEntryPoint.Enabled))
+      if (!PluginEntryPoint.Enabled)
         return;
 
       try


### PR DESCRIPTION
Unity's old scripting runtime version of Mono does not support XLinq's `XObject.Changed` event (it does nothing), so we weren't saving any modifications to .csproj files. This PR makes the change tracking manual.

See #662 