### PR TITLE
Fix C# language level override with "latest"

### DIFF
--- a/resharper/resharper-unity/src/ProjectModel/Caches/UnityProjectFileCacheProvider.cs
+++ b/resharper/resharper-unity/src/ProjectModel/Caches/UnityProjectFileCacheProvider.cs
@@ -101,19 +101,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Caches
                 if (xmlElement == null)
                     continue;
 
+                // We can't just grab the value here because there may be multiple values set, one per configuration.
+                // I haven't seen Unity or Rider do this, so it must be VSTU, but I don't have proof...
                 if (xmlElement.GetElementsByTagName("LangVersion").Count > 0)
-                {
                     explicitLangVersion = true;
-                }
 
-                if (versionFromDll != null) 
+                if (versionFromDll != null)
                     continue;
-                
-                // Ideally, we could get the defines through the project model
-                // (see IManagedProjectConfiguration), but that only seems to
-                // give us the currently active project settings, and Unity's
-                // own .csproj creator only sets the version for the Debug build,
-                // not the Release build. VSTU sets the defines in both configurations.
+
+                // Ideally, we could get the defines through the project model (see IManagedProjectConfiguration), but
+                // that only seems to give us the currently active project settings, and Unity's own .csproj creator
+                // only sets the version for the Debug build, not the Release build. VSTU sets the defines in both
+                // configurations.
                 foreach (XmlNode defines in xmlElement.GetElementsByTagName("DefineConstants"))
                     unityVersion = GetVersionFromDefines(defines.InnerText, unityVersion);
             }
@@ -143,7 +142,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Caches
             }
             return unityVersion;
         }
-        
+
         [CanBeNull]
         private static Version TryGetUnityVersionFromDll(XmlElement documentElement)
         {
@@ -152,10 +151,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Caches
                 .Where(c => c.Name == "Reference" && c.GetAttribute("Include").StartsWith("UnityEngine") || c.GetAttribute("Include").Equals("UnityEditor"))
                 .SelectMany(d => d.ChildElements())
                 .FirstOrDefault(c => c.Name == "HintPath");
-            
-            if (referencePathElement == null || string.IsNullOrEmpty(referencePathElement.InnerText)) 
+
+            if (referencePathElement == null || string.IsNullOrEmpty(referencePathElement.InnerText))
                 return null;
-            
+
             var filePath = FileSystemPath.Parse(referencePathElement.InnerText);
             if (filePath.ExistsFile)
             {
@@ -165,7 +164,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Caches
                     if (!exePath.ExistsFile)
                         exePath = filePath.Combine("../../../../Unity.exe"); // Editor\Data\Managed\UnityEngine\UnityEngine.dll
                     if (exePath.ExistsFile)
-                        return new Version(new Version(FileVersionInfo.GetVersionInfo(exePath.FullPath).FileVersion).ToString(3));    
+                        return new Version(new Version(FileVersionInfo.GetVersionInfo(exePath.FullPath).FileVersion).ToString(3));
                 }
                 else if (PlatformUtil.RuntimePlatform == PlatformUtil.Platform.MacOsX)
                 {
@@ -177,8 +176,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel.Caches
                     var fullVersion = UnityVersion.GetVersionFromInfoPlist(infoPlistPath);
                     return UnityVersion.Parse(fullVersion);
                 }
-            } 
-            
+            }
+
             return null;
         }
 


### PR DESCRIPTION
It was incorrectly treating this as though it were "default", and trying to apply heuristics.  It now correctly treats this as "latest", e.g. C# 7.3 at time of going to press.