### PR TITLE
[WIP] Various build updates

### DIFF
--- a/resharper/Directory.Build.targets
+++ b/resharper/Directory.Build.targets
@@ -9,4 +9,13 @@
     <GenerateErrorsGenInputs Remove="$(PsiGenToolsDir)/ErrorsGen.exe" />
     <GenerateErrorsGenInputs Include="$(PsiGenToolsDir)/../ErrorsGen.exe" />
   </ItemGroup>
+
+  <!-- The VSSDK packages used by the ReSharper projects add references to PresentationCore and PresentationFramework
+       which cause harmless compile time warnings when compiled on Windows -->
+  <Target Name="FixWpfReferencesForUnix" BeforeTargets="ResolveAssemblyReferences" Condition=" '$(OS)' == 'Unix' ">
+    <ItemGroup>
+      <Reference Remove="PresentationCore" />
+      <Reference Remove="PresentationFramework" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/resharper/src/GradleLauncher/GradleLauncher.csproj
+++ b/resharper/src/GradleLauncher/GradleLauncher.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -45,14 +44,17 @@
     <ProjectReference Include="..\..\..\unity\EditorPlugin\EditorPlugin.csproj">
       <Project>{67cfb019-ce94-4251-8c3a-4dc70e4e4a52}</Project>
       <Name>EditorPlugin</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\..\..\unity\EditorPlugin\EditorPluginFull.csproj">
       <Project>{51b82b3c-294f-4751-8754-223c660172e4}</Project>
       <Name>EditorPluginFull</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\resharper-unity\resharper-unity.rider.csproj">
       <Project>{d8a177c3-8adf-4b53-aa48-bb5dc1150869}</Project>
       <Name>resharper-unity.rider</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/resharper/src/resharper-unity/Rider/Debugger/UnityComponentData/UnityComponentDataSource.cs
+++ b/resharper/src/resharper-unity/Rider/Debugger/UnityComponentData/UnityComponentDataSource.cs
@@ -106,7 +106,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.UnityComponentData
                     }
                     catch (Exception e)
                     {
-                        myLogger.Error("Failed to fetch parameter {0} of entity {1}", currentIndex, myEntityObject);
+                        myLogger.Error(e, "Failed to fetch parameter {0} of entity {1}", currentIndex, myEntityObject);
                     }
                 }
 

--- a/resharper/src/resharper-unity/Rider/UnitTesting/UnityNUnitServiceProvider.cs
+++ b/resharper/src/resharper-unity/Rider/UnitTesting/UnityNUnitServiceProvider.cs
@@ -20,7 +20,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
     [SolutionComponent]
     public class UnityNUnitServiceProvider : NUnitServiceProvider
     {
-        private readonly UnityEditorProtocol myUnityEditorProtocol;
         private readonly RunViaUnityEditorStrategy myUnityEditorStrategy;
         private readonly RdUnityModel myRdUnityModel;
         private readonly IProperty<EditorPluginModel> myUnityEditorModel;

--- a/resharper/src/resharper-unity/app.config
+++ b/resharper/src/resharper-unity/app.config
@@ -1,0 +1,42 @@
+<configuration>
+  <runtime>
+    <!-- Unify ReSharper's references to multiple Visual Studio dlls to the lowest supported version -->
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Logic" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI.Wpf" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <!-- Rider's RolsynHost pulls in a newer version of System.IO.Compression -->
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="4.0.0.0-4.1.1.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/resharper/src/resharper-unity/resharper-unity.resharper.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.resharper.csproj
@@ -95,10 +95,6 @@
       <LogicalName>JetBrains.ReSharper.Plugins.Unity.Templates.templates.dotSettings</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  <!-- TODO: remove after ClrChangeSignatureParameters stops using ListEvents -->
-  <ItemGroup Condition=" '$(OS)' == 'Unix' ">
-    <Compile Remove="CSharp\Feature\Services\QuickFixes\IncorrectMethodSignatureQuickFix.cs" />
-  </ItemGroup>
   <ItemGroup>
     <!-- This requires WPF and PresentationFramework to build -->
     <ThemedIconsXamlV3 Include="Resources\Logo\unity-logo.xaml" Condition=" '$(OS)' != 'Unix' ">

--- a/resharper/src/resharper-unity/resharper-unity.resharper.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.resharper.csproj
@@ -6,6 +6,8 @@
     <!-- TODO: Fix up the .psi files so we don't get the obsolete warnings -->
     <NoWarn>0618</NoWarn>
     <LangVersion>7.2</LangVersion>
+    <!-- This is needed for ReferenceAssemblyRedirects to pick up app.config -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RESHARPER;$(CommandLineConstants)</DefineConstants>

--- a/resharper/src/resharper-unity/resharper-unity.rider.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.rider.csproj
@@ -1,5 +1,4 @@
-﻿<Project>
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity</AssemblyName>
@@ -117,5 +116,4 @@
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/resharper/src/resharper-unity/resharper-unity.rider.debugger.csproj
+++ b/resharper/src/resharper-unity/resharper-unity.rider.debugger.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <TargetFramework>net461</TargetFramework>
         <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Rider.Debugger</AssemblyName>
@@ -17,5 +16,4 @@
     <ItemGroup>
         <Compile Include="**/Rider/Debugger/**" />
     </ItemGroup>
-    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/resharper/test/src/app.config
+++ b/resharper/test/src/app.config
@@ -1,0 +1,42 @@
+<configuration>
+  <runtime>
+    <!-- Unify ReSharper's references to multiple Visual Studio dlls to the lowest supported version -->
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.Logic" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI.Wpf" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <!-- Rider's RolsynHost pulls in a newer version of System.IO.Compression -->
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="4.0.0.0-4.1.1.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/resharper/test/src/tests.resharper.csproj
+++ b/resharper/test/src/tests.resharper.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Tests.ReSharper</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Tests</RootNamespace>
     <LangVersion>7.2</LangVersion>
+    <!-- This is needed for ReferenceAssemblyRedirects to pick up app.config -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RESHARPER;$(CommandLineConstants)</DefineConstants>

--- a/resharper/test/src/tests.resharper.csproj
+++ b/resharper/test/src/tests.resharper.csproj
@@ -22,12 +22,4 @@
     <EmbeddedResource Remove="ShaderLab\Host\**" />
     <None Remove="ShaderLab\Host\**" />
   </ItemGroup>
-  <!-- TODO: remove after ClrChangeSignatureParameters stops using ListEvents -->
-  <ItemGroup Condition=" '$(OS)' == 'Unix' ">
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidSignatureFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidTypeParametersFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidReturnTypeFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/IncorrectMethodSignatureFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidStaticModifierQuickFixTests.cs" />
-  </ItemGroup>
 </Project>

--- a/resharper/test/src/tests.rider.csproj
+++ b/resharper/test/src/tests.rider.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Tests.Rider</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Tests</RootNamespace>
     <LangVersion>7.2</LangVersion>
+    <!-- This is needed for ReferenceAssemblyRedirects to pick up app.config -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RIDER;$(CommandLineConstants)</DefineConstants>

--- a/resharper/test/src/tests.rider.csproj
+++ b/resharper/test/src/tests.rider.csproj
@@ -17,12 +17,4 @@
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\resharper-unity\resharper-unity.rider.csproj" />
   </ItemGroup>
-  <!-- TODO: remove after ClrChangeSignatureParameters stops using ListEvents -->
-  <ItemGroup Condition=" '$(OS)' == 'Unix' ">
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidSignatureFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidTypeParametersFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidReturnTypeFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/IncorrectMethodSignatureFixTests.cs" />
-    <Compile Remove="CSharp/Intentions/QuickFixes/InvalidStaticModifierQuickFixTests.cs" />
-  </ItemGroup>
 </Project>

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -7,10 +7,6 @@ import java.util.regex.Pattern
 
 ext.backend = new BackendHelper(ext.repoRoot, buildDir, ext.localRiderSdkRoot, logger, ext.productVersion)
 
-def teamcityVersion = System.env['TEAMCITY_VERSION']
-project.ci.Progress("teamcityVersion = $teamcityVersion")
-ext.isTeamcity = teamcityVersion != null
-
 // Used to provide a package version to both msbuild and dotnet restore
 ext.extraMSBuildArgs = []
 
@@ -385,3 +381,4 @@ task publishCiBackendArtifacts {
         ci.PublishArtifact(packReSharperPlugin.outputs.files.singleFile)
     }
 }
+publishCiBuildData.dependsOn publishCiBackendArtifacts

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -220,7 +220,6 @@ task unzipReSharperSdk(type: Sync){
     group backendGroup
     onlyIf { !project.shouldBuildRiderOnly }    
     dependsOn configurations.reSharper
-
     
     if (backend.reSharperSdkPath.isDirectory()) {
         logger.lifecycle("R# SDK bundle found: $backend.reSharperSdkPath.canonicalPath")
@@ -230,10 +229,13 @@ task unzipReSharperSdk(type: Sync){
         logger.lifecycle("R# SDK is not bundled")
         backend.reSharperSdkPath = new File(repoRoot, "rider/build/DownloadedReSharperSDK")
     }
-    
-    ci.Progress("Downloading/unzipping ReSharper SDK to $backend.reSharperSdkPath")
+
     from { configurations.reSharper.collect { zipTree(it) } }
     into backend.reSharperSdkPath
+
+    doFirst {
+      ci.Progress("Unzipping ReSharper SDK to $backend.reSharperSdkPath")
+    }
 }
 
 task prepareRiderBuildProps(type: GenerateBuildPropsTask) {

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -62,10 +62,6 @@ class MSBuildTask extends DefaultTask {
     @InputFile
     File buildFile
 
-    MSBuildTask() {
-        onlyIf { !project.dotNetUpToDate }
-    }
-
     // TODO: Set msbuild verbosity based on gradle log level
 
     @TaskAction
@@ -142,10 +138,6 @@ class MonoExecTask extends AbstractExecTask {
 class RestorePackagesTask extends DefaultTask {
     @InputFile
     File packagesFile
-
-    RestorePackagesTask() {
-        onlyIf { !project.dotNetUpToDate }
-    }
 
     @TaskAction
     def restore() {

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -58,17 +58,15 @@ class MSBuildTask extends DefaultTask {
     @InputFile
     File buildFile
 
-    // TODO: Set msbuild verbosity based on gradle log level
-
     @TaskAction
     def build() {
         project.ci.Progress("Building $buildFile ($project.BuildConfiguration)")
 
-        def arguments = [ buildFile, "/p:Configuration=$project.BuildConfiguration", "/p:Version=$project.version", '/v:normal', '/nologo'] //, "/bl:${buildFile.name}.binlog" ]
+        def arguments = [ buildFile, "/p:Configuration=$project.BuildConfiguration", "/p:Version=$project.version", "/v:${getVerbosity()}", '/nologo'] //, "/bl:${buildFile.name}.binlog" ]
         arguments.addAll(project.extraMSBuildArgs)
 
         def msbuildPath = findMSBuildPath()
-        logger.lifecycle("msbuild call=$msbuildPath " + arguments.toString())
+        logger.info("msbuild call=$msbuildPath " + arguments.toString())
 
         project.exec {
             executable = msbuildPath
@@ -79,12 +77,12 @@ class MSBuildTask extends DefaultTask {
 
     def findMSBuildPath() {
         if (project.ext.has('msbuildPath')) {
-            logger.lifecycle("msbuildPath (cached): $project.msbuildPath")
+            logger.info("msbuildPath (cached): $project.msbuildPath")
             return project.msbuildPath
         }
 
         project.ext.msbuildPath = project.isWindows ? findMSBuildPathWindows() : findMSBuildPathUnix()
-        logger.lifecycle "msbuildPath: $project.msbuildPath"
+        logger.info "msbuildPath: $project.msbuildPath"
         return project.msbuildPath
     }
 
@@ -111,6 +109,16 @@ class MSBuildTask extends DefaultTask {
         }
 
         return project.file(stdout.toString().trim())
+    }
+
+    def getVerbosity() {
+        switch (project.gradle.startParameter.logLevel) {
+            case LogLevel.QUIET:        return "quiet";
+            case LogLevel.LIFECYCLE:    return "minimal";
+            case LogLevel.INFO:         return "normal";
+            case LogLevel.DEBUG:        return "detailed";
+        }
+        return "normal";
     }
 }
 
@@ -139,8 +147,7 @@ class RestorePackagesTask extends DefaultTask {
     def restore() {
         project.ci.Progress("Restoring packages for $packagesFile")
 
-        // TODO: Map verbosity to gradle logging verbosity
-        def restoreArguments = [ 'restore', '--verbosity', 'normal' ]        
+        def restoreArguments = [ 'restore', '--verbosity', "${getVerbosity()}" ]
         restoreArguments << '--source' << 'https://api.nuget.org/v3/index.json'
         restoreArguments << '--source' << project.backend.riderSdkPath
         restoreArguments << '--source' << project.backend.reSharperSdkPath
@@ -153,6 +160,16 @@ class RestorePackagesTask extends DefaultTask {
             standardOutput = System.out
         }
     }
+
+    def getVerbosity() {
+        switch (project.gradle.startParameter.logLevel) {
+            case LogLevel.QUIET:        return "quiet";
+            case LogLevel.LIFECYCLE:    return "minimal";
+            case LogLevel.INFO:         return "normal";
+            case LogLevel.DEBUG:        return "detailed";
+        }
+        return "normal";
+    }
 }
 
 class GenerateBuildPropsTask extends DefaultTask {    
@@ -164,7 +181,7 @@ class GenerateBuildPropsTask extends DefaultTask {
     def generate() {
         project.ci.Progress("Generating Build.props for $packageName")
         def packageVersion = parsePackageVersion()
-        logger.lifecycle("$msBuildParameter=$packageVersion")
+        logger.info("$msBuildParameter=$packageVersion")
 
         new File("$project.repoRoot/resharper/$packageName" + ".generated.props").text = """<Project>
   <PropertyGroup>
@@ -178,7 +195,7 @@ class GenerateBuildPropsTask extends DefaultTask {
         assert packagesDirectory.isDirectory()
         def escapedPackageName = Pattern.quote(packageName)
 
-        logger.lifecycle("Looking for package $packageName in $packagesDirectory")
+        logger.info("Looking for package $packageName in $packagesDirectory")
 
         def packageVersion = packagesDirectory.listFiles().collect { File f ->
             if (f.isFile()) {
@@ -253,7 +270,7 @@ task prepareNuGetConfig {
     </packageSources>
     </configuration>
     """
-        logger.lifecycle(nugetConfigText)
+        logger.info(nugetConfigText)
         new File("$repoRoot/resharper/NuGet.Config").text = nugetConfigText
     }
 }

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-ext.backend = new BackendHelper(ext.repoRoot, buildDir, ext.dependenciesDir, logger, ext.productVersion)
+ext.backend = new BackendHelper(ext.repoRoot, buildDir, ext.localRiderSdkRoot, logger, ext.productVersion)
 
 def teamcityVersion = System.env['TEAMCITY_VERSION']
 project.ci.Progress("teamcityVersion = $teamcityVersion")
@@ -25,7 +25,7 @@ class BackendHelper {
     File riderSdkPath
     File reSharperSdkPath
 
-    BackendHelper(File repoRoot, File buildDir, File dependenciesDir, Logger logger, String productVersion) {
+    BackendHelper(File repoRoot, File buildDir, File localRiderSdkRoot, Logger logger, String productVersion) {
         repositoryRoot = repoRoot
         assert repositoryRoot.isDirectory()
 
@@ -42,8 +42,8 @@ class BackendHelper {
         riderTestsProject = new File(backendRoot, 'test/src/tests.rider.csproj')
         assert riderTestsProject.isFile()
 
-        if (dependenciesDir.isDirectory()) {            
-            riderSdkPath = new File(dependenciesDir.canonicalPath, "lib/ReSharperHostSdk")
+        if (localRiderSdkRoot.isDirectory()) {            
+            riderSdkPath = new File(localRiderSdkRoot.canonicalPath, "lib/ReSharperHostSdk")
             assert riderSdkPath.isDirectory()
 
             logger.lifecycle("Rider SDK bundle found: $riderSdkPath.canonicalPath")

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -28,7 +28,8 @@ ext.RdGen = com.jetbrains.rider.generator.gradle.RdgenTask
 ext.productVersion = "2018.3"
 ext.repoRoot = new File("..").canonicalFile
 ext.isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
-ext.dependenciesDir = new File("dependencies")
+ext.localRiderSdkRoot = new File("dependencies")  // SDK from TC configuration/artifacts
+ext.rdLibDirectory = getRdLibDirectory()  // Note that this is also used by the protocol project
 ext.shouldBuildRiderOnly = false
 
 if (!ext.has("BuildCounter"))
@@ -99,3 +100,14 @@ task resolveDependencies {
   }
 }
 
+
+def getRdLibDirectory() {
+  def root = localRiderSdkRoot
+  if (root.exists() && root.isDirectory()) {
+    logger.lifecycle("'dependencies' dir found, using as Rider SDK root")
+  }
+  else {
+    root = new File(repoRoot, "rider/build/riderRD-${productVersion}-SNAPSHOT")
+  }
+  return new File(root, "lib/rd").canonicalFile
+}

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -79,6 +79,23 @@ apply from: 'frontend.gradle'
 apply from: 'model.gradle'
 
 
+// Tasks:
+//
+// When running in CI, we call `gradle buildPlugin`
+// When running interactively, we call `gradle runIde`
+// We can pass `-PdotNetUpToDate=true` to skip building dotnet things, as the no-op build is REALLY slow
+//
+// `buildPlugin` depends on `prepareSandbox` and then zips up the sandbox dir and puts the file in rider/build/distributions
+// `runIde` depends on `prepareSandbox` and then executes IJ inside the sandbox dir
+// `prepareSandbox` depends on the standard Java `jar` task and then copies everything into the sandbox dir
+//
+// `buildPlugin`, `runIde` and `prepareSandbox` are provided by the intellij gradle plugin
+//
+// When running in CI, the CI tasks will publish build version and the ReSharper artifacts
+// When calling `buildPlugin`, the CI tasks force building the ReSharper artifacts
+// When calling `runIde`, we only need to build Rider, debugger and Unity editor bits
+
+
 task resolveDependencies {
   description 'Resolves all projects dependencies from the repository'
   group 'Build Server'

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -75,6 +75,7 @@ logger.lifecycle("Configuration=$BuildConfiguration")
 
 apply from: 'backend.gradle'
 apply from: 'frontend.gradle'
+apply from: 'model.gradle'
 
 
 task resolveDependencies {

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id 'com.ullink.nunit' version '1.12' 
 }
 
+
 apply plugin: 'com.jetbrains.rdgen'
 apply from: 'ci.gradle'
 

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -20,7 +20,32 @@ plugins {
     id 'com.ullink.nunit' version '1.12' 
 }
 
+apply plugin: 'com.jetbrains.rdgen'
+apply from: 'ci.gradle'
+
+
+ext.RdGen = com.jetbrains.rider.generator.gradle.RdgenTask
 ext.productVersion = "2018.3"
+ext.repoRoot = new File("..").canonicalFile
+ext.isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
+ext.dependenciesDir = new File("dependencies")
+ext.shouldBuildRiderOnly = false
+
+if (!ext.has("BuildCounter"))
+    ext.BuildCounter = 9999
+
+if (!ext.has("BuildConfiguration")) {
+    ext.BuildConfiguration = ext.isBuildingUnderCi ? "Release" : "Debug"
+}
+
+if (!ext.has('dotNetUpToDate') || ext.dotNetUpToDate ==~ "(?i)False")
+    ext.dotNetUpToDate = false
+
+/* done as an optional step so that we can reuse the build artifacts */
+if (!ext.has("RunTests") || ext.RunTests ==~ "(?i)False")
+    ext.RunTests = false
+
+
 
 configurations {
     reSharper
@@ -36,56 +61,21 @@ dependencies {
     reSharper group: "com.jetbrains.intellij.resharper", name: "resharperUltimatePackages", version: "${productVersion}-SNAPSHOT", ext: "zip"
 }
 
-apply plugin: 'com.jetbrains.rdgen'
-
-ext.RdGen = com.jetbrains.rider.generator.gradle.RdgenTask
-
-ext.repoRoot = new File("..").canonicalFile
-ext.isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
-ext.dependenciesDir = new File("dependencies")
-
 wrapper {
     gradleVersion = '4.7'
     distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 
-if (System.env['TEAMCITY_VERSION'] != null) {
-    ext.ci = new TeamCityService()
-    ext.isBuildingUnderCi = true
-    gradle.taskGraph.addTaskExecutionListener(new TeamCityEventLogger(ci))
-} else if (System.env['TRAVIS'] != null) {
-    ext.ci = new TravisService()
-    ext.isBuildingUnderCi = true
-    gradle.taskGraph.addTaskExecutionListener(new TravisEventLogger(ci))
-} else {
-    ext.ci = new NullService()
-    ext.isBuildingUnderCi = false
-}
-
-if (!ext.has("BuildCounter"))
-    ext.BuildCounter = 9999
-
-if (!ext.has("BuildConfiguration")) {
-    ext.BuildConfiguration = ext.isBuildingUnderCi ? "Release" : "Debug"
-}
-
-if (!ext.has('dotNetUpToDate') || ext.dotNetUpToDate ==~ "(?i)False")
-    ext.dotNetUpToDate = false
-
-/* done as an optional step so that we can reuse the build artifacts */
-if (!ext.has("RunTests") || ext.RunTests ==~ "(?i)False")
-    ext.RunTests = false
-logger.lifecycle("RunTests=$RunTests")
-
-ext.shouldBuildRiderOnly = false
-
 version "${productVersion}.0.$BuildCounter"
+
 
 logger.lifecycle("version=$version")
 logger.lifecycle("Configuration=$BuildConfiguration")
 
+
 apply from: 'backend.gradle'
 apply from: 'frontend.gradle'
+
 
 task resolveDependencies {
   description 'Resolves all projects dependencies from the repository'
@@ -106,113 +96,5 @@ task resolveDependencies {
       }
     }
   }
-}
-
-interface CIService {
-    void Progress(String message)
-    void OpenBlock(String name, String description)
-    void CloseBlock(String name)
-    void PublishArtifact(File path)
-}
-
-class NullService implements CIService {
-
-    void Progress(String message) {
-        println message
-    }
-
-    void OpenBlock(String name, String description) { }
-    void CloseBlock(String name) { }
-
-    void PublishArtifact(File path) {
-        println "Publish: $path.absolutePath"
-    }
-
-    void SetBuildNumber(String version) {
-        println "Build: $version"
-    }
-}
-
-class TeamCityService implements CIService {
-
-    // TODO: These values should be escaped
-    void Progress(String message) {
-        println "##teamcity[progressMessage '$message']"
-    }
-
-    void OpenBlock(String name, String description) {
-        println "##teamcity[blockOpened name='$name' description='$description']"
-    }
-
-    void CloseBlock(String name) {
-        println "##teamcity[blockClosed name='$name']"
-    }
-
-    void PublishArtifact(File path) {
-        println "##teamcity[publishArtifacts '$path.absolutePath']"
-    }
-
-    void SetBuildNumber(String version) {
-        println "##teamcity[buildNumber '$version']"
-    }
-}
-
-class TeamCityEventLogger extends BuildAdapter implements TaskExecutionListener {
-
-    private CIService ci
-
-    TeamCityEventLogger(CIService ci) {
-        this.ci = ci
-    }
-
-    void beforeExecute(Task task) {
-        ci.Progress("gradle:$task.name")
-        ci.OpenBlock("gradle:$task.name", "gradle:$task.name")
-    }
-
-    void afterExecute(Task task, TaskState state) {
-        ci.CloseBlock("gradle:$task.name")
-    }
-}
-
-
-class TravisService implements CIService {
-
-    void Progress(String message) {
-        println message
-    }
-
-    void OpenBlock(String name, String description) {
-        println "travis_fold:start:$name\033[33;1m:$description\033[0m"
-    }
-
-    void CloseBlock(String name) {
-        println "\ntravis_fold:end:$name\r"
-    }
-
-    void PublishArtifact(File path) {
-        println "Artifact: $path.absolutePath"
-    }
-
-    void SetBuildNumber(String version) {
-        println "Build number: $version"
-    }
-}
-
-class TravisEventLogger extends BuildAdapter implements TaskExecutionListener {
-
-    private CIService ci
-
-    TravisEventLogger(CIService ci) {
-        this.ci = ci
-    }
-
-    void beforeExecute(Task task) {
-        ci.OpenBlock(task.name, task.name)
-    }
-
-    void afterExecute(Task task, TaskState state) {
-        ci.CloseBlock(task.name)
-    }
 }
 

--- a/rider/ci.gradle
+++ b/rider/ci.gradle
@@ -1,3 +1,15 @@
+task publishCiBuildNumber {
+    doLast {
+        ci.SetBuildNumber(version)
+    }
+}
+
+task publishCiBuildData {
+    dependsOn publishCiBuildNumber
+}
+
+
+
 if (System.env['TEAMCITY_VERSION'] != null) {
     ext.ci = new TeamCityService()
     ext.isBuildingUnderCi = true
@@ -10,6 +22,14 @@ if (System.env['TEAMCITY_VERSION'] != null) {
     ext.ci = new NullService()
     ext.isBuildingUnderCi = false
 }
+
+
+if (ext.isBuildingUnderCi) {
+    buildPlugin.finalizedBy publishCiBuildData
+}
+
+
+
 
 interface CIService {
     void Progress(String message)

--- a/rider/ci.gradle
+++ b/rider/ci.gradle
@@ -1,0 +1,121 @@
+if (System.env['TEAMCITY_VERSION'] != null) {
+    ext.ci = new TeamCityService()
+    ext.isBuildingUnderCi = true
+    gradle.taskGraph.addTaskExecutionListener(new TeamCityEventLogger(ci))
+} else if (System.env['TRAVIS'] != null) {
+    ext.ci = new TravisService()
+    ext.isBuildingUnderCi = true
+    gradle.taskGraph.addTaskExecutionListener(new TravisEventLogger(ci))
+} else {
+    ext.ci = new NullService()
+    ext.isBuildingUnderCi = false
+}
+
+interface CIService {
+    void Progress(String message)
+    void OpenBlock(String name, String description)
+    void CloseBlock(String name)
+    void PublishArtifact(File path)
+}
+
+class NullService implements CIService {
+
+    void Progress(String message) {
+        println message
+    }
+
+    void OpenBlock(String name, String description) { }
+    void CloseBlock(String name) { }
+
+    void PublishArtifact(File path) {
+        println "Publish: $path.absolutePath"
+    }
+
+    void SetBuildNumber(String version) {
+        println "Build: $version"
+    }
+}
+
+class TeamCityService implements CIService {
+
+    // TODO: These values should be escaped
+    void Progress(String message) {
+        println "##teamcity[progressMessage '$message']"
+    }
+
+    void OpenBlock(String name, String description) {
+        println "##teamcity[blockOpened name='$name' description='$description']"
+    }
+
+    void CloseBlock(String name) {
+        println "##teamcity[blockClosed name='$name']"
+    }
+
+    void PublishArtifact(File path) {
+        println "##teamcity[publishArtifacts '$path.absolutePath']"
+    }
+
+    void SetBuildNumber(String version) {
+        println "##teamcity[buildNumber '$version']"
+    }
+}
+
+class TeamCityEventLogger extends BuildAdapter implements TaskExecutionListener {
+
+    private CIService ci
+
+    TeamCityEventLogger(CIService ci) {
+        this.ci = ci
+    }
+
+    void beforeExecute(Task task) {
+        ci.Progress("gradle:$task.name")
+        ci.OpenBlock("gradle:$task.name", "gradle:$task.name")
+    }
+
+    void afterExecute(Task task, TaskState state) {
+        ci.CloseBlock("gradle:$task.name")
+    }
+}
+
+
+class TravisService implements CIService {
+
+    void Progress(String message) {
+        println message
+    }
+
+    void OpenBlock(String name, String description) {
+        println "travis_fold:start:$name\033[33;1m:$description\033[0m"
+    }
+
+    void CloseBlock(String name) {
+        println "\ntravis_fold:end:$name\r"
+    }
+
+    void PublishArtifact(File path) {
+        println "Artifact: $path.absolutePath"
+    }
+
+    void SetBuildNumber(String version) {
+        println "Build number: $version"
+    }
+}
+
+class TravisEventLogger extends BuildAdapter implements TaskExecutionListener {
+
+    private CIService ci
+
+    TravisEventLogger(CIService ci) {
+        this.ci = ci
+    }
+
+    void beforeExecute(Task task) {
+        ci.OpenBlock(task.name, task.name)
+    }
+
+    void afterExecute(Task task, TaskState state) {
+        ci.CloseBlock(task.name)
+    }
+}
+

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -198,9 +198,13 @@ def unityeditorplugin_path = "$projectDir/../unity/build/JetBrains.Rider.Unity.E
 def unityeditorplugin_full_path = "$projectDir/../unity/build/JetBrains.Rider.Unity.Editor.Plugin.Full/Assets/Plugins/Editor/JetBrains/JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked.dll"
 
 prepareSandbox {
-    // Already depends on the standard Java build/jar task
-    dependsOn buildReSharperHostPlugin, buildUnityEditorPlugin
-    dependsOn nunit // will only get run when passed RunTests
+    // Default dependsOn includes the standard Java build/jar task
+
+    if (!project.dotNetUpToDate)
+        dependsOn buildReSharperHostPlugin, buildUnityEditorPlugin
+
+    if (project.RunTests)
+        dependsOn nunit
 
     // Have dependent tasks use uptodateWhen { project.isRunningUnderCi etc. }
     //inputs.files(buildRiderPlugin.outputs)

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -84,63 +84,6 @@ compileKotlin {
     }
 }
 
-apply plugin: 'com.jetbrains.rdgen'
-
-ext.modelDir = new File(repoRoot, "rider/protocol/src/main/kotlin/model")
-
-// TODO: Add an msbuild task for this, too?
-// Because we sometimes skip building the C# solutions (calling runIde from the C# IDE), we might
-// get into the situation where we rebuild the protocol for .kt, but not .cs
-// Maybe we should have an msbuild task to run rdgen if the input model .kt is newer than the output
-// .cs. Or make sure we don't skip the msbuild tasks if this task runs
-
-task generateRiderModel(type: RdGen) {
-    def csOutput = new File(repoRoot, "resharper/src/resharper-unity/Rider/RdUnityProtocol")
-    def ktOutput = new File(repoRoot, "rider/src/main/kotlin/com/jetbrains/rider/protocol/RdUnityProtocol")
-
-    params {
-        verbose = true
-        classpath "$rdLibDirectory/rider-model.jar"
-        sources "$modelDir/rider"
-        hashFolder = 'build/rdgen/rider'
-        packages = "model.rider"
-
-        generator {
-            language = "kotlin"
-            transform = "asis"
-            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
-            namespace = "com.jetbrains.rider.model"
-            directory = "$ktOutput"
-        }
-
-        generator {
-            language = "csharp"
-            transform = "reversed"
-            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
-            namespace = "JetBrains.Rider.Model"
-            directory = "$csOutput"
-        }
-
-    }
-}
-
-task generateEditorPluginModel(type: RdGen) {
-    params {
-        verbose = true
-        classpath "$rdLibDirectory/rider-model.jar"
-        hashFolder = "build/rdgen/editorPlugin"
-        sources "$modelDir/editorPlugin"
-        packages = "model.editorPlugin"
-    }
-}
-
-task generateModel {
-    group = 'other'
-    description = 'Generates protocol models.'
-}
-
-generateModel.dependsOn(generateRiderModel, generateEditorPluginModel)
-
 
 // When running in CI, we call `gradle buildPlugin`
 // When running interactively, we call `gradle runIde`
@@ -171,7 +114,7 @@ task publishCiBuildData {
 }
 
 buildPlugin.finalizedBy publishCiBuildData
-buildPlugin.dependsOn generateModel, validatePluginXml
+buildPlugin.dependsOn validatePluginXml
 
 // If we're building `runIde`, only build Rider bits. We only know this once the task graph
 // has been evaluated. It's now too late to change inputs/outputs or dependencies. An alternative

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -20,8 +20,8 @@ intellij {
     // localPath = '/Users/matt/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/171.4089.265/Rider EAP.app/Contents'
     // localPath = "F:\\RiderSDK"
 
-    if (dependenciesDir.exists()) {
-        localPath = dependenciesDir.canonicalPath
+    if (localRiderSdkRoot.exists()) {
+        localPath = localRiderSdkRoot.canonicalPath
     } else {
         version = "${productVersion}-SNAPSHOT"
     }
@@ -33,6 +33,7 @@ intellij {
 
     plugins = [ 'JavaScriptLanguage', 'rider-plugins-appender' ]
 }
+
 
 task validatePluginXml {
     def pluginXml = new File(repoRoot, "rider/src/main/resources/META-INF/plugin.xml")
@@ -50,30 +51,6 @@ task validatePluginXml {
     logger.lifecycle("$pluginXml.path is valid XML and contains only US-ASCII symbols, bytes: $rawBytes.length")
 }
 
-def frontendSdkRoot = dependenciesDir
-// bundled build configuration on TC
-if (dependenciesDir.exists() && dependenciesDir.isDirectory()) {
-    logger.lifecycle("dependencies dir found, using as frontend SDK root")    
-}
-else {
-    def frontendSdkVersion = "${productVersion}-SNAPSHOT"
-    def frontendSdkDirs = []
-    def frontendSdkSearchPath = new File(repoRoot, "rider/build")
-
-    if (frontendSdkDirs.size() > 0) {
-        assert frontendSdkDirs.size() == 1
-
-        def frontendSdkSingleDir = frontendSdkDirs.first()
-        def match = frontendSdkSingleDir.name =~ /riderRD-(.+)/
-        assert match.matches()
-
-        frontendSdkVersion = match[0][1]
-    }
-
-    frontendSdkRoot = new File(frontendSdkSearchPath, "riderRD-$frontendSdkVersion")
-}
-
-ext.rdLibDirectory = new File(frontendSdkRoot, "lib/rd").canonicalFile
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -35,22 +35,6 @@ intellij {
 }
 
 
-task validatePluginXml {
-    def pluginXml = new File(repoRoot, "rider/src/main/resources/META-INF/plugin.xml")
-    assert pluginXml.isFile()
-
-    def parsed = new XmlParser().parse(pluginXml).text()
-    assert parsed.length() > 0
-
-    def rawBytes = pluginXml.bytes
-    assert rawBytes.length > 0
-
-    def invalid = rawBytes.findAll { it < 0 }
-    assert invalid.size() == 0
-
-    logger.lifecycle("$pluginXml.path is valid XML and contains only US-ASCII symbols, bytes: $rawBytes.length")
-}
-
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -91,7 +75,6 @@ task publishCiBuildData {
 }
 
 buildPlugin.finalizedBy publishCiBuildData
-buildPlugin.dependsOn validatePluginXml
 
 // If we're building `runIde`, only build Rider bits. We only know this once the task graph
 // has been evaluated. It's now too late to change inputs/outputs or dependencies. An alternative
@@ -178,6 +161,30 @@ prepareSandbox {
         from 'projectTemplates'
     }
 }
+
+
+task validatePluginXml {
+  def pluginXml = new File(repoRoot, "rider/src/main/resources/META-INF/plugin.xml")
+  assert pluginXml.isFile()
+
+  inputs.file(pluginXml)
+  outputs.file(pluginXml)
+
+  doLast {
+    def parsed = new XmlParser().parse(pluginXml).text()
+    assert parsed.length() > 0
+
+    def rawBytes = pluginXml.bytes
+    assert rawBytes.length > 0
+
+    def invalid = rawBytes.findAll { it < 0 }
+    assert invalid.size() == 0
+
+    logger.lifecycle("$pluginXml.path is valid XML and contains only US-ASCII symbols, bytes: $rawBytes.length")
+  }
+}
+prepareSandbox.dependsOn validatePluginXml
+
 
 test {
     useTestNG() {}

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -5,6 +5,15 @@ sourceSets {
     }
 }
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 intellij {
     pluginName 'rider-unity'
     type 'RD'
@@ -35,46 +44,6 @@ intellij {
 }
 
 
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
-
-// When running in CI, we call `gradle buildPlugin`
-// When running interactively, we call `gradle runIde`
-// When running from the open rider solution, we call `gradle runIde -PDotNetUpToDate=true`
-//   to skip slow, no-op nuget restore and msbuild. Maybe .NET Core 2.1 will speed that up for us
-
-// buildPlugin depends on prepareSandbox, then zips up the sandbox dir
-// runIde depends on prepareSandbox, then executes IJ inside that dir
-// prepareSandbox dependsOn standard java build/jar then copies everything to the sandbox dir
-
-// When calling buildPlugin, we should build everything on the backend
-// When calling runIde, we should only build Rider and the Unity editor
-// prepareSandbox should also make sure that all of the Rider and Unity editor bits are copied
-//   (who owns this, frontend, or backend?)
-
-
-task publishCiBuildNumber {
-    doLast {
-        ci.SetBuildNumber(version)
-    }
-}
-
-task publishCiBuildData {
-    if (project.isBuildingUnderCi) {
-        dependsOn publishCiBuildNumber
-        dependsOn publishCiBackendArtifacts
-    }
-}
-
-buildPlugin.finalizedBy publishCiBuildData
 
 // If we're building `runIde`, only build Rider bits. We only know this once the task graph
 // has been evaluated. It's now too late to change inputs/outputs or dependencies. An alternative

--- a/rider/model.gradle
+++ b/rider/model.gradle
@@ -1,0 +1,57 @@
+ext.modelDir = new File(repoRoot, "rider/protocol/src/main/kotlin/model")
+
+// TODO: Add an msbuild task for this, too?
+// Because we sometimes skip building the C# solutions (calling runIde from the C# IDE), we might
+// get into the situation where we rebuild the protocol for .kt, but not .cs
+// Maybe we should have an msbuild task to run rdgen if the input model .kt is newer than the output
+// .cs. Or make sure we don't skip the msbuild tasks if this task runs
+
+task generateRiderModel(type: RdGen) {
+    def csOutput = new File(repoRoot, "resharper/src/resharper-unity/Rider/RdUnityProtocol")
+    def ktOutput = new File(repoRoot, "rider/src/main/kotlin/com/jetbrains/rider/protocol/RdUnityProtocol")
+
+    params {
+        verbose = true
+        classpath "$rdLibDirectory/rider-model.jar"
+        sources "$modelDir/rider"
+        hashFolder = 'build/rdgen/rider'
+        packages = "model.rider"
+
+        generator {
+            language = "kotlin"
+            transform = "asis"
+            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+            namespace = "com.jetbrains.rider.model"
+            directory = "$ktOutput"
+        }
+
+        generator {
+            language = "csharp"
+            transform = "reversed"
+            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+            namespace = "JetBrains.Rider.Model"
+            directory = "$csOutput"
+        }
+
+    }
+}
+
+task generateEditorPluginModel(type: RdGen) {
+    params {
+        verbose = true
+        classpath "$rdLibDirectory/rider-model.jar"
+        hashFolder = "build/rdgen/editorPlugin"
+        sources "$modelDir/editorPlugin"
+        packages = "model.editorPlugin"
+    }
+}
+
+task generateModel {
+    group = 'protocol'
+    description = 'Generates protocol models.'
+    dependsOn generateRiderModel, generateEditorPluginModel
+}
+
+// TODO: The dotnet world should depend on this, too
+jar.dependsOn generateModel
+buildPlugin.dependsOn generateModel


### PR DESCRIPTION
Build improvements for .csproj files:

* Fix warnings about mismatched assembly versions
* Fix some unused variable warnings
* Clean up .csproj files - proper imports for .net sdk, and remove Unix only exclusions

And for gradle files:

* Improve skipping dotnet tasks
* Only validate plugin.xml if it's changed
* Split CI and model into own files
* Set logging level for msbuild + nuget restore based on gradle logging level

Not yet done. For discussion:

I'd like to move the unzipped SDK folders to the gradle cache, so they work like IJ does with its SDK. This would reduce the amount of _stuff_ in the `build` folders, which helps if you have multiple checkouts.

- [ ] Unzip R# SDK into gradle cache folder, rather than build folder (like IJ does with it's SDK)
- [ ] Unzip Rider SDK into gradle cache folder, too. This would change how rdgen works. The task would have to be added in an "after evaluate" step, as we don't know the Rider SDK's gradle cache location until "after evaluate"
- [ ] Rewrite `backend.gradle` as `dotnet.gradle` and change the dependencies for `runIde` to only build Rider. `buildPlugin` would continue to build everything. This will clean up the file and replace the currently not very nice way we decide what to build.
- [ ] Change the default `build.sh` and `build.ps1` to build in Debug mode with minimal logging, for interactive use. Update the CI builds to pass in a verbose logging flag.
