### PR TITLE
Add custom naming style for serialised fields

### DIFF
--- a/resharper/src/resharper-unity/CSharp/Psi/Naming/Elements/UnityNamedElement.cs
+++ b/resharper/src/resharper-unity/CSharp/Psi/Naming/Elements/UnityNamedElement.cs
@@ -1,0 +1,48 @@
+using System;
+using JetBrains.Annotations;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.Naming.Elements;
+using JetBrains.ReSharper.Psi.Naming.Settings;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Naming.Elements
+{
+    // We could pass null here, but we only actually support C#...
+    [NamedElementsBag(typeof(CSharpLanguage))]
+    public class UnityNamedElement : ElementKindOfElementType
+    {
+        [UsedImplicitly] public static readonly IElementKind SERIALISED_FIELD =
+            new UnityNamedElement("UNITY_SERIALISED_FIELD", "Unity serialized field", IsSerialisedField, new NamingRule
+            {
+                NamingStyleKind = NamingStyleKinds.aaBb
+            });
+
+        private readonly NamingRule myNamingRule;
+
+        protected UnityNamedElement(string name, string presentableName, Func<IDeclaredElement, bool> isApplicable,
+                        NamingRule namingRule)
+            : base(name, presentableName, isApplicable)
+        {
+            myNamingRule = namingRule;
+        }
+
+        public override PsiLanguageType Language => CSharpLanguage.Instance;
+
+        // This doesn't really do anything useful. See UnityNamingRuleDefaultSettings
+        public override NamingRule GetDefaultRule() => myNamingRule;
+
+        private static bool IsSerialisedField(IDeclaredElement declaredElement)
+        {
+            if (!(declaredElement is IField field))
+                return false;
+
+            if (!declaredElement.IsFromUnityProject())
+                return false;
+
+            var solution = declaredElement.GetSolution();
+            var unityApi = solution.GetComponent<UnityApi>();
+            return unityApi.IsSerialisedField(field);
+        }
+    }
+}

--- a/resharper/src/resharper-unity/CSharp/Psi/Naming/Elements/UnityNamingRuleDefaultSettings.cs
+++ b/resharper/src/resharper-unity/CSharp/Psi/Naming/Elements/UnityNamingRuleDefaultSettings.cs
@@ -1,0 +1,58 @@
+using System;
+using JetBrains.Application;
+using JetBrains.Application.Settings;
+using JetBrains.Application.Settings.Implementation;
+using JetBrains.ReSharper.Psi.CSharp.Naming2;
+using JetBrains.ReSharper.Psi.Naming.Elements;
+using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Naming.Elements
+{
+    // Defining an element kind isn't enough, we also need to set up a rule that uses it. This is a different process
+    // for CLR and non-CLR languages. The rules come from a per-language instance of INamingPolicyProvider, which gets
+    // its values from settings. For non-CLR languages, this is simply a map from element kind name to NamingPolicy,
+    // which is a list of NamingRules and a flag for inspections. If the rule isn't set up, the default NamingRule comes
+    // from IElementKind.GetDefaultRule.
+    // CLR languages have a more flexible (but also more confusing) system. There are two sets of rules, predefined and
+    // user. The predefined rules are a map of enum to NamingPolicy, with hardcoded defaults. The NamingPolicy can be
+    // modified, but the rule cannot be deleted. The user rules are more flexible, with a set of element kinds, flags
+    // for static and instance modifiers, plus the NamingPolicy. These have to be set in defaults, and can be both
+    // modified and deleted.
+    // I'm not really sure why there is this split. AFAICT, the predefined rules could all be handled with user rules,
+    // if a "do not delete" flag was added. One thing these rules provide is a set of fallbacks, so that there is no
+    // need to provide default rules for all possible element kinds. For example, the XAML namespace naming rule can
+    // fallback to the TypesAndNamespaces predefined type if XamlNamedElements.NAMESPACE_ALIAS doesn't have a rule.
+    // Whatever, this class adds a default user rule for our Unity element kinds
+    [ShellComponent]
+    public class UnityNamingRuleDefaultSettings : HaveDefaultSettings
+    {
+        public static readonly Guid SerializedFieldRuleGuid = new Guid("5F0FDB63-C892-4D2C-9324-15C80B22A7EF");
+
+        public UnityNamingRuleDefaultSettings(ILogger logger, ISettingsSchema settingsSchema)
+            : base(logger, settingsSchema)
+        {
+        }
+
+        public override void InitDefaultSettings(ISettingsStorageMountPoint mountPoint)
+        {
+            SetIndexedValue(mountPoint, (CSharpNamingSettings key) => key.UserRules, SerializedFieldRuleGuid,
+                GetUnitySerializedFieldRule());
+        }
+
+        public static ClrUserDefinedNamingRule GetUnitySerializedFieldRule()
+        {
+            var lowerCaseNamingPolicy = new NamingPolicy(new NamingRule {NamingStyleKind = NamingStyleKinds.aaBb});
+            return new ClrUserDefinedNamingRule(
+                new ClrNamedElementDescriptor(
+                    AccessRightKinds.Any,
+                    StaticnessKinds.Instance,
+                    new ElementKindSet(UnityNamedElement.SERIALISED_FIELD),
+                    "Unity serialized field"),
+                lowerCaseNamingPolicy
+            );
+        }
+
+        public override string Name => "Unity default naming rules";
+    }
+}

--- a/resharper/src/resharper-unity/Rider/OptionsPageBase.cs
+++ b/resharper/src/resharper-unity/Rider/OptionsPageBase.cs
@@ -14,8 +14,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
     {
         protected OptionsPageBase(
             [NotNull] Lifetime lifetime,
-            [NotNull] OptionsSettingsSmartContext optionsSettingsSmartContext)
-            : base(lifetime, optionsSettingsSmartContext)
+            [NotNull] OptionsSettingsSmartContext settingsStore)
+            : base(lifetime, settingsStore)
         {
         }
 

--- a/resharper/src/resharper-unity/Rider/UnityOptionsPage.cs
+++ b/resharper/src/resharper-unity/Rider/UnityOptionsPage.cs
@@ -1,46 +1,107 @@
-﻿using JetBrains.Application.Environment;
+﻿using System;
+using System.Linq.Expressions;
+using JetBrains.Application.Environment;
 using JetBrains.Application.Environment.Helpers;
+using JetBrains.Application.Settings;
 using JetBrains.Application.UI.Options;
+using JetBrains.Application.UI.Options.OptionsDialog.SimpleOptions.ViewModel;
 using JetBrains.DataFlow;
 using JetBrains.ReSharper.Feature.Services.OptionPages.CodeEditing;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Naming.Elements;
 using JetBrains.ReSharper.Plugins.Unity.Resources;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
+using JetBrains.ReSharper.Psi.CSharp.Naming2;
+using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider
 {
-    [OptionsPage(
-        PID,
-        "Unity Engine",
-        typeof(LogoThemedIcons.UnityLogo),
-        Sequence = 0.01,
+    [OptionsPage(PID, "Unity Engine", typeof(LogoThemedIcons.UnityLogo), Sequence = 0.01,
         ParentId = CodeEditingPage.PID)]
     public class UnityOptionsPage : OptionsPageBase
     {
         public const string PID = "UnityPluginSettings";
 
-        public UnityOptionsPage(
-            Lifetime lifetime,
-            OptionsSettingsSmartContext optionsSettingsSmartContext,
-            RunsProducts.ProductConfigurations productConfigurations)
-            : base(lifetime, optionsSettingsSmartContext)
+        private static readonly Expression<Func<CSharpNamingSettings, IIndexedEntry<Guid, ClrUserDefinedNamingRule>>>
+            ourUserRulesAccessor = s => s.UserRules;
+
+        public UnityOptionsPage(Lifetime lifetime, OptionsSettingsSmartContext settingsStore,
+                                RunsProducts.ProductConfigurations productConfigurations)
+            : base(lifetime, settingsStore)
         {
             Header("General");
 
             CheckBox((UnitySettings s) => s.InstallUnity3DRiderPlugin, "Install or update Rider plugin automatically");
             CheckBox((UnitySettings s) => s.AllowAutomaticRefreshInUnity, "Automatically refresh Assets in Unity");
-            
+
+            AddNamingSection(lifetime, settingsStore);
+
             Header("ShaderLab");
 
-            CheckBox((UnitySettings s) => s.EnableShaderLabHippieCompletion, "Enable simple word-based completion in ShaderLab files");
+            CheckBox((UnitySettings s) => s.EnableShaderLabHippieCompletion,
+                "Enable simple word-based completion in ShaderLab files");
 
             if (productConfigurations.IsInternalMode())
             {
                 AddEmptyLine();
-                CheckBox((UnitySettings s) => s.EnableCgErrorHighlighting, "Parse Cg files for syntax errors. Only works in internal mode.");
+                CheckBox((UnitySettings s) => s.EnableCgErrorHighlighting,
+                    "Parse Cg files for syntax errors. Only works in internal mode.");
                 AddText("Requires solution reopen.");
             }
 
             FinishPage();
+        }
+
+        private void AddNamingSection(Lifetime lifetime, IContextBoundSettingsStore settingsStore)
+        {
+            // Rider doesn't have a UI for editing user defined rules. See RIDER-8339
+#if RIDER
+            Header("Naming");
+
+            var entry = settingsStore.Schema.GetIndexedEntry(ourUserRulesAccessor);
+            var userRule = GetUnitySerializedFieldRule(settingsStore, entry);
+            Assertion.AssertNotNull(userRule, "userRule != null");
+
+            var property = new Property<object>(lifetime, "ComboOptionViewModel_SerializedFieldNamingStyle");
+            property.SetValue(userRule.Policy.NamingRule.NamingStyleKind);
+            property.Change.Advise_NoAcknowledgement(lifetime, args =>
+            {
+                var rule = GetUnitySerializedFieldRule(settingsStore, entry);
+                rule.Policy.NamingRule.NamingStyleKind = (NamingStyleKinds) args.New;
+                SetUnitySerializedFieldRule(settingsStore, entry, rule);
+            });
+
+            AddComboOption(property, "Naming style for serialized fields:",
+                new RadioOptionPoint(NamingStyleKinds.AaBb, "UpperCamelCase"),
+                new RadioOptionPoint(NamingStyleKinds.AaBb_AaBb, "UpperCamelCase_UnderscoreTolerant"),
+                new RadioOptionPoint(NamingStyleKinds.AaBb_aaBb, "UpperCamelCase_underscoreTolerant"),
+                new RadioOptionPoint(NamingStyleKinds.aaBb, "lowerCamelCase"),
+                new RadioOptionPoint(NamingStyleKinds.aaBb_AaBb, "lowerCamelCase_UnderscoreTolerant"),
+                new RadioOptionPoint(NamingStyleKinds.aaBb_aaBb, "lowerCamelCase_underscoreTolerant"),
+                new RadioOptionPoint(NamingStyleKinds.AA_BB, "ALL_UPPER"),
+                new RadioOptionPoint(NamingStyleKinds.Aa_bb, "First_upper"));
+        }
+
+        private static ClrUserDefinedNamingRule GetUnitySerializedFieldRule(IContextBoundSettingsStore settingsStore,
+                                                                            SettingsIndexedEntry entry)
+        {
+            var userRule = settingsStore.GetIndexedValue(entry,
+                UnityNamingRuleDefaultSettings.SerializedFieldRuleGuid, null) as ClrUserDefinedNamingRule;
+            if (userRule == null)
+            {
+                userRule = UnityNamingRuleDefaultSettings.GetUnitySerializedFieldRule();
+                SetUnitySerializedFieldRule(settingsStore, entry, userRule);
+            }
+
+            return userRule;
+        }
+
+        private static void SetUnitySerializedFieldRule(IContextBoundSettingsStore settingsStore,
+                                                        SettingsIndexedEntry entry, ClrUserDefinedNamingRule userRule)
+        {
+            settingsStore.SetIndexedValue(entry, UnityNamingRuleDefaultSettings.SerializedFieldRuleGuid, null,
+                userRule);
+#endif
         }
     }
 }

--- a/resharper/src/resharper-unity/Settings/UnitySettings.cs
+++ b/resharper/src/resharper-unity/Settings/UnitySettings.cs
@@ -9,7 +9,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
     {
         [SettingsEntry(true, "If this option is enabled, the Rider Unity editor plugin will be automatically installed and updated.")]
         public bool InstallUnity3DRiderPlugin;
-        
+
         [SettingsEntry(true, "If this option is enabled, Rider will automatically notify the Unity editor to refresh assets.")]
         public bool AllowAutomaticRefreshInUnity;
 

--- a/resharper/src/resharper-unity/resharper-unity.rider.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.rider.csproj
@@ -109,9 +109,9 @@
       <SubType>Designer</SubType>
     </ThemedIconsXamlV3>
   </ItemGroup>
-<ItemGroup>
+  <ItemGroup>
     <Compile Remove="**/Rider/Debugger/**" />
-</ItemGroup>
+  </ItemGroup>
   <!-- References -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />

--- a/resharper/test/data/CSharp/Psi/Naming/Elements/SerializedFieldNameWarnings01.cs
+++ b/resharper/test/data/CSharp/Psi/Naming/Elements/SerializedFieldNameWarnings01.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    public float serializedField01;
+    public float SerializedField02;
+
+    [SerializeField] private float mySerializedField03;
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float NonSerializedField06;
+}
+
+[Serializable]
+public class SerializedClass
+{
+    public float serializedField01;
+    public float SerializedField02;
+
+    [SerializeField] private float mySerializedField03;
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float NonSerializedField06;
+}
+
+public class NotSerialized
+{
+    public float serializedField01;
+    public float SerializedField02;
+
+    [SerializeField] private float mySerializedField03;
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float NonSerializedField06;
+}

--- a/resharper/test/data/CSharp/Psi/Naming/Elements/SerializedFieldNameWarnings01.cs.gold
+++ b/resharper/test/data/CSharp/Psi/Naming/Elements/SerializedFieldNameWarnings01.cs.gold
@@ -1,0 +1,49 @@
+﻿using System;
+using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    public float serializedField01;
+    public float |SerializedField02|(0);
+
+    [SerializeField] private float |mySerializedField03|(1);
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float |NonSerializedField06|(2);
+}
+
+[Serializable]
+public class SerializedClass
+{
+    public float serializedField01;
+    public float |SerializedField02|(3);
+
+    [SerializeField] private float |mySerializedField03|(4);
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float |NonSerializedField06|(5);
+}
+
+public class NotSerialized
+{
+    public float |serializedField01|(6);
+    public float SerializedField02;
+
+    [SerializeField] private float mySerializedField03;
+
+    public static float NonSerializedField04;
+    [NonSerialized] public float NonSerializedField05;
+    private float |NonSerializedField06|(7);
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Name 'SerializedField02' does not match rule 'Unity serialized field'. Suggested name is 'serializedField02'.
+(1): ReSharper Warning: Name 'mySerializedField03' does not match rule 'Unity serialized field'. Suggested name is 'serializedField03'.
+(2):<overlapped> ReSharper Warning: Name 'NonSerializedField06' does not match rule 'Instance fields (private)'. Suggested name is 'myNonSerializedField06'.
+(3): ReSharper Warning: Name 'SerializedField02' does not match rule 'Unity serialized field'. Suggested name is 'serializedField02'.
+(4): ReSharper Warning: Name 'mySerializedField03' does not match rule 'Unity serialized field'. Suggested name is 'serializedField03'.
+(5):<overlapped> ReSharper Warning: Name 'NonSerializedField06' does not match rule 'Instance fields (private)'. Suggested name is 'myNonSerializedField06'.
+(6): ReSharper Warning: Name 'serializedField01' does not match rule 'Fields (not private)'. Suggested name is 'SerializedField01'.
+(7):<overlapped> ReSharper Warning: Name 'NonSerializedField06' does not match rule 'Instance fields (private)'. Suggested name is 'myNonSerializedField06'.

--- a/resharper/test/src/CSharp/Psi/Naming/Elements/UnitySerializedFieldNameInspectionTests.cs
+++ b/resharper/test/src/CSharp/Psi/Naming/Elements/UnitySerializedFieldNameInspectionTests.cs
@@ -1,0 +1,14 @@
+using JetBrains.ReSharper.Feature.Services.Naming;
+using JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.Stages.Analysis;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.Naming.Elements
+{
+    [TestUnity]
+    public class UnitySerializedFieldNameInspectionTests : CSharpHighlightingTestBase<InconsistentNamingWarning>
+    {
+        protected override string RelativeTestDataPath => @"CSharp\Psi\Naming\Elements";
+
+        [Test] public void TestSerializedFieldNameWarnings01() { DoNamedTest2(); }
+    }
+}


### PR DESCRIPTION
This PR will recognise Unity serialised fields as an entity that has its own naming style, rather than using the existing public or private field naming styles. By default, the naming style is `lowerCamelCase`, and if a serialised field doesn't match, it will receive a highlight and a quick fix to rename.

The naming style can be changed (`UpperCamelCase`, `lowerCamlCase_UnderscoreTolerant`, etc.), however, this is not available in the standard C# Naming Code Style tab (see [RIDER-8339](https://youtrack.jetbrains.com/issues/RIDER-8339)), but is available as a drop down in the Unity settings tab.