### PR TITLE
Refresh VFS before handling external files

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesManager.kt
@@ -11,6 +11,7 @@ import com.jetbrains.rdclient.util.idea.getOrCreateUserData
 import com.jetbrains.rider.plugins.unity.util.SemVer
 import com.jetbrains.rider.plugins.unity.util.UnityCachesFinder
 import com.jetbrains.rider.plugins.unity.util.UnityInstallationFinder
+import com.jetbrains.rider.plugins.unity.util.refreshAndFindFile
 import com.jetbrains.rider.projectDir
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -143,7 +144,7 @@ class PackagesManager(private val project: Project) {
     }
 
     private fun getManifestJsonFile(): VirtualFile? {
-        return project.projectDir.findFileByRelativePath("Packages/manifest.json")
+        return project.refreshAndFindFile("Packages/manifest.json")
     }
 
     private fun getPackagesFromDependencies(packagesFolder: VirtualFile, registry: String, builtInPackagesFolder: Path?,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileUtils.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileUtils.kt
@@ -1,0 +1,13 @@
+package com.jetbrains.rider.plugins.unity.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.rider.projectDir
+import java.nio.file.Paths
+
+fun Project.refreshAndFindFile(relativeFile: String): VirtualFile?
+{
+    val path = Paths.get(this.projectDir.path, relativeFile)
+    return VfsUtil.findFile(path, true)
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityInstallationFinder.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityInstallationFinder.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.util.SystemProperties
 import com.intellij.util.io.exists
 import com.jetbrains.rider.model.rdUnityModel
-import com.jetbrains.rider.projectDir
 import com.jetbrains.rider.projectView.solution
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -64,9 +63,9 @@ class UnityInstallationFinder(private val project: Project) {
     }
 
     private fun tryGetApplicationPathFromEditorInstanceJson(): Path? {
-        // Get the version from Library/EditorInstance.json and try and heuristically try to find the application.
-        // Later versions of Unity will write this file, and it will only exist while the project is open. The protocol
-        // is more accurate, as it will give us the actual application path
+        // Get the version from Library/EditorInstance.json and try to heuristically find the application. The plugin
+        // and later  versions of Unity will write this file, and it will only exist while the project is open. The
+        // protocol is more accurate, as it will give us the actual application path
         val (status, editorInstanceJson) = EditorInstanceJson.load(project)
         if (status == EditorInstanceJsonStatus.Valid) {
             return tryGetApplicationPathFromVersion(editorInstanceJson!!.version)
@@ -78,7 +77,7 @@ class UnityInstallationFinder(private val project: Project) {
         // Get the version from ProjectSettings/ProjectVersion.txt, and heuristically try to find the application.
         // This is a best effort attempt to find the application, as the version is the version of Unity that last saved
         // the project, rather than last opened it, and we're guessing where the application folder is
-        val projectVersionTxt = project.projectDir.findFileByRelativePath("ProjectSettings/ProjectVersion.txt") ?: return null
+        val projectVersionTxt = project.refreshAndFindFile("ProjectSettings/ProjectVersion.txt") ?: return null
         val text = VfsUtil.loadText(projectVersionTxt)
         val result = Regex("""m_EditorVersion: (?<version>.*$)""").find(text)
         return result?.let { it.groups["version"]?.value }?.let { tryGetApplicationPathFromVersion(it) }


### PR DESCRIPTION
Should hopefully stop the VFS from working with stale files and thinking files are still valid when they've been deleted.