### PR TITLE
Double click to attach to a Unity process

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityProcessPickerDialog.kt
@@ -4,16 +4,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.VerticalFlowLayout
-import com.intellij.ui.ColoredListCellRenderer
-import com.intellij.ui.PortField
-import com.intellij.ui.ScrollPaneFactory
-import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.*
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.dialog
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.FlowLayout
 import java.awt.Insets
+import java.awt.event.MouseEvent
 import javax.swing.*
 
 class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(project) {
@@ -36,6 +34,16 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
                 isOKActionEnabled = list.selectedValue.allowDebugging
             }
         }
+
+        object: DoubleClickListener() {
+            override fun onDoubleClick(p0: MouseEvent?): Boolean {
+                if (list.selectedIndex != -1) {
+                    doOKAction()
+                }
+                return true
+            }
+        }.installOn(list)
+
         init()
         setResizable(false)
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/toolWindow/log/UnityLogPanelView.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/toolWindow/log/UnityLogPanelView.kt
@@ -44,7 +44,7 @@ import javax.swing.event.DocumentEvent
 class UnityLogPanelView(project: Project, private val logModel: UnityLogPanelModel, unityHost: UnityHost) {
     private val console = TextConsoleBuilderFactory.getInstance()
         .createBuilder(project)
-        .filters(*Extensions.getExtensions<Filter>(AnalyzeStacktraceUtil.EP_NAME, project))
+        .filters(*Extensions.getExtensions<Filter>(AnalyzeStacktraceUtil.EP_NAME.name, project))
         .console as ConsoleViewImpl
 
     private val eventList = UnityLogPanelEventList().apply {


### PR DESCRIPTION
In the Attach to Unity Process dialog, double clicking an item in the list will now close the dialog and attach to that process.