### PR TITLE
Remove incorrect implicit use annotations

### DIFF
--- a/resharper/src/resharper-unity/annotations/UnityEditor.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEditor.xml
@@ -7,10 +7,11 @@
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEditor.CanEditMultipleObjects">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEditor.Editor</argument>
+    </attribute>
   </member>
   <member name="T:UnityEditor.CustomEditor">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEditor.Editor</argument>
     </attribute>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.AnimationModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.AnimationModule.xml
@@ -1,7 +1,6 @@
 <assembly name="UnityEngine.AnimationModule">
 
   <member name="T:UnityEngine.SharedBetweenAnimatorsAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.StateMachineBehaviour</argument>
     </attribute>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.CoreModule.xml
@@ -138,37 +138,37 @@
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull(UnityEngine.Object,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull(UnityEngine.Object,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
@@ -237,25 +237,25 @@
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:null =&gt; halt</argument>
     </attribute>
@@ -375,39 +375,32 @@
   <!-- Attributes -->
   <member name="T:UnityEngine.AddComponentMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
   </member>
   <member name="T:UnityEngine.ContextMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
-  <member name="T:UnityEngine.ContextMenuItemAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
-  </member>
   <member name="T:UnityEngine.CreateAssetMenuAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.ScriptableObject</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.DisallowMultipleComponent">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.ExecuteInEditMode">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.HelpURLAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
-  </member>
-  <member name="T:UnityEngine.HideInInspector">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEngine.ImageEffectAllowedInSceneView">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -416,16 +409,11 @@
     </attribute>
   </member>
   <member name="T:UnityEngine.PreferBinarySerialization">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.ScriptableObject</argument>
     </attribute>
   </member>
-  <member name="T:UnityEngine.PropertyAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
-  </member>
   <member name="T:UnityEngine.RequireComponent">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.Component</argument>
     </attribute>
@@ -434,7 +422,6 @@
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEngine.SelectionBaseAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.IMGUIModule.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.IMGUIModule.xml
@@ -1,7 +1,0 @@
-<assembly name="UnityEngine.IMGUIModule">
-
-  <member name="T:UnityEngine.GUITargetAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
-  </member>
-
-</assembly>

--- a/resharper/src/resharper-unity/annotations/UnityEngine.xml
+++ b/resharper/src/resharper-unity/annotations/UnityEngine.xml
@@ -57,6 +57,7 @@
     </typeparameter>
   </member>
   
+
   <!-- UnityEngine.Assertions.Assert -->
   <member name="M:UnityEngine.Assertions.Assert.IsTrue(System.Boolean)">
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
@@ -137,37 +138,37 @@
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNull(UnityEngine.Object,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Assert.IsNotNull(UnityEngine.Object,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>value:null =&gt; halt</argument>
     </attribute>
@@ -236,25 +237,25 @@
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustBeNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:notnull =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:null =&gt; halt</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Assertions.Must.MustExtensions.MustNotBeNull``1(``0,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethdAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>expected:null =&gt; halt</argument>
     </attribute>
@@ -374,42 +375,32 @@
   <!-- Attributes -->
   <member name="T:UnityEngine.AddComponentMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
+      <argument>UnityEngine.MonoBehaviour</argument>
+    </attribute>
   </member>
   <member name="T:UnityEngine.ContextMenu">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
-  <member name="T:UnityEngine.ContextMenuItemAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
-  </member>
   <member name="T:UnityEngine.CreateAssetMenuAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.ScriptableObject</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.DisallowMultipleComponent">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.ExecuteInEditMode">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
-  </member>
-  <member name="T:UnityEngine.GUITargetAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEngine.HelpURLAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
-  </member>
-  <member name="T:UnityEngine.HideInInspector">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEngine.ImageEffectAllowedInSceneView">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
@@ -418,16 +409,11 @@
     </attribute>
   </member>
   <member name="T:UnityEngine.PreferBinarySerialization">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.ScriptableObject</argument>
     </attribute>
   </member>
-  <member name="T:UnityEngine.PropertyAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
-  </member>
   <member name="T:UnityEngine.RequireComponent">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.Component</argument>
     </attribute>
@@ -436,13 +422,11 @@
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:UnityEngine.SelectionBaseAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
   </member>
   <member name="T:UnityEngine.SharedBetweenAnimatorsAttribute">
-    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.BaseTypeRequiredAttribute.#ctor(System.Type)">
       <argument>UnityEngine.StateMachineBehaviour</argument>
     </attribute>

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantAttributeOnTarget/Availability/RedundantFieldAttribute.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantAttributeOnTarget/Availability/RedundantFieldAttribute.cs
@@ -1,3 +1,5 @@
+#pragma warning disable 169
+
 using UnityEngine;
 using UnityEditor;
 

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantAttributeOnTarget/Availability/RedundantFieldAttribute.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantAttributeOnTarget/Availability/RedundantFieldAttribute.cs.gold
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿#pragma warning disable 169
+
+using UnityEngine;
 using UnityEditor;
 
 public class Foo

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantHideInInspectorAttribute/Availability/Test02.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantHideInInspectorAttribute/Availability/Test02.cs
@@ -1,3 +1,5 @@
+#pragma warning disable 169
+
 using UnityEngine;
 
 public class Test

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantHideInInspectorAttribute/Availability/Test02.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/RedundantHideInInspectorAttribute/Availability/Test02.cs.gold
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿#pragma warning disable 169
+
+using UnityEngine;
 
 public class Test
 {


### PR DESCRIPTION
Remove some incorrect implicit use annotations, and remove others that interfere with existing usage suppression (e.g. `PropertyAttribute`, which is a base type of `HeaderAttribute` which would mark a serialised field as in use, but the code does that better).

Fixes [RIDER-19408](https://youtrack.jetbrains.com/issues/RIDER-19408)