### PR TITLE
Improve redundant event function warnings

### DIFF
--- a/resharper/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs
+++ b/resharper/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class Test : MonoBehaviour
@@ -20,5 +21,69 @@ public class Test : MonoBehaviour
     public void LateUpdate()
     {
         int i;
+    }
+}
+
+public class Base : MonoBehaviour
+{
+    public virtual void Update()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    public virtual void FixedUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - has derived symbol and removing this will break code
+    public virtual void LateUpdate()
+    {
+    }
+
+    public void Start()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    public virtual void Reset()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Redundant - empty method, not inherited
+    public virtual void OnValidate()
+    {
+    }
+}
+
+public class Derived : Base
+{
+    // Not redundant - hides base implementation
+    public override void Update()
+    {
+    }
+
+    // Not redundant - doing something
+    public override void FixedUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - doing something. Also overrides empty virtual method in Base
+    public override void LateUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - shadows base implementation
+    public new void Start()
+    {
+    }
+
+    // Normal redundant override warning
+    public override void Reset()
+    {
+        base.Reset();
     }
 }

--- a/resharper/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs.gold
+++ b/resharper/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs.gold
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class Test : MonoBehaviour
 {
@@ -23,6 +24,71 @@ public class Test : MonoBehaviour
     }
 }
 
+public class Base : MonoBehaviour
+{
+    public virtual void Update()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    public virtual void FixedUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - has derived symbol and removing this will break code
+    public virtual void LateUpdate()
+    {
+    }
+
+    public void Start()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    public virtual void Reset()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Redundant - empty method, not inherited
+    |public virtual void OnValidate()
+    {
+    }|(2)
+}
+
+public class Derived : Base
+{
+    // Not redundant - hides base implementation
+    public override void Update()
+    {
+    }
+
+    // Not redundant - doing something
+    public override void FixedUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - doing something. Also overrides empty virtual method in Base
+    public override void LateUpdate()
+    {
+        Console.WriteLine("Doing something");
+    }
+
+    // Not redundant - shadows base implementation
+    public new void Start()
+    {
+    }
+
+    // Normal redundant override warning
+    |public override void Reset()
+    {
+        base.Reset();
+    }|(3)
+}
 ---------------------------------------------------------
 (0): ReSharper Dead Code: Redundant Unity event function
 (1): ReSharper Dead Code: Redundant Unity event function
+(2): ReSharper Dead Code: Redundant Unity event function
+(3): ReSharper Dead Code: Redundant method override

--- a/resharper/test/src/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarningTests.cs
+++ b/resharper/test/src/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarningTests.cs
@@ -1,11 +1,22 @@
-﻿using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
+﻿using JetBrains.Application.Settings;
+using JetBrains.ReSharper.Daemon.CSharp.Errors;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.FeaturesTestFramework.Daemon;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
+using JetBrains.ReSharper.Psi;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.Stages.Analysis
 {
     [TestUnity]
-    public class RedundantEventFunctionWarningTests : CSharpHighlightingTestBase<RedundantEventFunctionWarning>
+    public class RedundantEventFunctionWarningTests : CSharpHighlightingTestBase
     {
+        protected override bool HighlightingPredicate(IHighlighting highlighting, IPsiSourceFile sourceFile,
+            IContextBoundSettingsStore settingsStore)
+        {
+            return highlighting is RedundantEventFunctionWarning || highlighting is RedundantOverriddenMemberWarning;
+        }
+
         protected override string RelativeTestDataPath => @"CSharp\Daemon\Stages\Analysis";
 
         [Test] public void TestRedundantEventFunctionWarning() { DoNamedTest2(); }


### PR DESCRIPTION
Don't highlight if it's hiding a base implementation, or it's overriding a virtual method

Fixes [RIDER-19894](https://youtrack.jetbrains.com/issue/RIDER-19894)