### PR TITLE
backport fix to keep PlayModeSavedState

### DIFF
--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -156,7 +156,7 @@ namespace JetBrains.Rider.Unity.Editor
         File.Delete(protocolInstanceJsonPath);
       };
 
-      ourSavedState = GetEditorState();
+      PlayModeSavedState = GetEditorState();
       SetupAssemblyReloadEvents();
 
       ourInitialized = true;
@@ -201,7 +201,7 @@ namespace JetBrains.Rider.Unity.Editor
 #pragma warning restore 618
       {
         var newState = GetEditorState();
-        if (ourSavedState != newState)
+        if (PlayModeSavedState != newState)
         {
           if (PluginSettings.AssemblyReloadSettings == AssemblyReloadSettings.RecompileAfterFinishedPlaying)
           {
@@ -214,7 +214,7 @@ namespace JetBrains.Rider.Unity.Editor
               EditorApplication.UnlockReloadAssemblies();
             }
           }
-          ourSavedState = newState;
+          PlayModeSavedState = newState;
         }
       };
 
@@ -314,7 +314,7 @@ namespace JetBrains.Rider.Unity.Editor
       Paused
     }
 
-    private static PlayModeState ourSavedState = PlayModeState.Stopped;
+    internal static PlayModeState PlayModeSavedState = PlayModeState.Stopped;
 
     private static void AdviseUnityActions(EditorPluginModel model, Lifetime connectionLifetime)
     {


### PR DESCRIPTION
UnityException: get_isPlaying is not allowed to be called during serialization, call it from OnEnable instead. Called from ScriptableObject 'FunctionalityIsland'.
See "Script Serialization" page in the Unity Manual for further details.
JetBrains.Rider.Unity.Editor.UnityEventCollector+<>c__DisplayClass3_0.<ApplicationOnLogMessageReceived>b__0 ()
JetBrains.Rider.Unity.Editor.MainThreadDispatcher.Queue (System.Action action)