### PR TITLE
Optimize plugin startup performance

### DIFF
--- a/unity/EditorPlugin/NonUnity/RiderProtocolController.cs
+++ b/unity/EditorPlugin/NonUnity/RiderProtocolController.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using JetBrains.DataFlow;
 using JetBrains.Platform.RdFramework;
 using JetBrains.Platform.RdFramework.Impl;
@@ -32,7 +34,7 @@ namespace JetBrains.Rider.Unity.Editor.NonUnity
     }
   }
   
-  [Serializable]
+//  [Serializable]
   class ProtocolInstance
   {
     public int Port;
@@ -46,7 +48,15 @@ namespace JetBrains.Rider.Unity.Editor.NonUnity
 
     public static string ToJson(List<ProtocolInstance> connections)
     {
-        return JsonConvert.SerializeObject(connections);
+        //return JsonConvert.SerializeObject(connections); //turns out to be slow https://github.com/JetBrains/resharper-unity/issues/728 
+      var sb = new StringBuilder("[");
+
+      sb.Append(connections
+        .Select(connection=> "{" + $"\"Port\":{connection.Port},\"SolutionName\":\"{connection.SolutionName}\"" + "}")
+        .Aggregate((a, b) => a + "," + b));
+
+      sb.Append("]");
+      return sb.ToString();
     }
   }
 }


### PR DESCRIPTION
Avoid using JsonConvert.SerializeObject which is slow, use StringBuilder instead.