### PR TITLE
Minor build updates

### DIFF
--- a/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde__offline_.xml
+++ b/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/runIde__offline_.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde (offline)" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/build/gradle-launcher/bin/Debug/net461/gradle-launcher.exe" />
+    <option name="PROGRAM_PARAMETERS" value="../../rider runIde -PskipDotnet=true --offline" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/gradle-launcher" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      <env name="ASPNETCORE_URLS" value="http://localhost:5000" />
+    </envs>
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/gradle-launcher/gradle-launcher.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value=".NETFramework,Version=v4.6.1" />
+    <browser url="http://localhost:5000" />
+    <method v="2">
+      <option name="Build" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/rider/model.gradle
+++ b/rider/model.gradle
@@ -1,4 +1,5 @@
 def modelDir = new File(repoRoot, "rider/protocol/src/main/kotlin/model")
+def hashBaseDir = new File(repoRoot, "rider/build/rdgen")
 
 // TODO: Think about adding an msbuild task for rdgen
 
@@ -12,7 +13,7 @@ task generateRiderModel(type: tasks.getByName('rdgen').class) {
         verbose = true
         classpath { backend.getRiderModelJar() }
         sources "$modelDir/rider"
-        hashFolder = 'build/rdgen/rider'
+        hashFolder = "$hashBaseDir/rider"
         packages = "model.rider"
 
         generator {
@@ -37,8 +38,8 @@ task generateEditorPluginModel(type: tasks.getByName('rdgen').class) {
     params {
         verbose = true
         classpath { backend.getRiderModelJar() }
-        hashFolder = "build/rdgen/editorPlugin"
         sources "$modelDir/editorPlugin"
+        hashFolder = "$hashBaseDir/editorPlugin"
         packages = "model.editorPlugin"
     }
 }


### PR DESCRIPTION
* Reverts the default `--offline` behaviour in the Gradle launcher app
* Adds a new "runIde (offline)" shared run configuration. Use this to run Gradle in offline mode so that it doesn't check online for dependencies. I don't know if it's actually faster, but it's very useful when you don't have internet connection. Running in offline mode can prevent running the debug instance of Rider if Gradle needs to download the JRE, which is a runtime dependency. Use the existing "runIde" run configuration to run in online mode in this case.
* Save the rdgen build hash in a reliably consistent location under the project folder