### PR TITLE
RIDER-17815 do not run debug and dotCover for Unity run strategy

### DIFF
--- a/resharper/src/resharper-unity/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
+++ b/resharper/src/resharper-unity/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
@@ -77,6 +77,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
             {
                 return Task.FromResult(false);
             }
+
+            var hostId = run.HostController.HostId;
+            if (hostId == WellKnownHostProvidersIds.DebugProviderId)
+            {
+                run.Launch.Output.Error("Starting Unity tests from 'Debug' is currently unsupported. Please attach to editor and use 'Run'.");
+                return Task.FromResult(false);
+            }
+            
+            if (hostId != WellKnownHostProvidersIds.RunProviderId)
+            {
+                run.Launch.Output.Error($"Starting Unity tests from '{hostId}' is currently unsupported.");
+                return Task.FromResult(false);
+            }
             
             var tcs = new TaskCompletionSource<bool>();
             run.Launch.PutData(ourLaunchedInUnityKey, "smth");
@@ -116,8 +129,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
                 if (unitTestElement == null) //https://youtrack.jetbrains.com/issue/RIDER-15849
                 {
                     var name = result.ParentId.Substring(result.ParentId.LastIndexOf(".", StringComparison.Ordinal) + 1);
-                    var brakets = result.TestId.Substring(result.ParentId.Length);
-                    var newID = result.ParentId+"."+name+brakets;
+                    var brackets = result.TestId.Substring(result.ParentId.Length);
+                    var newID = result.ParentId+"."+name+brackets;
                     unitTestElement = GetElementById(newID);
                 }
                 if (unitTestElement == null)

--- a/resharper/src/resharper-unity/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
+++ b/resharper/src/resharper-unity/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
@@ -87,7 +87,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
             
             if (hostId != WellKnownHostProvidersIds.RunProviderId)
             {
-                run.Launch.Output.Error($"Starting Unity tests from '{hostId}' is currently unsupported.");
+                run.Launch.Output.Error($"Starting Unity tests from '{hostId}' is currently unsupported. Please use `Run`.");
                 return Task.FromResult(false);
             }
             


### PR DESCRIPTION
Looks like this.
Actually, there's no difference between run and debug for us at all, but Debug doesn't attach automatically and that confuses people, so I've disabled it too.

Disabling the buttons themselves is not possible right now due to internal workings of unit tests and us using NUnitTestProvider and having 2 different strategies for it. Maybe in `183`?
![image](https://user-images.githubusercontent.com/8605238/43659720-8392d33e-9765-11e8-935e-6db9c897fe5e.png)
