### PR TITLE
Fix isUnity Notification

### DIFF
--- a/resharper/resharper-unity/src/Rider/UnityInstallationSynchronizer.cs
+++ b/resharper/resharper-unity/src/Rider/UnityInstallationSynchronizer.cs
@@ -9,12 +9,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
     [SolutionComponent]
     public class UnityInstallationSynchronizer
     {
-        public UnityInstallationSynchronizer(Lifetime lifetime, UnityReferencesTracker referencesTracker,
+        public UnityInstallationSynchronizer(Lifetime lifetime, UnitySolutionTracker solutionTracker,
                                              UnityHost host, UnityInstallationFinder finder, UnityVersion unityVersion)
         {
-            referencesTracker.HasUnityReference.Advise(lifetime, hasReference =>
+            solutionTracker.IsUnityProjectFolder.Advise(lifetime, isUnityProjectFolder =>
             {
-                if (!hasReference) return;
+                if (!isUnityProjectFolder) return;
                 var version = unityVersion.GetActualVersionForSolution();
                 var path = finder.GetApplicationPath(version);
                 if (path == null)

--- a/resharper/resharper-unity/src/UnityInstallationFinder.cs
+++ b/resharper/resharper-unity/src/UnityInstallationFinder.cs
@@ -23,17 +23,17 @@ namespace JetBrains.ReSharper.Plugins.Unity
         {
             var possible = GetPossibleInstallationInfos();
             
-            var bestChoice = possible.LastOrDefault(a =>
+            var bestChoice = possible.Where(a =>
                 a.Version.Major == version.Major && a.Version.Minor == version.Minor &&
-                a.Version.Build == version.Build);
+                a.Version.Build == version.Build).OrderBy(b=>b.Version).LastOrDefault();
             if (bestChoice != null)
                 return bestChoice.Path;
-            var secondChoice = possible.LastOrDefault(a =>
-                a.Version.Major == version.Major && a.Version.Minor == version.Minor);
+            var secondChoice = possible.Where(a =>
+                a.Version.Major == version.Major && a.Version.Minor == version.Minor).OrderBy(b=>b.Version).LastOrDefault();
             if (secondChoice != null)
                 return secondChoice.Path;
-            var worstChoice =  possible.LastOrDefault(a =>
-                a.Version.Major == version.Major);
+            var worstChoice =  possible.Where(a => a.Version.Major == version.Major)
+                .OrderBy(b=>b.Version).LastOrDefault();
             return worstChoice?.Path;
         }
         

--- a/resharper/resharper-unity/src/UnityInstallationFinder.cs
+++ b/resharper/resharper-unity/src/UnityInstallationFinder.cs
@@ -23,16 +23,16 @@ namespace JetBrains.ReSharper.Plugins.Unity
         {
             var possible = GetPossibleInstallationInfos();
             
-            var bestChoice = possible.FirstOrDefault(a =>
+            var bestChoice = possible.LastOrDefault(a =>
                 a.Version.Major == version.Major && a.Version.Minor == version.Minor &&
                 a.Version.Build == version.Build);
             if (bestChoice != null)
                 return bestChoice.Path;
-            var secondChoice = possible.FirstOrDefault(a =>
+            var secondChoice = possible.LastOrDefault(a =>
                 a.Version.Major == version.Major && a.Version.Minor == version.Minor);
             if (secondChoice != null)
                 return secondChoice.Path;
-            var worstChoice =  possible.FirstOrDefault(a =>
+            var worstChoice =  possible.LastOrDefault(a =>
                 a.Version.Major == version.Major);
             return worstChoice?.Path;
         }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/OpenUnityProjectAsFolderNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/OpenUnityProjectAsFolderNotification.kt
@@ -4,91 +4,91 @@ import com.intellij.ide.impl.ProjectUtil
 import com.intellij.ide.projectView.ProjectView
 import com.intellij.notification.*
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeFrame
 import com.intellij.util.ui.EdtInvocationManager
-import com.jetbrains.rider.UnityProjectDiscoverer
+import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.model.RdExistingSolution
 import com.jetbrains.rider.model.RdVirtualSolution
+import com.jetbrains.rider.plugins.unity.UnityHost
 import com.jetbrains.rider.plugins.unity.actions.StartUnityAction
 import com.jetbrains.rider.plugins.unity.explorer.UnityExplorer
 import com.jetbrains.rider.plugins.unity.util.EditorInstanceJson
 import com.jetbrains.rider.plugins.unity.util.EditorInstanceJsonStatus
-import com.jetbrains.rider.plugins.unity.util.UnityInstallationFinder
 import com.jetbrains.rider.projectDir
 import com.jetbrains.rider.projectView.SolutionManager
 import com.jetbrains.rider.projectView.solutionDescription
 import javax.swing.event.HyperlinkEvent
 
-class OpenUnityProjectAsFolderNotification(private val project: Project, private val unityProjectDiscoverer: UnityProjectDiscoverer)
-    : ProjectComponent {
+class OpenUnityProjectAsFolderNotification(project: Project, unityHost: UnityHost)
+    : LifetimedProjectComponent(project) {
 
     companion object {
         private val notificationGroupId = NotificationGroup("Unity project open", NotificationDisplayType.STICKY_BALLOON, true)
     }
 
-    override fun projectOpened() {
-        // Do nothing if we're not in Unity folders, or we are, but we're a proper .sln based solution
-        if (!unityProjectDiscoverer.isUnityProjectFolder || project.solutionDescription is RdExistingSolution) return
+    init {
+        unityHost.model.applicationPath.advise(componentLifetime) {
+            // Do nothing if we're not in Unity folders, or we are, but we're a proper .sln based solution
+            if (project.solutionDescription is RdExistingSolution) return@advise
 
-        val solutionDescription = project.solutionDescription
-        if (solutionDescription is RdVirtualSolution) {
-            var adviceText = " Please <a href=\"reopen\">click here</a> to start Unity, generate a solution file and reopen the project."
-            val (status, _) = EditorInstanceJson.load(project)
-            if (status == EditorInstanceJsonStatus.Valid || UnityInstallationFinder(project).getApplicationPath() == null) {
-                adviceText = " Please <a href=\"close\">close</a> and reopen through the Unity editor, or by opening a .sln file."
-            }
-            val content = if (solutionDescription.projectFilePaths.isEmpty()) {
-                "This looks like a Unity project. C# and Unity specific functionality is not available when the project is opened as a folder." +
-                    adviceText
-            }
-            else
-                "This looks like a Unity project. C# and Unity specific functionality is not available when only a single project is opened." +
-                    adviceText
-            val title = "Unity functionality unavailable"
-            val notification = Notification(notificationGroupId.displayId, title, content, NotificationType.WARNING)
-            notification.setListener { _, hyperlinkEvent ->
-
-                if (hyperlinkEvent.eventType != HyperlinkEvent.EventType.ACTIVATED) return@setListener
-
-                if (hyperlinkEvent.description == "close") {
-                    ProjectUtil.closeAndDispose(project)
-                    WelcomeFrame.showIfNoProjectOpened()
+            val solutionDescription = project.solutionDescription
+            if (solutionDescription is RdVirtualSolution) {
+                var adviceText = " Please <a href=\"reopen\">click here</a> to start Unity, generate a solution file and reopen the project."
+                val (status, _) = EditorInstanceJson.load(project)
+                if (status == EditorInstanceJsonStatus.Valid) {
+                    adviceText = " Please <a href=\"close\">close</a> and reopen through the Unity editor, or by opening a .sln file."
                 }
-                if (hyperlinkEvent.description == "reopen") {
-                    StartUnityAction.StartUnityAndRider(project)
-                    ProjectUtil.closeAndDispose(project)
-                    WelcomeFrame.showIfNoProjectOpened()
-                }
-            }
+                val content = if (solutionDescription.projectFilePaths.isEmpty()) {
+                    "This looks like a Unity project. C# and Unity specific functionality is not available when the project is opened as a folder." +
+                            adviceText
+                } else
+                    "This looks like a Unity project. C# and Unity specific functionality is not available when only a single project is opened." +
+                            adviceText
+                val title = "Unity functionality unavailable"
+                val notification = Notification(notificationGroupId.displayId, title, content, NotificationType.WARNING)
+                notification.setListener { _, hyperlinkEvent ->
 
-            val baseDir: VirtualFile = project.projectDir
-            val solutionFile = baseDir.findChild(baseDir.name + ".sln")
-            if (solutionFile != null && solutionFile.exists()) {
-                notification.addAction(object : NotificationAction("Reopen as Unity project") {
-                    override fun actionPerformed(e: AnActionEvent, n: Notification) {
-                        // SolutionManager doesn't close the current project if focusOpenInNewFrame is set to true,
-                        // and if it's set to false, we get prompted if we want to open in new or same frame. We
-                        // don't care - we want to close this project, so new frame or reusing means nothing
-                        e.project?.let { ProjectUtil.closeAndDispose(it) }
-                        val newProject = SolutionManager.openExistingSolution(null, true, solutionFile)
+                    if (hyperlinkEvent.eventType != HyperlinkEvent.EventType.ACTIVATED) return@setListener
 
-                        // Opening as folder saves settings to `.idea/.idea.{folder}`. This includes the last selected
-                        // solution view pane, which will be file system. A Unity generated solution will use the
-                        // same settings folder, so will read the last selected solution view pane and fail to show
-                        // the Unity explorer view. We'll override that saved value here, and make Unity Explorer
-                        // the currently selected value. See RIDER-17865
-                        EdtInvocationManager.getInstance().invokeLater {
-                            val projectView = ProjectView.getInstance(newProject)
-                            projectView.changeView(UnityExplorer.ID)
-                        }
+                    if (hyperlinkEvent.description == "close") {
+                        ProjectUtil.closeAndDispose(project)
+                        WelcomeFrame.showIfNoProjectOpened()
                     }
-                })
-            }
+                    if (hyperlinkEvent.description == "reopen") {
+                        StartUnityAction.StartUnityAndRider(project)
+                        ProjectUtil.closeAndDispose(project)
+                        WelcomeFrame.showIfNoProjectOpened()
+                    }
+                }
 
-            Notifications.Bus.notify(notification, project)
+                val baseDir: VirtualFile = project.projectDir
+                val solutionFile = baseDir.findChild(baseDir.name + ".sln")
+                if (solutionFile != null && solutionFile.exists()) {
+                    notification.addAction(object : NotificationAction("Reopen as Unity project") {
+                        override fun actionPerformed(e: AnActionEvent, n: Notification) {
+                            // SolutionManager doesn't close the current project if focusOpenInNewFrame is set to true,
+                            // and if it's set to false, we get prompted if we want to open in new or same frame. We
+                            // don't care - we want to close this project, so new frame or reusing means nothing
+                            e.project?.let { ProjectUtil.closeAndDispose(it) }
+                            val newProject = SolutionManager.openExistingSolution(null, true, solutionFile)
+
+                            // Opening as folder saves settings to `.idea/.idea.{folder}`. This includes the last selected
+                            // solution view pane, which will be file system. A Unity generated solution will use the
+                            // same settings folder, so will read the last selected solution view pane and fail to show
+                            // the Unity explorer view. We'll override that saved value here, and make Unity Explorer
+                            // the currently selected value. See RIDER-17865
+                            EdtInvocationManager.getInstance().invokeLater {
+                                val projectView = ProjectView.getInstance(newProject)
+                                projectView.changeView(UnityExplorer.ID)
+                            }
+                        }
+                    })
+                }
+
+                Notifications.Bus.notify(notification, project)
+            }
         }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/OpenUnityProjectAsFolderNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/OpenUnityProjectAsFolderNotification.kt
@@ -35,8 +35,6 @@ class OpenUnityProjectAsFolderNotification(private val project: Project, private
 
         val solutionDescription = project.solutionDescription
         if (solutionDescription is RdVirtualSolution) {
-
-            //var reopenText = "<a href=\"reopen\">reopen</a>"
             var adviceText = " Please <a href=\"reopen\">click here</a> to start Unity, generate a solution file and reopen the project."
             val (status, _) = EditorInstanceJson.load(project)
             if (status == EditorInstanceJsonStatus.Valid || UnityInstallationFinder(project).getApplicationPath() == null) {


### PR DESCRIPTION
**Currently**
When you get pong-tdd from vcs it is opened as a folder.
And ApplicationPath is not populated
So Start Unity action is not availbale and Notification is saying just close project and open it via Unity.

**With this fix**
When project is opened as folder and IsUnityProjectFolder is thue, then ApplicationPath is found and passed to frontend, Start Unity is working and Notification says click here and Unity will be opened and will open Rider with solution.