### PR TITLE
Quick fix for access properties by id instead of string

### DIFF
--- a/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
+++ b/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
@@ -70,6 +70,12 @@
         <Description>Using the string for the component type variants results in additional overhead that should not be incurred.</Description>
       </Tag>
 
+      <Tag externalName="PreferAddressByIdToGraphicsParamsWarning.HIGHLIGHTING_ID"
+           default="WARNING">
+        <Title>Use generic method overload instead of a string one</Title>
+        <Description>Using the string to address graphics properties results in additional overhead that should not be incurred.</Description>
+      </Tag>
+      
       <Tag externalName="AmbiguousTypeInStringLiteralWarning.HIGHLIGHTING_ID"
            default="WARNING">
         <Title>Several types with the same name, this can result in unexpected behaviour at runtime</Title>
@@ -235,6 +241,17 @@
     <Parameter type="ILiteralExpression" name="argument" />
     <Parameter type="ITypeElement[]" name="availableTypes" isValid="skip"/>
     <Message value="Generic method overload is preferred. Using the string parameter results in additional overhead."/>
+    <Range>Argument.GetHighlightingRange()</Range>
+    <Behavour overlapResolvePolicy="NONE" />
+  </Warning>
+
+  <Warning name="PreferAddressByIdToGraphicsParams" configurableSeverity="Unity.PreferAddressByIdToGraphicsParams">
+    <Parameter type="IInvocationExpression" name="invocationMethod" />
+    <Parameter type="ICSharpArgument" name="argument" />
+    <Parameter type="string" name="literal" />
+    <Parameter type="string" name="typeName" />
+    <Parameter type="string" name="mapFunction" />
+    <Message value="Int method overload is preferred. Using the string parameter results in additional overhead."/>
     <Range>Argument.GetHighlightingRange()</Range>
     <Behavour overlapResolvePolicy="NONE" />
   </Warning>

--- a/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
+++ b/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
@@ -248,6 +248,7 @@
   <Warning name="PreferAddressByIdToGraphicsParams" configurableSeverity="Unity.PreferAddressByIdToGraphicsParams">
     <Parameter type="IInvocationExpression" name="invocationMethod" />
     <Parameter type="ICSharpArgument" name="argument" />
+    <Parameter type="IExpression" name="argumentExpression" />
     <Parameter type="string" name="literal" />
     <Parameter type="string" name="typeName" />
     <Parameter type="string" name="mapFunction" />

--- a/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
+++ b/resharper/src/resharper-unity/CSharp/Daemon/Errors/CSharpErrors.xml
@@ -72,7 +72,7 @@
 
       <Tag externalName="PreferAddressByIdToGraphicsParamsWarning.HIGHLIGHTING_ID"
            default="WARNING">
-        <Title>Use generic method overload instead of a string one</Title>
+        <Title>Use int overload to access properties instead of string</Title>
         <Description>Using the string to address graphics properties results in additional overhead that should not be incurred.</Description>
       </Tag>
       
@@ -255,7 +255,7 @@
     <Range>Argument.GetHighlightingRange()</Range>
     <Behavour overlapResolvePolicy="NONE" />
   </Warning>
-
+ 
   <Warning name="AmbiguousTypeInStringLiteral" configurableSeverity="Unity.AmbiguousTypeInStringLiteral">
     <Parameter type="ILiteralExpression" name="argument" />
     <Message value="There are several types with the same name, this can result in an unexpected behaviour at the runtime."/>

--- a/resharper/src/resharper-unity/CSharp/Daemon/Stages/Analysis/PreferAddressByIdToGraphicsParamsAnalyzer.cs
+++ b/resharper/src/resharper-unity/CSharp/Daemon/Stages/Analysis/PreferAddressByIdToGraphicsParamsAnalyzer.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.API;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve.Filters;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
+{
+    [ElementProblemAnalyzer(typeof(IInvocationExpression), HighlightingTypes = new[] { typeof(PreferAddressByIdToGraphicsParamsWarning) })]
+    public class PreferAddressByIdToGraphicsParamsAnalyzer : UnityElementProblemAnalyzer<IInvocationExpression>
+    {
+        
+        private static readonly IDictionary<IClrTypeName, (IClrTypeName, string)> ourTypes = new Dictionary<IClrTypeName, (IClrTypeName, string)>()
+        {
+            {KnownTypes.Animator, (KnownTypes.Animator, "StringToHash")},
+            {KnownTypes.Shader, (KnownTypes.Shader, "PropertyToID")},
+            {KnownTypes.Material, (KnownTypes.Shader, "PropertyToID")},
+        }; 
+        
+        public PreferAddressByIdToGraphicsParamsAnalyzer([NotNull] UnityApi unityApi)
+            : base(unityApi)
+        {
+        }
+
+        protected override void Analyze(IInvocationExpression expression, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
+        {
+            var reference = expression.Reference;
+            if (reference == null) return;
+            
+            var info = reference.Resolve();
+            if (info.ResolveErrorType == ResolveErrorType.OK && info.DeclaredElement is IMethod stringMethod)
+            {
+                if (HasOverloadWithIntParameter(stringMethod, expression, out var argumentIndex, out var containingType))
+                {
+                    var argument = expression.Arguments[argumentIndex];
+                    
+                    var helpData = ourTypes[containingType.GetClrName()];
+                    
+                    if (argument.Expression is ILiteralExpression literal)
+                    {
+                        if (literal.ConstantValue.Value is string str)
+                        {
+                            consumer.AddHighlighting(new PreferAddressByIdToGraphicsParamsWarning(expression, argument, str, helpData.Item1.FullName, helpData.Item2));
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool HasOverloadWithIntParameter(IMethod stringMethod, IInvocationExpression expression, out int index, out ITypeElement containingType)
+        {
+            index = 0;
+            containingType = null;
+            
+            if (!stringMethod.ShortName.StartsWith("Get") && !stringMethod.ShortName.StartsWith("Set")) return false;
+            
+            containingType = stringMethod.GetContainingType();
+
+            if (containingType == null || !ourTypes.ContainsKey(containingType.GetClrName()))
+            {
+                return false;
+            }
+            
+            var type = TypeFactory.CreateType(containingType);
+            var table = type.GetSymbolTable(expression.PsiModule).Filter(
+                new AccessRightsFilter(new DefaultAccessContext(expression)),
+                new ExactNameFilter(stringMethod.ShortName),
+                new PredicateFilter(t => MatchSignatureStringToIntMethod(stringMethod, t.GetDeclaredElement() as IMethod)));
+
+
+            if (table.GetSymbolInfos(stringMethod.ShortName).SingleOrDefault()?.GetDeclaredElement() is IMethod result)
+            {
+                var parameters = result.Parameters;
+                var stringMethodParameters = stringMethod.Parameters;
+                for (int i = 0; i < parameters.Count; i++)
+                {
+                    if (parameters[i].Type.IsInt() && stringMethodParameters[i].Type.IsString())
+                    {
+                        index = i;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool MatchSignatureStringToIntMethod(IMethod stringMethod, IMethod intMethod)
+        {
+            if (!stringMethod.ReturnType.Equals(intMethod.ReturnType)) return false;
+
+            var stringMethodParameters = stringMethod.Parameters;
+            var intMethodParameters = intMethod.Parameters;
+
+            if (stringMethodParameters.Count != intMethodParameters.Count) return false;
+
+            bool isFound = false;
+            for (int i = 0; i < stringMethodParameters.Count; i++)
+            {
+                var intMethodParam = intMethodParameters[i];
+                var stringMethodParam = stringMethodParameters[i];
+
+                if (stringMethodParam.Type.IsString() && intMethodParam.Type.IsInt())
+                {
+                    if (!intMethodParam.ShortName.ToLower().Contains("id")||
+                        !stringMethodParam.ShortName.ToLower().Contains("name"))
+                    {
+                        return false;
+                    }
+                    isFound = true;
+                }
+                else if (!intMethodParam.Type.Equals(stringMethodParam.Type))
+                {
+                    return false;
+                }
+            }
+
+            return isFound;
+        }
+    }
+}

--- a/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
+++ b/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
@@ -1,0 +1,148 @@
+using System;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Naming.Extentions;
+using JetBrains.ReSharper.Psi.Naming.Impl;
+using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
+{
+    [QuickFix]
+    public class PreferAddressByIdToGraphicsParamsQuickFix : QuickFixBase
+    {
+        private IInvocationExpression myInvocationExpression;
+        private ICSharpArgument myArgument;
+        private string myLiteral;
+        private string myMapFuntion;
+        private string myTypeName; 
+        
+        public PreferAddressByIdToGraphicsParamsQuickFix(PreferAddressByIdToGraphicsParamsWarning warning)
+        {
+            myInvocationExpression = warning.InvocationMethod;
+            myArgument = warning.Argument;
+            myLiteral = warning.Literal;
+            myMapFuntion = warning.MapFunction;
+            myTypeName = warning.TypeName;
+        }
+        
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            var psiModule = myInvocationExpression.PsiModule;
+            var classDeclaration = GetTopLevelClass(myInvocationExpression);
+
+            var factory = CSharpElementFactory.GetInstance(myInvocationExpression);
+
+            var fieldInitializerValue = factory.CreateExpression("$0.$1($2)", 
+                TypeFactory.CreateTypeByCLRName(myTypeName, myInvocationExpression.PsiModule),
+                myMapFuntion,
+                $"\"{myLiteral}\"");
+
+
+            // generate field if we need it. If we have field which addresses to same property reuse it.
+            var name = TryFindField(myLiteral, classDeclaration, myTypeName, myMapFuntion);
+
+            if (name == null)
+            {
+                name = GetUniqueName(myInvocationExpression, myLiteral);
+                var newMemberDeclaration = factory.CreateFieldDeclaration(psiModule.GetPredefinedType().Int, name);
+
+                newMemberDeclaration.SetReadonly(true);
+                newMemberDeclaration.SetStatic(true);
+                newMemberDeclaration.SetAccessRights(AccessRights.PRIVATE);
+                newMemberDeclaration.SetInitial(factory.CreateExpressionInitializer(fieldInitializerValue));
+
+                classDeclaration.AddClassMemberDeclaration(newMemberDeclaration);
+            }
+
+            // replace argument
+            var argument = factory.CreateArgument(ParameterKind.VALUE, factory.CreateReferenceExpression(name));
+            myArgument.ReplaceBy(argument);
+            return null;
+        }
+
+        private static string TryFindField(string propertyName, IClassDeclaration declaration, string requiredTypeName, string requiredMethodName)
+        {
+            foreach (var field in declaration.FieldDeclarations)
+            {
+                var initializer = field.Initial;
+                if (initializer is IExpressionInitializer exprInit && exprInit.Value is IInvocationExpression invocation)
+                {
+                    var method = invocation.Reference?.Resolve()?.DeclaredElement as IMethod;
+                    
+                    if (method == null) continue;
+                    if (!method.ShortName.Equals(requiredMethodName)) continue;
+
+                    var containingType = method.GetContainingType();
+                    if (containingType == null) continue;
+
+                    if (!containingType.GetClrName().FullName.Equals(requiredTypeName)) continue;
+
+                    var arguments = invocation.Arguments;
+
+                    if (arguments.Count == 1 &&
+                        arguments[0].Expression is ILiteralExpression literal &&
+                        literal.ConstantValue.Value is string str &&
+                        str.Equals(propertyName))
+                    {
+                        return field.DeclaredName;
+                    }
+                }
+            }
+
+            return null;
+        }
+        
+        private static string GetUniqueName(IInvocationExpression invocationExpression, string baseName)
+        {
+            var namingManager = invocationExpression.GetPsiServices().Naming;
+            var policyProvider = namingManager.Policy.GetPolicyProvider(invocationExpression.Language, invocationExpression.GetSourceFile());
+            var namingRule = policyProvider.GetPolicy(NamedElementKinds.PrivateStaticReadonly).NamingRule;
+            var name = namingManager.Parsing.Parse(baseName, namingRule, policyProvider);
+            var nameRoot = name.GetRootOrDefault(baseName);
+            var namesCollection = namingManager.Suggestion.CreateEmptyCollection(PluralityKinds.Unknown, CSharpLanguage.Instance, true, policyProvider);
+            namesCollection.Add(nameRoot, new EntryOptions(PluralityKinds.Unknown, SubrootPolicy.Decompose, emphasis: Emphasis.Good));
+            var suggestionOptions = new SuggestionOptions
+            {
+                DefaultName = baseName,
+                UniqueNameContext = invocationExpression,
+            };
+            var namesSuggestion = namesCollection.Prepare(NamedElementKinds.PrivateStaticReadonly, ScopeKind.Common, suggestionOptions);
+            return namesSuggestion.FirstName();
+        }
+
+        private static IClassDeclaration GetTopLevelClass(IInvocationExpression expression)
+        {
+
+            var baseClass = expression.GetContainingNode<IClassDeclaration>();
+            if (baseClass == null)
+            {
+                return null;
+            }
+
+            var next = ClassDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            while (next!= null)
+            {
+                baseClass = next;
+                next = ClassDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            }
+
+            return baseClass;
+        }
+        
+        
+        public override string Text => "Use int overload";
+        
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            return myArgument.IsValid();
+        }
+    }
+}

--- a/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
+++ b/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
@@ -6,6 +6,7 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.CSharp.Util;
 using JetBrains.ReSharper.Psi.Naming.Extentions;
 using JetBrains.ReSharper.Psi.Naming.Impl;
 using JetBrains.ReSharper.Psi.Naming.Settings;
@@ -29,6 +30,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
             myInvocationExpression = warning.InvocationMethod;
             myArgument = warning.Argument;
             myLiteral = warning.Literal;
+            if (myLiteral != null && !ValidityChecker.IsValidIdentifier(myLiteral))
+            {
+                myLiteral = "Property";
+            }
+            
             myMapFuntion = warning.MapFunction;
             myTypeName = warning.TypeName;
         }
@@ -142,7 +148,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
         
         public override bool IsAvailable(IUserDataHolder cache)
         {
-            return myArgument.IsValid();
+            return myLiteral != null && myArgument.IsValid();
         }
     }
 }

--- a/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
+++ b/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
@@ -91,13 +92,21 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
             return null;
         } 
 
+        [CanBeNull]
         private static IDeclaredElement TryFindIdDeclarationInClassLikeDeclaration(IClassLikeDeclaration declaration, string propertyName,
             string requiredTypeName, string requiredMethodName, out string name)
         {
             name = null;
-            foreach (var member in declaration.ClassMemberDeclarations)
+            
+            var classDeclaredElement = declaration.DeclaredElement;
+            if (classDeclaredElement == null)
+                return null;
+            
+            var members = classDeclaredElement.GetMembers().Where(x => x is IField || x is IProperty)
+                .SelectNotNull(x => x.GetDeclarations().SingleOrDefault());
+            
+            foreach (var member in members)
             {
-
                 switch (member)
                 {
                     case IFieldDeclaration field:

--- a/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
+++ b/resharper/src/resharper-unity/CSharp/Feature/Services/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFix.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
@@ -7,9 +8,11 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.CSharp.Util;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve.Managed;
 using JetBrains.ReSharper.Psi.Naming.Extentions;
 using JetBrains.ReSharper.Psi.Naming.Impl;
 using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.ReSharper.Psi.Resolve.Managed;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl;
 using JetBrains.Util;
@@ -19,94 +22,215 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
     [QuickFix]
     public class PreferAddressByIdToGraphicsParamsQuickFix : QuickFixBase
     {
-        private IInvocationExpression myInvocationExpression;
-        private ICSharpArgument myArgument;
-        private string myLiteral;
-        private string myMapFuntion;
-        private string myTypeName; 
+        private readonly IInvocationExpression myInvocationExpression;
+        private readonly ICSharpArgument myArgument;
+        
+        // using for name of new generated field
+        private readonly string myFieldName;
+        
+        // using for find already declared field or property
+        private readonly string myGraphicsPropertyName;
+
+        // using to handle concatenation operations with const values and save possibility to correct refactoring
+        private readonly IExpression myArgumentExpression;
+        private readonly string myMapFunction;
+        private readonly string myTypeName; 
         
         public PreferAddressByIdToGraphicsParamsQuickFix(PreferAddressByIdToGraphicsParamsWarning warning)
         {
             myInvocationExpression = warning.InvocationMethod;
             myArgument = warning.Argument;
-            myLiteral = warning.Literal;
-            if (myLiteral != null && !ValidityChecker.IsValidIdentifier(myLiteral))
+            myFieldName = myGraphicsPropertyName = warning.Literal;
+            if (!ValidityChecker.IsValidIdentifier(myFieldName))
             {
-                myLiteral = "Property";
+                myFieldName = "Property";
             }
-            
-            myMapFuntion = warning.MapFunction;
+
+            myArgumentExpression = warning.ArgumentExpression;
+            myMapFunction = warning.MapFunction;
             myTypeName = warning.TypeName;
         }
         
         protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
         {
-            var psiModule = myInvocationExpression.PsiModule;
-            var classDeclaration = GetTopLevelClass(myInvocationExpression);
-
             var factory = CSharpElementFactory.GetInstance(myInvocationExpression);
 
-            var fieldInitializerValue = factory.CreateExpression("$0.$1($2)", 
-                TypeFactory.CreateTypeByCLRName(myTypeName, myInvocationExpression.PsiModule),
-                myMapFuntion,
-                $"\"{myLiteral}\"");
-
-
-            // generate field if we need it. If we have field which addresses to same property reuse it.
-            var name = TryFindField(myLiteral, classDeclaration, myTypeName, myMapFuntion);
-
-            if (name == null)
+            //  try find declaration where string to id conversation is done. If we don't find it, create in top-level class
+            var idDeclaration = TryFindDeclaration(myInvocationExpression, myGraphicsPropertyName, myTypeName, myMapFunction, out var name); 
+            if (idDeclaration == null)
             {
-                name = GetUniqueName(myInvocationExpression, myLiteral);
-                var newMemberDeclaration = factory.CreateFieldDeclaration(psiModule.GetPredefinedType().Int, name);
+                var psiModule = myInvocationExpression.PsiModule;
+                var fieldInitializerValue = factory.CreateExpression("$0.$1($2)", 
+                    TypeFactory.CreateTypeByCLRName(myTypeName, myInvocationExpression.PsiModule),
+                    myMapFunction,
+                    myArgumentExpression.Copy());
+                
+                name = GetUniqueName(myInvocationExpression, myFieldName).NotNull();
+                var newDeclaration = factory.CreateFieldDeclaration(psiModule.GetPredefinedType().Int, name);
+                idDeclaration = newDeclaration.DeclaredElement;
+                if (idDeclaration == null)
+                    return null;
+                
+                newDeclaration.SetReadonly(true);
+                newDeclaration.SetStatic(true);
+                newDeclaration.SetAccessRights(AccessRights.PRIVATE);
+                newDeclaration.SetInitial(factory.CreateExpressionInitializer(fieldInitializerValue));
 
-                newMemberDeclaration.SetReadonly(true);
-                newMemberDeclaration.SetStatic(true);
-                newMemberDeclaration.SetAccessRights(AccessRights.PRIVATE);
-                newMemberDeclaration.SetInitial(factory.CreateExpressionInitializer(fieldInitializerValue));
-
-                classDeclaration.AddClassMemberDeclaration(newMemberDeclaration);
+                // TODO: [C#8] default interface implementations
+                // interface is not good place to add field declaration
+                var classDeclaration = GetTopLevelClassLikeDeclaration(myInvocationExpression);
+                classDeclaration.AddClassMemberDeclaration(newDeclaration);
             }
 
             // replace argument
-            var argument = factory.CreateArgument(ParameterKind.VALUE, factory.CreateReferenceExpression(name));
+            var referenceExpression = factory.CreateReferenceExpression("$0", idDeclaration);
+            
+            
+            var argument = factory.CreateArgument(ParameterKind.VALUE, myArgument.NameIdentifier?.Name, referenceExpression);
             myArgument.ReplaceBy(argument);
             return null;
-        }
+        } 
 
-        private static string TryFindField(string propertyName, IClassDeclaration declaration, string requiredTypeName, string requiredMethodName)
+        private static IDeclaredElement TryFindIdDeclarationInClassLikeDeclaration(IClassLikeDeclaration declaration, string propertyName,
+            string requiredTypeName, string requiredMethodName, out string name)
         {
-            foreach (var field in declaration.FieldDeclarations)
+            name = null;
+            foreach (var member in declaration.ClassMemberDeclarations)
             {
-                var initializer = field.Initial;
-                if (initializer is IExpressionInitializer exprInit && exprInit.Value is IInvocationExpression invocation)
+
+                switch (member)
                 {
-                    var method = invocation.Reference?.Resolve()?.DeclaredElement as IMethod;
-                    
-                    if (method == null) continue;
-                    if (!method.ShortName.Equals(requiredMethodName)) continue;
-
-                    var containingType = method.GetContainingType();
-                    if (containingType == null) continue;
-
-                    if (!containingType.GetClrName().FullName.Equals(requiredTypeName)) continue;
-
-                    var arguments = invocation.Arguments;
-
-                    if (arguments.Count == 1 &&
-                        arguments[0].Expression is ILiteralExpression literal &&
-                        literal.ConstantValue.Value is string str &&
-                        str.Equals(propertyName))
-                    {
-                        return field.DeclaredName;
-                    }
-                }
+                    case IFieldDeclaration field:
+                        if (HandleField(field, propertyName, requiredTypeName, requiredMethodName, out name))
+                            return field.DeclaredElement;
+                        break;
+                    case IPropertyDeclaration property:
+                        if (HandleProperty(property, propertyName, requiredTypeName, requiredMethodName, out name))
+                        {
+                            return property.DeclaredElement;
+                        }
+                        break;
+                } 
             }
 
             return null;
         }
+
+        private static bool HandleProperty(IPropertyDeclaration property, string propertyName, string requiredTypeName, string requiredMethodName, out string name)
+        {
+            name = null;
+            if (!property.IsStatic)
+                return false;
+
+            var accessors = property.AccessorDeclarations;
+            if (accessors.Count != 1)
+                return false;
+
+            if (accessors[0].Kind != AccessorKind.GETTER)
+                return false;
+                
+            if (property.DeclaredElement == null) 
+                return false;
+                
+            var initializer = property.Initial;
+            if (initializer is IExpressionInitializer exprInit && exprInit.Value is IInvocationExpression invocation)
+            {
+                return HandleInvocation(invocation, propertyName, requiredTypeName, requiredMethodName, out name);
+            }
+
+            return false;
+        }
+
+        private static bool HandleField(IFieldDeclaration field, string propertyName, string requiredTypeName, string requiredMethodName, out string name)
+        {
+            name = null;
+            if (!field.IsStatic || !field.IsReadonly)
+                return false;
+                
+            if (field.DeclaredElement == null) 
+                return false;
+                
+            var initializer = field.Initial;
+            if (initializer is IExpressionInitializer exprInit && exprInit.Value is IInvocationExpression invocation)
+            {
+                return HandleInvocation(invocation, propertyName, requiredTypeName, requiredMethodName, out name);
+            }
+
+            return false;
+        }
+
+        private static bool HandleInvocation(IInvocationExpression invocation, string propertyName, string requiredTypeName,
+            string requiredMethodName, out string name)
+        {
+            name = null;
+            
+            var method = invocation.Reference?.Resolve().DeclaredElement as IMethod;
+                    
+            if (method == null) return false;
+            if (!method.ShortName.Equals(requiredMethodName)) return false;;
+
+            var containingType = method.GetContainingType();
+            if (containingType == null) return false;;
+
+            if (!containingType.GetClrName().FullName.Equals(requiredTypeName)) return false;;
+
+            var arguments = invocation.Arguments;
+
+            if (arguments.Count == 1)
+            {
+                var constantValue = arguments[0].Value.ConstantValue(new UniversalContext(invocation));
+                if (constantValue.Value?.Equals(propertyName) == true)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static IDeclaredElement TryFindDeclaration([NotNull]IInvocationExpression expression, [NotNull]string propertyName,
+            [NotNull]string requiredTypeName, [NotNull]string requiredMethodName, out string name)
+        {
+            name = null;
+            var baseClass = expression.GetContainingNode<IClassLikeDeclaration>();
+            if (baseClass == null)
+            {
+                return null;
+            }
+            var result = TryFindIdDeclarationInClassLikeDeclaration(baseClass, propertyName, requiredTypeName, requiredMethodName, out name);
+            if (result != null)
+                return result;
+            
+            var next = ClassLikeDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            while (next != null)
+            {
+                baseClass = next;
+                result = TryFindIdDeclarationInClassLikeDeclaration(baseClass, propertyName, requiredTypeName, requiredMethodName, out name);
+                if (result != null)
+                    return result;
+                
+                next = ClassLikeDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            }
+
+            return null;
+        } 
         
-        private static string GetUniqueName(IInvocationExpression invocationExpression, string baseName)
+        private static IClassLikeDeclaration GetTopLevelClassLikeDeclaration([NotNull]IInvocationExpression expression)
+        {
+            var baseClass = expression.GetContainingNode<IClassLikeDeclaration>();
+            if (baseClass == null)
+                return null;
+            
+            var next = ClassLikeDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            while (next != null)
+            {
+                baseClass = next;
+                next = ClassLikeDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
+            }
+
+            return baseClass;
+        }
+        
+        [NotNull]
+        private static string GetUniqueName( [NotNull]IInvocationExpression invocationExpression,  [NotNull]string baseName)
         {
             var namingManager = invocationExpression.GetPsiServices().Naming;
             var policyProvider = namingManager.Policy.GetPolicyProvider(invocationExpression.Language, invocationExpression.GetSourceFile());
@@ -123,32 +247,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
             var namesSuggestion = namesCollection.Prepare(NamedElementKinds.PrivateStaticReadonly, ScopeKind.Common, suggestionOptions);
             return namesSuggestion.FirstName();
         }
-
-        private static IClassDeclaration GetTopLevelClass(IInvocationExpression expression)
-        {
-
-            var baseClass = expression.GetContainingNode<IClassDeclaration>();
-            if (baseClass == null)
-            {
-                return null;
-            }
-
-            var next = ClassDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
-            while (next!= null)
-            {
-                baseClass = next;
-                next = ClassDeclarationNavigator.GetByNestedTypeDeclaration(baseClass);
-            }
-
-            return baseClass;
-        }
-        
-        
-        public override string Text => "Use int overload";
+ 
+        public override string Text => "Use 'int' overload";
         
         public override bool IsAvailable(IUserDataHolder cache)
         {
-            return myLiteral != null && myArgument.IsValid();
+            return myInvocationExpression.IsValid() && myArgument.IsValid();
         }
     }
 }

--- a/resharper/src/resharper-unity/KnownTypes.cs
+++ b/resharper/src/resharper-unity/KnownTypes.cs
@@ -24,6 +24,11 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName Physics = new ClrTypeName("UnityEngine.Physics");
         public static readonly IClrTypeName Physics2D = new ClrTypeName("UnityEngine.Physics2D");
         
+        public static readonly IClrTypeName Animator = new ClrTypeName("UnityEngine.Animator");
+        public static readonly IClrTypeName Shader = new ClrTypeName("UnityEngine.Shader");
+        public static readonly IClrTypeName Material = new ClrTypeName("UnityEngine.Material");
+
+
         // UnityEngine.Networking
         public static readonly IClrTypeName NetworkBehaviour = new ClrTypeName("UnityEngine.Networking.NetworkBehaviour");
         public static readonly IClrTypeName SyncVarAttribute =

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/AnimatorPropertyTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/AnimatorPropertyTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class AnimatorPropertyTest
+    {
+        public void Method(Animator animator)
+        {
+            animator.SetFloat("te{caret}st", 10f, 10f, 10f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/AnimatorPropertyTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/AnimatorPropertyTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class AnimatorPropertyTest
+    {
+      private static readonly int Test = Animator.StringToHash("test");
+
+      public void Method(Animator animator)
+        {
+            animator.SetFloat(Te{caret}st, 10f, 10f, 10f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstConcatCreateFieldTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstConcatCreateFieldTest.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstConcatCreateFieldTest
+    {
+        public const string test = "test";
+            
+        public void Method(Material material)
+        {
+            material.SetFloat(test + "Foo" + {caret} test, 10.0f)};
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstConcatCreateFieldTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstConcatCreateFieldTest.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstConcatCreateFieldTest
+    {
+      private static readonly int TestFootest = Shader.PropertyToID(test + "Foo" +  test);
+      public const string test = "test";
+            
+        public void Method(Material material)
+        {
+            material.SetFloat(TestFoo{caret}test, 10.0f)};
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueConcatReuseTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueConcatReuseTest.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstantValueTest
+    {
+        public const string test = "test";
+        private static readonly int Property = Shader.PropertyToID(test + "Foo")
+            
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}stFoo", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueConcatReuseTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueConcatReuseTest.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstantValueTest
+    {
+        public const string test = "test";
+        private static readonly int Property = Shader.PropertyToID(test + "Foo")
+            
+        public void Method(Material material)
+        {
+            material.SetFloat(Prope{caret}rty, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueReuseTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueReuseTest.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstantValueTest
+    {
+        public const string test = "test";
+        private static readonly int Property = Shader.PropertyToID(test)
+            
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueReuseTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ConstantValueReuseTest.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ConstantValueTest
+    {
+        public const string test = "test";
+        private static readonly int Property = Shader.PropertyToID(test)
+            
+        public void Method(Material material)
+        {
+            material.SetFloat(Prope{caret}rty, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class InvalidLiteralForProperyNameTest
+    {
+        public void Test(Material material)
+        {
+            material.SetFloat("f{caret}loat", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs.gold
@@ -4,7 +4,7 @@ namespace DefaultNamespace
 {
     public class InvalidLiteralForProperyNameTest
     {
-      private static readonly int Property = Shader.PropertyToID("Property");
+      private static readonly int Property = Shader.PropertyToID("float");
 
       public void Test(Material material)
         {

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/InvalidLiteralForPropertyNameTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class InvalidLiteralForProperyNameTest
+    {
+      private static readonly int Property = Shader.PropertyToID("Property");
+
+      public void Test(Material material)
+        {
+            material.SetFloat({caret}Property, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedClassTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedClassTest.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class NestedClassTest
+    {
+        public class Nested
+        {
+            private string Test = null;  // for  unique name testing.
+            
+            public void Method(Material material)
+            {
+                material.SetFloat("te{caret}st", 10.0f);
+            }
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedClassTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedClassTest.cs.gold
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class NestedClassTest
+    {
+      private static readonly int Test1 = Shader.PropertyToID("test");
+
+      public class Nested
+        {
+            private string Test = null;  // for  unique name testing.
+            
+            public void Method(Material material)
+            {
+                material.SetFloat(Te{caret}st1, 10.0f);
+            }
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedReuseTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedReuseTest.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class NestedReuseTest
+    {
+        public class Nested
+        {
+            private static int Property { get; } = Shader.PropertyToID("test")
+            
+            public void Method(Material material)
+            {
+                material.SetFloat("te{caret}st", 10.0f);
+            }
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedReuseTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NestedReuseTest.cs.gold
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class NestedReuseTest
+    {
+        public class Nested
+        {
+            private static int Property { get; } = Shader.PropertyToID("test")
+            
+            public void Method(Material material)
+            {
+                material.SetFloat(Prope{caret}rty, 10.0f);
+            }
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NewNameTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NewNameTest.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class NewNameTest
+    {
+        private static int Test = 0;
+        
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NewNameTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/NewNameTest.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class NewNameTest
+    {
+        private static int Test = 0;
+      private static readonly int Test1 = Shader.PropertyToID("test");
+
+      public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st1, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PartialClassTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PartialClassTest.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public partial class TestClass
+    {
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+
+    public partial class TestClass
+    {
+        private static readonly int Test = Shader.PropertyToID("test");
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PartialClassTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PartialClassTest.cs.gold
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public partial class TestClass
+    {
+        public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st, 10.0f);
+        }
+    }
+
+    public partial class TestClass
+    {
+        private static readonly int Test = Shader.PropertyToID("test");
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PropertyReuseTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PropertyReuseTest.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class PropertyReuseTest
+    {
+        private static readonly int Property { get; } = Shader.PropertyToID("test")
+            
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PropertyReuseTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/PropertyReuseTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class PropertyReuseTest
+    {
+        private static readonly int Property { get; } = Shader.PropertyToID("test")
+            
+        public void Method(Material material)
+        {
+            material.SetFloat(Prope{caret}rty, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseConflictNameTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseConflictNameTest.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class TopLevelClass
+{
+    private static readonly int Test = Shader.PropertyToID("test");
+
+    public class NestedClass
+    {
+        private static string Test = "notTest";
+
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseConflictNameTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseConflictNameTest.cs.gold
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public class TopLevelClass
+{
+    private static readonly int Test = Shader.PropertyToID("test");
+
+    public class NestedClass
+    {
+        private static string Test = "notTest";
+
+        public void Method(Material material)
+        {
+            material.SetFloat(TopLe{caret}velClass.Test, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseFailedCreateNewTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseFailedCreateNewTest.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class ReuseFailedCreateNewTest
+    {
+        private static readonly int Test = Shader.PropertyToID("test0");
+
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseFailedCreateNewTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseFailedCreateNewTest.cs.gold
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class ReuseFailedCreateNewTest
+    {
+        private static readonly int Test = Shader.PropertyToID("test0");
+      private static readonly int Test1 = Shader.PropertyToID("test");
+
+      public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st1, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseTest.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class ReuseTest
+    {
+        private static readonly int Test2 = Shader.PropertyToID("test");
+
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ReuseTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class ReuseTest
+    {
+        private static readonly int Test2 = Shader.PropertyToID("test");
+
+        public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st2, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ShaderPropertyTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ShaderPropertyTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ShaderPropertyTest
+    {
+        public void Test()
+        {
+            Shader.SetGlobalColor("Main{caret}Color", Color.black);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ShaderPropertyTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/ShaderPropertyTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class ShaderPropertyTest
+    {
+      private static readonly int MainColor = Shader.PropertyToID("MainColor");
+
+      public void Test()
+        {
+            Shader.SetGlobalColor(Main{caret}Color, Color.black);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/SimpleTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/SimpleTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class SimpleTest
+    {
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/SimpleTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/SimpleTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class SimpleTest
+    {
+      private static readonly int Test = Shader.PropertyToID("test");
+
+      public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/StructTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/StructTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public struct StructTest
+    {
+        public void Method(Material material)
+        {
+            material.SetFloat("te{caret}s", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/StructTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/StructTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public struct StructTest
+    {
+      private static readonly int Tes = Shader.PropertyToID("tes");
+
+      public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}s, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/UnderscoreNameTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/UnderscoreNameTest.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class UnderscoreNameTest
+    {
+        public void Method(Material material)
+        {
+            material.SetFloat("_te{caret}st", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/UnderscoreNameTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/UnderscoreNameTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace JetBrains.ReSharper.Psi.CSharp.Tree
+{
+    public class UnderscoreNameTest
+    {
+      private static readonly int Test = Shader.PropertyToID("_test");
+
+      public void Method(Material material)
+        {
+            material.SetFloat(Te{caret}st, 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/WithoutUnityNamespaceTest.cs
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/WithoutUnityNamespaceTest.cs
@@ -1,0 +1,10 @@
+namespace DefaultNamespace
+{
+    public class WithoutUnityNamespaceTest
+    {
+        public void Test(UnityEngine.Material material)
+        {
+            material.SetFloat("t{caret}est", 10.0f);
+        }
+    }
+}

--- a/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/WithoutUnityNamespaceTest.cs.gold
+++ b/resharper/test/data/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParams/WithoutUnityNamespaceTest.cs.gold
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class WithoutUnityNamespaceTest
+    {
+      private static readonly int Test1 = Shader.PropertyToID("test");
+
+      public void Test(UnityEngine.Material material)
+        {
+            material.SetFloat(T{caret}est1, 10.0f);
+        }
+    }
+}

--- a/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
+++ b/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
@@ -14,5 +14,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
         [Test] public void NewNameTest() { DoNamedTest(); }
         [Test] public void ReuseTest() { DoNamedTest(); }
         [Test] public void ReuseFailedCreateNewTest() { DoNamedTest(); }
+        [Test] public void NestedClassTest() { DoNamedTest(); }
+        [Test] public void WithoutUnityNamespaceTest() { DoNamedTest(); }
+        [Test] public void InvalidLiteralForPropertyNameTest() { DoNamedTest(); }
+        [Test] public void ShaderPropertyTest() { DoNamedTest(); }
+        [Test] public void AnimatorPropertyTest() { DoNamedTest(); }
     }
 }

--- a/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
+++ b/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
@@ -27,5 +27,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
         [Test] public void StructTest() { DoNamedTest(); }
         [Test] public void NestedReuseTest() { DoNamedTest(); }
         [Test] public void ConstConcatCreateFieldTest() { DoNamedTest(); }
+        [Test] public void PartialClassTest() { DoNamedTest(); }
     }
 }

--- a/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
+++ b/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
@@ -1,0 +1,18 @@
+using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
+{
+    [TestUnity]
+    public class PreferAddressByIdToGraphicsParamsQuickFixTests : QuickFixTestBase<PreferAddressByIdToGraphicsParamsQuickFix>
+    {
+        protected override string RelativeTestDataPath => @"CSharp\Intentions\QuickFixes\PreferAddressByIdToGraphicsParams";
+        protected override bool AllowHighlightingOverlap => true;
+
+        [Test] public void SimpleTest() { DoNamedTest(); }
+        [Test] public void NewNameTest() { DoNamedTest(); }
+        [Test] public void ReuseTest() { DoNamedTest(); }
+        [Test] public void ReuseFailedCreateNewTest() { DoNamedTest(); }
+    }
+}

--- a/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
+++ b/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
@@ -15,10 +15,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
         [Test] public void NewNameTest() { DoNamedTest(); }
         [Test] public void ReuseTest() { DoNamedTest(); }
         [Test] public void ReuseFailedCreateNewTest() { DoNamedTest(); }
+        [Test] public void ReuseConflictNameTest() { DoNamedTest(); }
         [Test] public void NestedClassTest() { DoNamedTest(); }
         [Test] public void WithoutUnityNamespaceTest() { DoNamedTest(); }
         [Test] public void InvalidLiteralForPropertyNameTest() { DoNamedTest(); }
         [Test] public void ShaderPropertyTest() { DoNamedTest(); }
         [Test] public void AnimatorPropertyTest() { DoNamedTest(); }
+        [Test] public void ConstantValueReuseTest() { DoNamedTest(); }
+        [Test] public void ConstantValueConcatReuseTest() { DoNamedTest(); }
+        [Test] public void PropertyReuseTest() { DoNamedTest(); }
+        [Test] public void StructTest() { DoNamedTest(); }
+        [Test] public void NestedReuseTest() { DoNamedTest(); }
+        [Test] public void ConstConcatCreateFieldTest() { DoNamedTest(); }
     }
 }

--- a/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
+++ b/resharper/test/src/CSharp/Intentions/QuickFixes/PreferAddressByIdToGraphicsParamsQuickFixTests.cs
@@ -11,6 +11,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
         protected override bool AllowHighlightingOverlap => true;
 
         [Test] public void SimpleTest() { DoNamedTest(); }
+        [Test] public void UnderscoreNameTest() { DoNamedTest(); }
         [Test] public void NewNameTest() { DoNamedTest(); }
         [Test] public void ReuseTest() { DoNamedTest(); }
         [Test] public void ReuseFailedCreateNewTest() { DoNamedTest(); }


### PR DESCRIPTION
Access properties in `Shader`, `Material`, `Animator` by `int` is faster than using `string` overload.

 The property IDs created from string hashes are deterministic over the course of a single run, so this quick fix creates a private static readonly field in class and reuse this field for overload.
Example:
```
public class SimpleTest
{
    public void Method(Material material)
    {
        material.SetFloat("test", 10.0f);
    }
}
```

is transformed to:

```
public class SimpleTest
{
    private static readonly int Test = Shader.PropertyToID("test");
    public void Method(Material material)
    {
        material.SetFloat(Test, 10.0f);
    }
}
```