### PR TITLE
Call SyncSolution on each Unity startup

### DIFF
--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -264,7 +264,7 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
 
       var changed = false;
       
-      // Unity always sets AllowUnsafeBlocks in 2017.1+
+      // Unity sets AllowUnsafeBlocks in 2017.1+ depending on Player settings or asmdef
       // Strictly necessary to compile unsafe code
       // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/VisualStudioIntegration/SolutionSynchronizationSettings.cs#L119
       if (configText.Contains(UNITY_UNSAFE_KEYWORD) && !isUnity20171OrLater)

--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -115,7 +115,7 @@ namespace JetBrains.Rider.Unity.Editor
       if (!RiderScriptableSingleton.Instance.CsprojProcessedOnce)
       {
         ourLogger.Verbose("Call OnGeneratedCSProjectFiles once per Unity process.");
-        CsprojAssetPostprocessor.OnGeneratedCSProjectFiles();
+        UnityUtils.SyncSolution(); // On first opening Unity doesn't regenerate csproj https://youtrack.jetbrains.com/issue/RIDER-21035
         RiderScriptableSingleton.Instance.CsprojProcessedOnce = true;
       }
 


### PR DESCRIPTION
Otherwise when Unity version is updated Unity doesn't update csproj and we end up with https://youtrack.jetbrains.com/issue/RIDER-21035