### PR TITLE
Version check typo fix

### DIFF
--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -196,7 +196,7 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
       {
         var configText = File.ReadAllText(configFilePath);
 
-        var isUnity20171OrLater = UnityUtils.UnityVersion < new Version(2017, 1);
+        var isUnity20171OrLater = UnityUtils.UnityVersion >= new Version(2017, 1);
 
         // Unity always sets AllowUnsafeBlocks in 2017.1+
         // Strictly necessary to compile unsafe code

--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -161,7 +161,7 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
     private static bool SetManuallyDefinedCompilerSettings(string projectFile, XElement projectContentElement, XNamespace xmlns)
     {
       // Handled natively by Unity 2017.1+
-      if (UnityUtils.UnityVersion < new Version(2017, 1))
+      if (UnityUtils.UnityVersion >= new Version(2017, 1))
         return false;
 
       string configPath = null;


### PR DESCRIPTION
SetManuallyDefinedCompilerSettings - must be called for unity version < 2017
In existing code if unity version is less then 2017 - this code will be skipped

Please accept asap
Tarkov developer will be very happy )