### PR TITLE
Show suspicious comparison warning for Unity objects

### DIFF
--- a/resharper/src/resharper-unity/CSharp/Daemon/Stages/Analysis/UnityObjectEqualityProblemAnalyzer.cs
+++ b/resharper/src/resharper-unity/CSharp/Daemon/Stages/Analysis/UnityObjectEqualityProblemAnalyzer.cs
@@ -1,0 +1,69 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Daemon.CSharp.Stages;
+using JetBrains.ReSharper.Daemon.UsageChecking;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.CSharp.Util;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
+{
+    [ElementProblemAnalyzer(typeof(IEqualityExpression),
+        HighlightingTypes = new[] { typeof(SuspiciousComparisonWarning) })]
+    public class UnityObjectEqualityProblemAnalyzer : UnityElementProblemAnalyzer<IEqualityExpression>
+    {
+        public UnityObjectEqualityProblemAnalyzer([NotNull] UnityApi unityApi)
+            : base(unityApi)
+        {
+        }
+
+        // Because UnityEngine.Object overrides its own equality operators, ReSharper can't make many assumptions about
+        // what the operators do. So it can't tell if a comparison of two different types is always false. E.g something
+        // like `if (collider == renderer)`. But we know how the operators work, so we can add a warning in this case.
+        // We can't say it's always false, because it's true if the two types end up having a common sub type, or if
+        // instances are null. So we'll reuse ReSharper's "Suspicious comparison: There is no type in the solution which
+        // is inherited from both `LHS` and `RHS`" warning.
+        // If anyone is relying on both values being null, it is better that they are explicit about it, and why
+        protected override void Analyze(IEqualityExpression equalityExpression, ElementProblemAnalyzerData data,
+                                        IHighlightingConsumer consumer)
+        {
+            // HaveCommonSubtype is quite expensive
+            if (!data.IsSlowAnalysisAllowed()) return;
+
+            var leftOperand = equalityExpression.LeftOperand;
+            var rightOperand = equalityExpression.RightOperand;
+            if (leftOperand == null || rightOperand == null) return;
+
+            var reference = equalityExpression.Reference;
+            Assertion.Assert(reference != null, "reference != null");
+            var @operator = reference.Resolve().DeclaredElement as IOperator;
+            if (@operator == null) return;
+
+            if (@operator.ShortName == "op_Equality" || @operator.ShortName == "op_Inequality")
+            {
+                var type = @operator.GetContainingType();
+                if (type == null) return;
+
+                if (Equals(type.GetClrName(), KnownTypes.Object))
+                {
+                    var leftHeuristicType = leftOperand.GetRuntimeExpressionType();
+                    var rightHeuristicType = rightOperand.GetRuntimeExpressionType();
+
+                    // Since both types derive from Object, the only way they can have a common subtype is if one type
+                    // derives from the other. HaveCommonSubtype is smart enough to short circuit the full check in this
+                    // case
+                    if (!HierarchyUtil.HaveCommonSubtype(leftHeuristicType, rightHeuristicType))
+                    {
+                        consumer.AddHighlighting(new SuspiciousComparisonWarning(
+                            equalityExpression, equalityExpression.GetDocumentRange(), leftHeuristicType,
+                            rightHeuristicType));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarning.cs
+++ b/resharper/test/data/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarning.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+public class UnityObjectEqualitySuspiciousComparisonWarning : MonoBehaviour
+{
+    public void TestMethod(Component component, Component component2)
+    {
+        var rigidBody = GetComponent<Rigidbody>();
+        var collider = GetComponent<Collider>();
+        
+        // No warning
+        if (component == component2) { }
+
+        // Suspicious comparison warnings
+        if (this == rigidBody) { }
+        if (this != rigidBody) { }
+
+        // Suspicious comparison warnings
+        if (collider == rigidBody) { }
+        if (collider != rigidBody) { }
+        
+        // No warnings
+        if (collider == component) { }
+        if (rigidBody == component) { }
+    }
+
+    public void TestMethod2(BaseBehaviour baseBehaviour, DerivedBehaviour derivedBehaviour)
+    {
+        // Suspicious comparison warnings
+        if (baseBehaviour == this) { }
+        if (baseBehaviour != this) { }
+        
+        // No warnings
+        if (baseBehaviour == derivedBehaviour) { }
+    }
+}
+
+public class BaseBehaviour : MonoBehaviour
+{
+}
+
+public class DerivedBehaviour : BaseBehaviour
+{
+}

--- a/resharper/test/data/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarning.cs.gold
+++ b/resharper/test/data/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarning.cs.gold
@@ -1,0 +1,51 @@
+﻿using UnityEngine;
+
+public class UnityObjectEqualitySuspiciousComparisonWarning : MonoBehaviour
+{
+    public void TestMethod(Component component, Component component2)
+    {
+        var rigidBody = GetComponent<Rigidbody>();
+        var collider = GetComponent<Collider>();
+        
+        // No warning
+        if (component == component2) { }
+
+        // Suspicious comparison warnings
+        if (|this == rigidBody|(0)) { }
+        if (|this != rigidBody|(1)) { }
+
+        // Suspicious comparison warnings
+        if (|collider == rigidBody|(2)) { }
+        if (|collider != rigidBody|(3)) { }
+        
+        // No warnings
+        if (collider == component) { }
+        if (rigidBody == component) { }
+    }
+
+    public void TestMethod2(BaseBehaviour baseBehaviour, DerivedBehaviour derivedBehaviour)
+    {
+        // Suspicious comparison warnings
+        if (|baseBehaviour == this|(4)) { }
+        if (|baseBehaviour != this|(5)) { }
+        
+        // No warnings
+        if (baseBehaviour == derivedBehaviour) { }
+    }
+}
+
+public class BaseBehaviour : MonoBehaviour
+{
+}
+
+public class DerivedBehaviour : BaseBehaviour
+{
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'UnityObjectEqualitySuspiciousComparisonWarning' and 'UnityEngine.Rigidbody'
+(1): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'UnityObjectEqualitySuspiciousComparisonWarning' and 'UnityEngine.Rigidbody'
+(2): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'UnityEngine.Collider' and 'UnityEngine.Rigidbody'
+(3): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'UnityEngine.Collider' and 'UnityEngine.Rigidbody'
+(4): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'BaseBehaviour' and 'UnityObjectEqualitySuspiciousComparisonWarning'
+(5): ReSharper Warning: Suspicious comparison: there is no type in the solution which is inherited from both 'BaseBehaviour' and 'UnityObjectEqualitySuspiciousComparisonWarning'

--- a/resharper/test/src/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarningTests.cs
+++ b/resharper/test/src/CSharp/Daemon/Stages/Analysis/UnityObjectEqualitySuspiciousComparisonWarningTests.cs
@@ -1,0 +1,14 @@
+using JetBrains.ReSharper.Daemon.UsageChecking;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.Stages.Analysis
+{
+    [TestUnity]
+    public class UnityObjectEqualitySuspiciousComparisonWarningTests
+        : CSharpHighlightingTestBase<SuspiciousComparisonWarning>
+    {
+        protected override string RelativeTestDataPath => @"CSharp\Daemon\Stages\Analysis";
+
+        [Test] public void TestUnityObjectEqualitySuspiciousComparisonWarning() { DoNamedTest2(); }
+    }
+}


### PR DESCRIPTION
Shows suspicious comparison warning when comparing two objects that derive from `UnityEngine.Object` but don't have a common subtype, such as `Collider` and `Rigidbody`.

Fixes [RIDER-18671](https://youtrack.jetbrains.com/issues/RIDER-18671)