### PR TITLE
Disable error for invalid asmdef reference

### DIFF
--- a/resharper/src/resharper-unity/Json/Daemon/Stages/Resolve/UnresolvedReferenceErrorHandler.cs
+++ b/resharper/src/resharper-unity/Json/Daemon/Stages/Resolve/UnresolvedReferenceErrorHandler.cs
@@ -13,7 +13,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Json.Daemon.Stages.Resolve
     {
         public IHighlighting Run(IReference reference)
         {
-            return new UnresolvedProjectReferenceError(reference);
+            // Don't show the error highlight for now - there are too many false positive hits due to references to
+            // assembly definitions in .asmdef files that are not part of the solution. These files need to be added
+            // into a custom PSI module to make this work properly. This is a quick fix
+            // return new UnresolvedProjectReferenceError(reference);
+            return null;
         }
 
         public IEnumerable<ResolveErrorType> ErrorTypes => new[]

--- a/resharper/test/data/Json/Intentions/QuickFixes/DuplicateItems/Availability/Test02.asmdef.gold
+++ b/resharper/test/data/Json/Intentions/QuickFixes/DuplicateItems/Availability/Test02.asmdef.gold
@@ -1,6 +1,6 @@
 ﻿{
   "name": "Test02",
-  "references": [ ||"Ref1"|(0)|(1), ||"Ref1"|(2)|(3), "|Ref2|(4)" ]
+  "references": [ ||"Ref1"|(0)|(1), ||"Ref1"|(2)|(3), "Ref2" ]
 }
 
 ------------------------------------------------
@@ -16,5 +16,3 @@ Remove invalid value
 3: JSON validation failed: Array items should be unique
 QUICKFIXES:
 Remove invalid value
-4: Unknown project reference 'Ref2'
-NO QUICKFIXES

--- a/resharper/test/data/Json/Intentions/QuickFixes/ReferencingSelf/Availability/Test01.asmdef.gold
+++ b/resharper/test/data/Json/Intentions/QuickFixes/ReferencingSelf/Availability/Test01.asmdef.gold
@@ -1,11 +1,9 @@
 ﻿{
   "name": "Test01",
-  "references": [ "|Unresolved|(0)", "|Test01|(1)" ]
+  "references": [ "Unresolved", "|Test01|(0)" ]
 }
 
 ------------------------------------------------
-0: Unknown project reference 'Unresolved'
-NO QUICKFIXES
-1: Cannot reference self
+0: Cannot reference self
 QUICKFIXES:
 Remove invalid value


### PR DESCRIPTION
Temporarily disable the error for invalid asmdef references, because it can't resolve against assembly definitions defined in files external to the project. A more permanent fix is to include those files into a custom PSI module. I'll raise another issue to do that post 2018.2

Fixes #647. Fixes RIDER-17700