### PR TITLE
Updates to YAML support

### DIFF
--- a/resharper/resharper-unity.sln.DotSettings
+++ b/resharper/resharper-unity.sln.DotSettings
@@ -43,6 +43,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playmode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resharper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scriptable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serisalisation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaders/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shakhov/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=VSTU/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using JetBrains.Application;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon.UsageChecking;
+using JetBrains.ReSharper.Plugins.Unity.Yaml;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
 using JetBrains.ReSharper.Plugins.Yaml.Settings;
 using JetBrains.ReSharper.Psi;
@@ -112,7 +113,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
             if (!unityApi.IsUnityType(type))
                 return false;
 
-            if (!myYamlSupport.IsParsingEnabled.Value)
+            var assetSerializationMode = method.GetSolution().GetComponent<AssetSerializationMode>();
+
+            // TODO: These two are usually used together. Consider combining in some way
+            if (!myYamlSupport.IsParsingEnabled.Value || !assetSerializationMode.IsForceText)
                 return IsPotentialEventHandler(unityApi, method);
 
             return method.GetSolution().GetComponent<UnityEventHandlerReferenceCache>().IsEventHandler(method);

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using JetBrains.Application;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Refactorings.Specific.Rename;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Psi;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings.Rename
+{
+    [ShellFeaturePart]
+    public class UnityEventTargetAtomicRenameFactory : IAtomicRenameFactory
+    {
+        public bool IsApplicable(IDeclaredElement declaredElement)
+        {
+            if (declaredElement is IMethod method)
+            {
+                var eventHandlerCache = declaredElement.GetSolution().GetComponent<UnityEventHandlerReferenceCache>();
+                return eventHandlerCache.IsEventHandler(method);
+            }
+
+            return false;
+        }
+
+        // Disable rename completely for Unity event handlers
+        public RenameAvailabilityCheckResult CheckRenameAvailability(IDeclaredElement element)
+        {
+            if (IsApplicable(element))
+                return RenameAvailabilityCheckResult.CanNotBeRenamed;
+
+            return RenameAvailabilityCheckResult.CanBeRenamed;
+        }
+
+        public IEnumerable<AtomicRenameBase> CreateAtomicRenames(IDeclaredElement declaredElement, string newName, bool doNotAddBindingConflicts)
+        {
+            return EmptyList<AtomicRenameBase>.Instance;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Rider/UnityOptionsPage.cs
+++ b/resharper/resharper-unity/src/Rider/UnityOptionsPage.cs
@@ -32,24 +32,25 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
         {
             Header("General");
 
-            CheckBox((UnitySettings s) => s.InstallUnity3DRiderPlugin, "Install or update Rider plugin automatically");
-            CheckBox((UnitySettings s) => s.AllowAutomaticRefreshInUnity, "Automatically refresh Assets in Unity");
+            CheckBox((UnitySettings s) => s.InstallUnity3DRiderPlugin,
+                "Automatically install and update Rider's Unity editor plugin (recommended)");
+            CheckBox((UnitySettings s) => s.AllowAutomaticRefreshInUnity, "Automatically refresh assets in Unity");
             CheckBox((UnitySettings s) => s.EnableDefaultUnityCodeStyle, "Enable default Unity code-style");
-            
+
             AddNamingSection(lifetime, settingsStore);
 
             // TODO: This needs to be available for ReSharper
             Header("C# code analysis");
             CheckBox((UnitySettings s) => s.EnablePerformanceCriticalCodeHighlighting,
-                "Enable highlighting of costly methods and indirect calls for these methods in performance critical code sections");
+                "Highlight expensive method calls in frequently called code");
 
             Header("ShaderLab");
             CheckBox((UnitySettings s) => s.EnableShaderLabHippieCompletion,
                 "Enable simple word-based completion in ShaderLab files");
 
-            Header("Experimental");
+            Header("Assets");
             CheckBox((YamlSettings s) => s.EnableYamlParsing,
-                "Parse Unity YAML files for references to methods");
+                "Parse text based asset files for class and method usages");
             AddText("Requires solution reopen.");
 
             if (productConfigurations.IsInternalMode())

--- a/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
@@ -43,7 +43,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
                 if (isEditorSettingsInText)
                 {
                     var text = editorSettingsPath.ReadAllText2().Text;
-                    var match = Regex.Match(text, "m_SerializationMode: (?<mode>.*)$");
+                    var match = Regex.Match(text, @"^\s+m_SerializationMode:\s+(?<mode>\d+)$", RegexOptions.Multiline);
                     if (match.Success)
                     {
                         if (int.TryParse(match.Groups["mode"].Value, out var mode))

--- a/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
                 if (isEditorSettingsInText)
                 {
                     var text = editorSettingsPath.ReadAllText2().Text;
-                    var match = Regex.Match(text, @"^\s+m_SerializationMode:\s+(?<mode>\d+)$", RegexOptions.Multiline);
+                    var match = Regex.Match(text, @"^\s+m_SerializationMode:\s+(?<mode>\d+)\s*$", RegexOptions.Multiline);
                     if (match.Success)
                     {
                         if (int.TryParse(match.Groups["mode"].Value, out var mode))

--- a/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+using JetBrains.ProjectModel;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml
+{
+    [SolutionComponent]
+    public class AssetSerializationMode
+    {
+        public AssetSerializationMode(ISolution solution, ILogger logger)
+        {
+            // TODO: React to changes in serialisation mode
+            // We could reload the value on any change, and then add or drop all asset files from the custom PSI module
+            // Right now, it's much easier to just read it once at solution load
+            // TODO: Display a notification if the project is set to binary or mixed
+
+            Mode = SerializationMode.Unknown;
+
+            var solutionDir = solution.SolutionDirectory;
+            var assetsDir = solutionDir.Combine("Assets");
+            var editorSettingsPath = solutionDir.Combine("ProjectSettings\\EditorSettings.asset");
+
+            // We don't need a full check to see if this is a Unity solution - if these things exist, it's good enough
+            // TODO: We need to refactor ProjectExtensions, UnityReferencesTracker and UnitySolutionTracker
+            // Too many classes doing the same kind of thing, slightly differently. And we need UnitySolutionTracker
+            // here, but it's a Rider only folder and too big to refactor right now
+            if (assetsDir.ExistsDirectory && editorSettingsPath.ExistsFile)
+            {
+                // If binary serialisation is enabled, the EditorSettings.asset file might be in binary. Sheesh
+                var isEditorSettingsInText = editorSettingsPath.ReadBinaryStream(reader =>
+                {
+                    var headerChars = new char[5];
+                    reader.Read(headerChars, 0, headerChars.Length);
+                    if (headerChars[0] == '%' && headerChars[1] == 'Y' && headerChars[2] == 'A' &&
+                        headerChars[3] == 'M' && headerChars[4] == 'L')
+                        return true;
+                    return false;
+                });
+
+                // At best, we can say that it's mixed. If the settings asset is in text, read it to get the proper value
+                Mode = SerializationMode.Mixed;
+
+                if (isEditorSettingsInText)
+                {
+                    var text = editorSettingsPath.ReadAllText2().Text;
+                    var match = Regex.Match(text, "m_SerializationMode: (?<mode>.*)$");
+                    if (match.Success)
+                    {
+                        if (int.TryParse(match.Groups["mode"].Value, out var mode))
+                        {
+                            if (mode >= 0 && mode <= 2)
+                                Mode = (SerializationMode) mode;
+                        }
+                    }
+                }
+
+                logger.Verbose("Unity asset serialisation mode: {0}", Mode);
+            }
+        }
+
+        public SerializationMode Mode { get; }
+        public bool IsForceText => Mode == SerializationMode.ForceText;
+
+        public enum SerializationMode
+        {
+            Unknown = -1,    // Most likely not a Unity project. Or failure to read
+            Mixed = 0,
+            ForceBinary = 1,
+            ForceText = 2
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
@@ -17,6 +17,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             Mode = SerializationMode.Unknown;
 
             var solutionDir = solution.SolutionDirectory;
+            if (!solutionDir.IsAbsolute) return; // True in tests
+
             var assetsDir = solutionDir.Combine("Assets");
             var editorSettingsPath = solutionDir.Combine("ProjectSettings\\EditorSettings.asset");
 
@@ -58,7 +60,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             }
         }
 
-        public SerializationMode Mode { get; }
+        public SerializationMode Mode { get; protected set; }
         public bool IsForceText => Mode == SerializationMode.ForceText;
 
         public enum SerializationMode

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
@@ -15,13 +15,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
             var reference = referenceOccurrence?.PrimaryReference;
             if (reference is UnityEventTargetReference)
                 return new[] {UnityYamlSpecificOccurrenceKinds.EventHandler};
+            if (reference is MonoScriptReference)
+                return new[] {UnityYamlSpecificOccurrenceKinds.ComponentUsage};
             return EmptyList<OccurrenceKind>.Instance;
         }
 
         public IEnumerable<OccurrenceKind> GetAllPossibleOccurrenceKinds()
         {
             // What about invocation, name capture?
-            return new[] {UnityYamlSpecificOccurrenceKinds.EventHandler};
+            return new[]
+            {
+                UnityYamlSpecificOccurrenceKinds.EventHandler,
+                UnityYamlSpecificOccurrenceKinds.ComponentUsage
+            };
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using ICSharpCode.NRefactory;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Occurrences;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
+{
+    [SolutionComponent]
+    public class UnityYamlOccurrenceKindProvider : IOccurrenceKindProvider
+    {
+        public ICollection<OccurrenceKind> GetOccurrenceKinds(IOccurrence occurrence)
+        {
+            var referenceOccurrence = occurrence as ReferenceOccurrence;
+            if (referenceOccurrence == null)
+                return EmptyList<OccurrenceKind>.Instance;
+
+            var reference = referenceOccurrence.PrimaryReference;
+            if (reference is UnityEventTargetReference)
+                return new[] {UnityYamlSpecificOccurrenceKinds.EventHandler};
+            return Util.EmptyList<OccurrenceKind>.Instance;
+        }
+
+        public IEnumerable<OccurrenceKind> GetAllPossibleOccurrenceKinds()
+        {
+            // What about invocation, name capture?
+            return new[] {UnityYamlSpecificOccurrenceKinds.EventHandler};
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlOccurrenceKindProvider.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using ICSharpCode.NRefactory;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
 {
@@ -12,13 +12,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
         public ICollection<OccurrenceKind> GetOccurrenceKinds(IOccurrence occurrence)
         {
             var referenceOccurrence = occurrence as ReferenceOccurrence;
-            if (referenceOccurrence == null)
-                return EmptyList<OccurrenceKind>.Instance;
-
-            var reference = referenceOccurrence.PrimaryReference;
+            var reference = referenceOccurrence?.PrimaryReference;
             if (reference is UnityEventTargetReference)
                 return new[] {UnityYamlSpecificOccurrenceKinds.EventHandler};
-            return Util.EmptyList<OccurrenceKind>.Instance;
+            return EmptyList<OccurrenceKind>.Instance;
         }
 
         public IEnumerable<OccurrenceKind> GetAllPossibleOccurrenceKinds()

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKindIconProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKindIconProvider.cs
@@ -1,7 +1,6 @@
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
 using JetBrains.ReSharper.Feature.Services.Resources;
-using JetBrains.ReSharper.Psi.Resources;
 using JetBrains.UI.Icons;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKindIconProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKindIconProvider.cs
@@ -1,0 +1,27 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Occurrences;
+using JetBrains.ReSharper.Feature.Services.Resources;
+using JetBrains.ReSharper.Psi.Resources;
+using JetBrains.UI.Icons;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
+{
+    [SolutionComponent]
+    public class UnityYamlSpecificOccurrenceKindIconProvider : IOccurrenceKindIconProvider
+    {
+        public IconId GetImageId(OccurrenceKind declaredElement)
+        {
+            // TODO: Better icon?
+            if (declaredElement == UnityYamlSpecificOccurrenceKinds.EventHandler)
+                return ServicesNavigationThemedIcons.UsageEventDeclaration.Id;
+            return null;
+        }
+
+        public int GetPriority(OccurrenceKind occurrenceKind)
+        {
+            if (occurrenceKind == UnityYamlSpecificOccurrenceKinds.EventHandler)
+                return -10;
+            return 0;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKinds.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKinds.cs
@@ -7,5 +7,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
     {
         [NotNull] public static readonly OccurrenceKind EventHandler =
             new OccurrenceKind("Unity event handler", OccurrenceKind.SemanticAxis, false);
+
+        [NotNull] public static readonly OccurrenceKind ComponentUsage =
+            new OccurrenceKind("Unity component usage", OccurrenceKind.SemanticAxis, false);
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKinds.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Occurrences/UnityYamlSpecificOccurrenceKinds.cs
@@ -1,0 +1,11 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.Occurrences;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
+{
+    public static class UnityYamlSpecificOccurrenceKinds
+    {
+        [NotNull] public static readonly OccurrenceKind EventHandler =
+            new OccurrenceKind("Unity event handler", OccurrenceKind.SemanticAxis, false);
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileCacheItem.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileCacheItem.cs
@@ -26,5 +26,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         {
             writer.Write(value.myGuid);
         }
+
+        public override string ToString() => $"guid: {myGuid}";
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.DataFlow;
 using JetBrains.ReSharper.Plugins.Yaml.Psi;
@@ -39,6 +40,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             return myAssetGuidToAssetFilePaths[guid];
         }
 
+        public IList<string> GetAssetNames(string guid)
+        {
+            return myAssetGuidToAssetFilePaths[guid].Select(p => p.NameWithoutExtension).ToList();
+        }
+
+        [CanBeNull]
         public string GetAssetGuid(IPsiSourceFile sourceFile)
         {
             return myAssetFilePathToGuid.TryGetValue(sourceFile.GetLocation(), out var guid) ? guid : null;

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerReferenceCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerReferenceCache.cs
@@ -76,7 +76,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             var referencedElements = new List<string>();
             var referenceProcessor = new RecursiveReferenceProcessor<UnityEventTargetReference>(reference =>
             {
-                var assetGuid = reference.GetAssetGuid();
+                var assetGuid = reference.GetScriptAssetGuid();
                 if (assetGuid != null)
                 {
                     var referencedElementKey = GetReferencedElementKey(assetGuid, reference.EventHandlerName);

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityMiscFilesProjectPsiModuleProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityMiscFilesProjectPsiModuleProvider.cs
@@ -12,12 +12,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         private readonly UnityExternalFilesModuleFactory myModuleFactory;
         private readonly UnityYamlPsiSourceFileFactory myPsiSourceFileFactory;
+        private readonly AssetSerializationMode myAssetSerializationMode;
 
         public UnityMiscFilesProjectPsiModuleProvider(UnityExternalFilesModuleFactory moduleFactory,
-                                                      UnityYamlPsiSourceFileFactory psiSourceFileFactory)
+                                                      UnityYamlPsiSourceFileFactory psiSourceFileFactory,
+                                                      AssetSerializationMode assetSerializationMode)
         {
             myModuleFactory = moduleFactory;
             myPsiSourceFileFactory = psiSourceFileFactory;
+            myAssetSerializationMode = assetSerializationMode;
         }
 
         public void Dispose() { }
@@ -42,8 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         }
 
         public void OnProjectFileChanged(IProjectFile projectFile, PsiModuleChange.ChangeType changeType,
-                                         PsiModuleChangeBuilder changeBuilder,
-                                         FileSystemPath oldLocation)
+                                         PsiModuleChangeBuilder changeBuilder, FileSystemPath oldLocation)
         {
             if (projectFile == null)
                 return;
@@ -56,6 +58,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             {
                 case PsiModuleChange.ChangeType.Added:
                     if (UnityYamlFileExtensions.IsAsset(projectFile.Location) &&
+                        myAssetSerializationMode.IsForceText &&
                         !module.ContainsPath(projectFile.Location))
                     {
                         // Create the PsiSourceFile, add it to the module, add the change to the builder

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/IUnityYamlReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/IUnityYamlReference.cs
@@ -1,0 +1,10 @@
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi.Resolve;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
+{
+    public interface IUnityYamlReference : IReference
+    {
+        IYamlDocument ComponentDocument { get; }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
@@ -1,0 +1,81 @@
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.Util;
+using JetBrains.Util.DataStructures;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
+{
+    public class MonoScriptReference : CheckedReferenceBase<IPlainScalarNode>, IUnityYamlReference
+    {
+        private readonly FileID myFileID;
+        private readonly MetaFileGuidCache myMetaFileGuidCache;
+
+        public MonoScriptReference(IPlainScalarNode owner, FileID fileID, MetaFileGuidCache metaFileGuidCache)
+            : base(owner)
+        {
+            myFileID = fileID;
+            myMetaFileGuidCache = metaFileGuidCache;
+        }
+
+        // The YAML document that contains the reference. This should always be a MonoBehaviour component
+        public IYamlDocument ComponentDocument => myOwner.GetContainingNode<IYamlDocument>();
+
+        public override ResolveResultWithInfo ResolveWithoutCache()
+        {
+            var resolveResultWithInfo = CheckedReferenceImplUtil.Resolve(this, GetReferenceSymbolTable(true));
+            if (!resolveResultWithInfo.Result.IsEmpty)
+                return resolveResultWithInfo;
+
+            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.NOT_RESOLVED);
+        }
+
+        public override ISymbolTable GetReferenceSymbolTable(bool useReferenceName)
+        {
+            var assetGuid = myFileID.guid;
+            var targetType = UnityObjectPsiUtil.GetTypeElementFromScriptAssetGuid(myOwner.GetSolution(), assetGuid);
+            if (targetType == null)
+                return EmptySymbolTable.INSTANCE;
+
+            // We don't need to do anything about useReferenceName, we only ever have one candidate
+
+            var symbolTable = new SymbolTable(myOwner.GetPsiServices());
+            symbolTable.AddSymbol(assetGuid, targetType);
+            return symbolTable;
+        }
+
+        public override ISymbolFilter[] GetSymbolFilters() => EmptyArray<ISymbolFilter>.Instance;
+        public override TreeTextRange GetTreeTextRange() => myOwner.GetTreeTextRange();
+        public override IAccessContext GetAccessContext() => new DefaultAccessContext(myOwner);
+
+        // Note that the guid is the (primary) reference name
+        public override string GetName() => myOwner.Text?.GetText() ?? SharedImplUtil.MISSING_DECLARATION_NAME;
+        public override bool HasMultipleNames => true;
+
+        public override HybridCollection<string> GetAllNames()
+        {
+            var assetNames = myMetaFileGuidCache.GetAssetNames(myFileID.guid);
+            switch (assetNames.Count)
+            {
+                case 0:
+                    return new HybridCollection<string>(myFileID.guid);
+                case 1:
+                    return new HybridCollection<string>(myFileID.guid, assetNames[0]);
+                default:
+                    return new HybridCollection<string>(myFileID.guid).Add(assetNames);
+            }
+        }
+
+        public override IReference BindTo(IDeclaredElement element)
+        {
+            // We don't need to do anything, as a rename doesn't change the guid that we have
+            return this;
+        }
+
+        public override IReference BindTo(IDeclaredElement element, ISubstitution substitution) => BindTo(element);
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReferenceFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReferenceFactory.cs
@@ -1,0 +1,49 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
+{
+    public class MonoScriptReferenceFactory : IReferenceFactory
+    {
+        public ReferenceCollection GetReferences(ITreeNode element, ReferenceCollection oldReferences)
+        {
+            if (ResolveUtil.CheckThatAllReferencesBelongToElement<MonoScriptReference>(oldReferences, element))
+                return oldReferences;
+
+            if (!(element is IPlainScalarNode guidValue))
+                return ReferenceCollection.Empty;
+
+            // m_Script: {fileID: 11500000, guid: xxx, type: x}
+            var guidEntry = FlowMapEntryNavigator.GetByValue(guidValue);
+            var flowIDMap = FlowMappingNodeNavigator.GetByEntrie(guidEntry);
+            var blockMappingEntry = BlockMappingEntryNavigator.GetByValue(flowIDMap);
+
+            if (guidEntry?.Key.AsString() == "guid" && blockMappingEntry?.Key.AsString() == "m_Script")
+            {
+                var fileID = flowIDMap.AsFileID();
+                if (fileID != null && !fileID.IsNullReference && fileID.IsMonoScript)
+                {
+                    var metaGuidCache = element.GetSolution().GetComponent<MetaFileGuidCache>();
+                    var reference = new MonoScriptReference(guidValue, fileID, metaGuidCache);
+                    return new ReferenceCollection(reference);
+                }
+            }
+
+            return ReferenceCollection.Empty;
+        }
+
+        // Names is likely to contain the name of the class. All we have in the file is the guid
+        public bool HasReference(ITreeNode element, IReferenceNameContainer names)
+        {
+            var guidValue = element as IPlainScalarNode;
+            var guidEntry = FlowMapEntryNavigator.GetByValue(guidValue);
+            var flowIDMap = FlowMappingNodeNavigator.GetByEntrie(guidEntry);
+            var blockMappingEntry = BlockMappingEntryNavigator.GetByValue(flowIDMap);
+            return guidEntry?.Key.AsString() == "guid" && blockMappingEntry?.Key.AsString() == "m_Script";
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReferenceProviderFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReferenceProviderFactory.cs
@@ -1,0 +1,47 @@
+using JetBrains.DataFlow;
+using JetBrains.ReSharper.Plugins.Yaml.Psi;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
+{
+    // Assets can contain MonoBehaviour instances, and each MonoBehaviour has a reference to a MonoScript instance that
+    // describes how to locate the script class that provides the functionality for the behaviour. In the YAML, this is
+    // represented by the m_Script member of the MonoBehaviour instance (!u!114). This member contains a fileID
+    // structure, where the guid identifies the script asset, and the fileID itself is a value relative to the script
+    // asset. For precompiled scripts, the asset is a .dll, and the fileID is a hash that identifies a class within the
+    // .dll. For loose scripts (i.e. .cs files) the fileID is irrelevant, and the static value 11500000 is used instead
+    // (115 is the class ID for MonoScript). Unity expects to find a class with the same name as the file, possibly in a
+    // namespace. Behaviour is undefined if there are multiple classes with the same name in a file (they would have to
+    // have different namespaces)
+    // We'll add a reference from the guid of a 11500000 fileID structure to the class it represents, by finding the C#
+    // file asset with the same guid, and the class of the same name inside the file
+    [ReferenceProviderFactory]
+    public class MonoScriptReferenceProviderFactory : IReferenceProviderFactory
+    {
+        public MonoScriptReferenceProviderFactory(Lifetime lifetime)
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            Changed = new Signal<IReferenceProviderFactory>(lifetime, GetType().FullName);
+        }
+
+        public IReferenceFactory CreateFactory(IPsiSourceFile sourceFile, IFile file, IWordIndex wordIndexForChecks)
+        {
+            if (sourceFile.PrimaryPsiLanguage.Is<YamlLanguage>() &&
+                UnityYamlFileExtensions.IsAsset(sourceFile.GetLocation()))
+            {
+                if (wordIndexForChecks == null || (wordIndexForChecks.CanContainAllSubwords(sourceFile, "m_Script") &&
+                                                   wordIndexForChecks.CanContainAllSubwords(sourceFile, "11500000")))
+                {
+                    return new MonoScriptReferenceFactory();
+                }
+            }
+
+            return null;
+        }
+
+        public ISignal<IReferenceProviderFactory> Changed { get; }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReferenceProviderFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReferenceProviderFactory.cs
@@ -1,11 +1,9 @@
-using System;
 using JetBrains.DataFlow;
 using JetBrains.ReSharper.Plugins.Yaml.Psi;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
 using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.ReSharper.Psi.Web.WebConfig;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
 {
@@ -48,10 +46,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
 
         public IReferenceFactory CreateFactory(IPsiSourceFile sourceFile, IFile file, IWordIndex wordIndexForChecks)
         {
-            // TODO: Can we get these references inside .asset as well?
-            // TODO: Any other file types?
-            if (sourceFile.PrimaryPsiLanguage.Is<YamlLanguage>() && string.Equals(sourceFile.GetExtensionWithDot(),
-                    ".unity", StringComparison.InvariantCultureIgnoreCase))
+            if (sourceFile.PrimaryPsiLanguage.Is<YamlLanguage>() &&
+                UnityYamlFileExtensions.IsAsset(sourceFile.GetLocation()))
             {
                 if (wordIndexForChecks == null || wordIndexForChecks.CanContainAllSubwords(sourceFile, "m_MethodName"))
                     return new UnityEventTargetReferenceFactory();

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlGuidUsageSearchFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlGuidUsageSearchFactory.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Plugins.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Search;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI;
+using JetBrains.Util.dataStructures;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
+{
+    [PsiSharedComponent]
+    public class UnityYamlGuidUsageSearchFactory : DomainSpecificSearcherFactoryBase
+    {
+        public override bool IsCompatibleWithLanguage(PsiLanguageType languageType)
+        {
+            return languageType.Is<YamlLanguage>();
+        }
+
+        public override IDomainSpecificSearcher CreateReferenceSearcher(IDeclaredElementsSet elements, bool findCandidates)
+        {
+            // We only use guids to find classes in YAML files
+            if (elements.All(e => e is IClass))
+                return new YamlReferenceSearcher(elements, findCandidates);
+            return null;
+        }
+
+        // Used to filter files before searching for reference
+        public override IEnumerable<string> GetAllPossibleWordsInFile(IDeclaredElement element)
+        {
+            // The existing YAML domain searcher word list will find all files that contain the element's short name,
+            // but won't find files that just have an asset guid
+            var metaFileGuidCache = element.GetSolution().GetComponent<MetaFileGuidCache>();
+            var words = new FrugalLocalList<string>();
+            foreach (var sourceFile in element.GetSourceFiles())
+            {
+                var guid = metaFileGuidCache.GetAssetGuid(sourceFile);
+                if (guid != null)
+                    words.Add(guid);
+            }
+
+            return words.ToList();
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityObjectPsiUtil.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityObjectPsiUtil.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.Util.dataStructures;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
+{
+    public static class UnityObjectPsiUtil
+    {
+        [NotNull]
+        public static string GetComponentName([NotNull] IYamlDocument componentDocument)
+        {
+            // If name is null, and fileid is external, just use component type ("MonoBehaviour")
+            var name = componentDocument.GetUnityObjectPropertyValue("m_Name").AsString();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                var scriptDocument = componentDocument.GetUnityObjectDocumentFromFileIDProperty("m_Script");
+                if (scriptDocument == null)
+                    return componentDocument.GetUnityObjectTypeFromRootNode() ?? "Component";
+
+                return scriptDocument.GetUnityObjectPropertyValue("m_Name").AsString()
+                       ?? scriptDocument.GetUnityObjectTypeFromRootNode()
+                       ?? "Component";
+            }
+            return name;
+        }
+
+        [NotNull]
+        public static string GetGameObjectPath([NotNull] IYamlDocument componentDocument)
+        {
+            // component.m_GameObject gives fileID
+            // gameObject.m_Component.component[i] is fileID to RectTransform
+            // transform.m_Father gives fileID to parent RectTransform
+            // parent.m_GameObject gives fileID to parent
+            // gameObject.m_Name is name
+            var parts = new FrugalLocalList<string>();
+
+            var gameObjectDocument = componentDocument.GetUnityObjectDocumentFromFileIDProperty("m_GameObject");
+            do
+            {
+                var name = gameObjectDocument.GetUnityObjectPropertyValue("m_Name").AsString() ?? "GameObject";
+                parts.Add(name);
+                gameObjectDocument = GetParentGameObject(gameObjectDocument);
+            } while (gameObjectDocument != null);
+
+            // This will only happen if the given component doesn't have a game object, which is weird
+            if (parts.Count == 0)
+                return "GameObject";
+
+            if (parts.Count == 1)
+                return parts[0];
+
+            var sb = new StringBuilder();
+            for (var i = parts.Count - 1; i >= 0; i--)
+            {
+                sb.Append(parts[i]);
+                sb.Append("\\");
+            }
+
+            return sb.ToString();
+        }
+
+        [CanBeNull]
+        private static IYamlDocument FindTransformComponentForGameObject([CanBeNull] IYamlDocument gameObjectDocument)
+        {
+            // GameObject:
+            //   m_Component:
+            //   - component: {fileID: 1234567890}
+            //   - component: {fileID: 1234567890}
+            //   - component: {fileID: 1234567890}
+            // One of these components is the RectTransform. Most likely the first, but we can't rely on order
+            if (gameObjectDocument?.GetUnityObjectPropertyValue("m_Component") is IBlockSequenceNode components)
+            {
+                var file = (IYamlFile) gameObjectDocument.GetContainingFile();
+
+                foreach (var componentEntry in components.EntriesEnumerable)
+                {
+                    // - component: {fileID: 1234567890}
+                    var componentNode = componentEntry.Value as IBlockMappingNode;
+                    var componentFileID = componentNode?.EntriesEnumerable.FirstOrDefault()?.Value.AsFileID();
+                    if (componentFileID != null && !componentFileID.IsNullReference && !componentFileID.IsExternal)
+                    {
+                        var component = file.FindDocumentByAnchor(componentFileID.fileID);
+                        if (component.GetUnityObjectTypeFromRootNode() == "RectTransform")
+                            return component;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private static IYamlDocument GetParentGameObject([CanBeNull] IYamlDocument gameObjectDocument)
+        {
+            var transformDocument = FindTransformComponentForGameObject(gameObjectDocument);
+            var parentTransformDocument = transformDocument.GetUnityObjectDocumentFromFileIDProperty("m_Father");
+            return parentTransformDocument.GetUnityObjectDocumentFromFileIDProperty("m_GameObject");
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
@@ -22,6 +22,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
         // Is external to the current file. True if there's an asset GUID
         public bool IsExternal => guid != null;
 
+        // The static value that represents a MonoScript asset (C# scripts can't have an ID inside the file)
+        public bool IsMonoScript => fileID == "11500000";
+
         public FileID(string guid, string fileID)
         {
             this.guid = guid;

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
@@ -2,7 +2,7 @@ using JetBrains.Annotations;
 using JetBrains.ReSharper.Plugins.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 
-namespace JetBrains.ReSharper.Plugins.Unity.Yaml
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
 {
     // ReSharper disable InconsistentNaming
     public class FileID

--- a/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using JetBrains.Application.UI.Icons.Special.ThemedIcons;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
@@ -14,7 +15,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
     [SolutionComponent]
     public class UnityYamlExtraGroupingRulesProvider : IRiderExtraGroupingRulesProvider
     {
-        public UnityYamlExtraGroupingRulesProvider(IconHost iconHost)
+        // IconHost is optional so that we don't fail if we're in tests
+        public UnityYamlExtraGroupingRulesProvider(IconHost iconHost = null)
         {
             ExtraRules = new IRiderUsageGroupingRule[]
             {
@@ -28,9 +30,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
 
     public abstract class UnityYamlUsageGroupingRuleBase : IRiderUsageGroupingRule
     {
-        private readonly IconHost myIconHost;
+        [CanBeNull] private readonly IconHost myIconHost;
 
-        protected UnityYamlUsageGroupingRuleBase(string name, IconId iconId, IconHost iconHost, double sortingPriority)
+        protected UnityYamlUsageGroupingRuleBase(string name, IconId iconId, [CanBeNull] IconHost iconHost,
+            double sortingPriority)
         {
             Name = name;
             IconId = iconId;
@@ -40,7 +43,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
 
         protected RdUsageGroup CreateModel(string text)
         {
-            return new RdUsageGroup(Name, text, myIconHost.Transform(IconId));
+            return new RdUsageGroup(Name, text, myIconHost?.Transform(IconId));
         }
 
         protected RdUsageGroup EmptyModel()
@@ -64,7 +67,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
     public class GameObjectUsageGroupingRule : UnityYamlUsageGroupingRuleBase
     {
         // TODO: Proper icon
-        public GameObjectUsageGroupingRule(IconHost iconHost)
+        public GameObjectUsageGroupingRule([CanBeNull] IconHost iconHost)
             : base("Unity Game Object", SpecialThemedIcons.Placeholder.Id, iconHost, 7.0)
         {
         }
@@ -90,7 +93,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
     public class ComponentUsageGroupingRule : UnityYamlUsageGroupingRuleBase
     {
         // TODO: Proper icon
-        public ComponentUsageGroupingRule(IconHost iconHost)
+        public ComponentUsageGroupingRule([CanBeNull] IconHost iconHost)
             : base("Unity Component", SpecialThemedIcons.Placeholder.Id, iconHost, 8.0)
         {
         }

--- a/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
@@ -72,7 +72,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
         public override RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor)
         {
             if (occurrence is ReferenceOccurrence referenceOccurrence &&
-                referenceOccurrence.PrimaryReference is UnityEventTargetReference reference)
+                referenceOccurrence.PrimaryReference is IUnityYamlReference reference)
             {
                 return CreateModel(UnityObjectPsiUtil.GetGameObjectPath(reference.ComponentDocument));
             }
@@ -98,7 +98,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
         public override RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor)
         {
             if (occurrence is ReferenceOccurrence referenceOccurrence &&
-                referenceOccurrence.PrimaryReference is UnityEventTargetReference reference)
+                referenceOccurrence.PrimaryReference is IUnityYamlReference reference)
             {
                 return CreateModel(UnityObjectPsiUtil.GetComponentName(reference.ComponentDocument));
             }

--- a/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
@@ -1,0 +1,116 @@
+using JetBrains.Application.UI.Icons.Special.ThemedIcons;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Occurrences;
+using JetBrains.ReSharper.Feature.Services.Tree;
+using JetBrains.ReSharper.Host.Features.Icons;
+using JetBrains.ReSharper.Host.Features.Usages;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;
+using JetBrains.Rider.Model;
+using JetBrains.UI.Icons;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
+{
+    [SolutionComponent]
+    public class UnityYamlExtraGroupingRulesProvider : IRiderExtraGroupingRulesProvider
+    {
+        public UnityYamlExtraGroupingRulesProvider(IconHost iconHost)
+        {
+            ExtraRules = new IRiderUsageGroupingRule[]
+            {
+                new GameObjectUsageGroupingRule(iconHost),
+                new ComponentUsageGroupingRule(iconHost)
+            };
+        }
+
+        public IRiderUsageGroupingRule[] ExtraRules { get; }
+    }
+
+    public abstract class UnityYamlUsageGroupingRuleBase : IRiderUsageGroupingRule
+    {
+        private readonly IconHost myIconHost;
+
+        protected UnityYamlUsageGroupingRuleBase(string name, IconId iconId, IconHost iconHost, double sortingPriority)
+        {
+            Name = name;
+            IconId = iconId;
+            SortingPriority = sortingPriority;
+            myIconHost = iconHost;
+        }
+
+        protected RdUsageGroup CreateModel(string text)
+        {
+            return new RdUsageGroup(Name, text, myIconHost.Transform(IconId));
+        }
+
+        protected RdUsageGroup EmptyModel()
+        {
+            return new RdUsageGroup(Name, string.Empty, null);
+        }
+
+        public abstract RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor);
+        public abstract void Navigate(IOccurrence occurrence);
+
+        public string Name { get; }
+        public IconId IconId { get; }
+        public bool IsSeparable => true;
+        public abstract bool IsNavigateable { get; }
+        public bool Configurable => true;
+        public bool PriorityDependsOnUsages => true;
+        public double SortingPriority { get; }
+    }
+
+    // The priorities here put us after directory, file, namespace, type and member
+    public class GameObjectUsageGroupingRule : UnityYamlUsageGroupingRuleBase
+    {
+        // TODO: Proper icon
+        public GameObjectUsageGroupingRule(IconHost iconHost)
+            : base("Unity Game Object", SpecialThemedIcons.Placeholder.Id, iconHost, 7.0)
+        {
+        }
+
+        public override RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor)
+        {
+            if (occurrence is ReferenceOccurrence referenceOccurrence &&
+                referenceOccurrence.PrimaryReference is UnityEventTargetReference reference)
+            {
+                return CreateModel(UnityObjectPsiUtil.GetGameObjectPath(reference.ComponentDocument));
+            }
+            return EmptyModel();
+        }
+
+        public override void Navigate(IOccurrence occurrence)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override bool IsNavigateable => false;
+    }
+
+    public class ComponentUsageGroupingRule : UnityYamlUsageGroupingRuleBase
+    {
+        // TODO: Proper icon
+        public ComponentUsageGroupingRule(IconHost iconHost)
+            : base("Unity Component", SpecialThemedIcons.Placeholder.Id, iconHost, 8.0)
+        {
+        }
+
+        public override RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor)
+        {
+            if (occurrence is ReferenceOccurrence referenceOccurrence &&
+                referenceOccurrence.PrimaryReference is UnityEventTargetReference reference)
+            {
+                return CreateModel(UnityObjectPsiUtil.GetComponentName(reference.ComponentDocument));
+            }
+
+            return EmptyModel();
+        }
+
+        public override void Navigate(IOccurrence occurrence)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override bool IsNavigateable => false;
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml
@@ -25,12 +26,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             return AllFileExtensionsWithDot.Contains(extensionWithDot, StringComparer.InvariantCultureIgnoreCase);
         }
 
-        public static bool IsAsset(FileSystemPath path)
+        public static bool IsAsset([NotNull] FileSystemPath path)
         {
             return AssetFileExtensionsWithDot.Contains(path.ExtensionWithDot, StringComparer.InvariantCultureIgnoreCase);
         }
 
-        public static bool IsMeta(FileSystemPath path)
+        public static bool IsMeta([NotNull] FileSystemPath path)
         {
             return string.Equals(path.ExtensionWithDot, MetaFileExtensionWithDot,
                 StringComparison.InvariantCultureIgnoreCase);

--- a/resharper/resharper-unity/src/Yaml/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/UnityYamlPsiExtensions.cs
@@ -1,0 +1,112 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Plugins.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml
+{
+    // ReSharper disable InconsistentNaming
+    public class FileID
+    {
+        public static readonly FileID Null = new FileID(null, "0");
+
+        public readonly string guid;
+        public readonly string fileID;
+        // public string type;    // I don't know what this type means
+
+        // Equivalent to a null pointer. We have null and IsNullReference, because null indicates missing (we've
+        // probably parsed something wrong), while  IsNullReference indicates that it's explicitly set to null
+        public bool IsNullReference => this == Null || fileID == "0";
+
+        public FileID(string guid, string fileID)
+        {
+            this.guid = guid;
+            this.fileID = fileID;
+        }
+
+        public override string ToString()
+        {
+            return $"FileID: {fileID}, {guid ?? " <no guid> "}";
+        }
+    }
+    // ReSharper restore InconsistentNaming
+
+    public static class UnityYamlPsiExtensions
+    {
+        [CanBeNull]
+        public static IYamlDocument FindDocumentByAnchor([CanBeNull] this IYamlFile file, [CanBeNull] string anchor)
+        {
+            if (file == null || anchor == null)
+                return null;
+
+            foreach (var document in file.DocumentsEnumerable)
+            {
+                var properties = GetDocumentBlockNodeProperties(document.BlockNode);
+                var text = properties?.AnchorProperty?.Text?.GetText() ?? string.Empty;
+                if (text == anchor)
+                    return document;
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        public static string AsString([CanBeNull] this INode node)
+        {
+            return node?.GetPlainScalarText();
+        }
+
+        [CanBeNull]
+        public static FileID AsFileID([CanBeNull] this INode node)
+        {
+            if (node is IFlowMappingNode flowMappingNode)
+            {
+                var fileID = flowMappingNode.FindMapEntryBySimpleKey("fileID")?.Value.AsString();
+                if (fileID == "0")
+                    return FileID.Null;
+                var guid = flowMappingNode.FindMapEntryBySimpleKey("guid")?.Value.AsString();
+                return new FileID(guid, fileID);
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        public static INode GetUnityObjectPropertyValue([CanBeNull] this IYamlDocument document, [NotNull] string key)
+        {
+            return FindRootBlockMapEntries(document).FindMapEntryBySimpleKey(key)?.Value;
+        }
+
+        [CanBeNull]
+        public static string GetUnityObjectTypeFromRootNode([CanBeNull] this IYamlDocument document)
+        {
+            // E.g.
+            // --- !u!114 &293532596
+            // MonoBehaviour:
+            //   m_ObjectHideFlags: 0
+            // This will return "MonoBehaviour"
+            // (Note that !u!114 is the actual type of this object - MonoBehaviour -
+            // https://docs.unity3d.com/Manual/ClassIDReference.html)
+            var rootBlockMappingNode = document?.BlockNode as IBlockMappingNode;
+            return rootBlockMappingNode?.EntriesEnumerable.FirstOrDefault()?.Key.AsString();
+        }
+
+        [CanBeNull]
+        private static INodeProperties GetDocumentBlockNodeProperties([CanBeNull] INode documentBlockNode)
+        {
+            if (documentBlockNode is IBlockSequenceNode sequenceNode)
+                return sequenceNode.Properties;
+            if (documentBlockNode is IBlockMappingNode mappingNode)
+                return mappingNode.Properties;
+            return null;
+        }
+
+        [CanBeNull]
+        private static IBlockMappingNode FindRootBlockMapEntries([CanBeNull] this IYamlDocument document)
+        {
+            // A YAML document is a block mapping node with a single entry. The key is usually the type of the object,
+            // while the value is another block mapping node. Those entries are the properties of the Unity object
+            var rootBlockMappingNode = document?.BlockNode as IBlockMappingNode;
+            return rootBlockMappingNode?.EntriesEnumerable.FirstOrDefault()?.Value as IBlockMappingNode;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/rider-unity.csproj.DotSettings
+++ b/resharper/resharper-unity/src/rider-unity.csproj.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=annotations/@EntryIndexedValue">False</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shaderlab_005Cdaemon_005Ccontexthighlighters_005Crider/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shaderlab_005Cdaemon_005Ccontexthighlighters_005Crider/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=yaml_005Crider/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 
 public class A : MonoBehaviour
 {
-  // Potential event handler - marked as in use
+  // Potential event handler, but YAML is enabled and a reference isn't found
+  // Should be unused
   public void UnusedMethod()
   {
   }

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.gold
@@ -5,12 +5,13 @@ using UnityEngine;
 
 public class A : MonoBehaviour
 {
-  // Potential event handler - marked as in use
-  public void UnusedMethod()
+  // Potential event handler, but YAML is enabled and a reference isn't found
+  // Should be unused
+  public void |UnusedMethod|(0)()
   {
   }
 
-  private void |UnusedPrivateMethod|(0)()
+  private void |UnusedPrivateMethod|(1)()
   {
   }
 
@@ -31,18 +32,18 @@ public class A : MonoBehaviour
   }
 
   // Should be unused - invalid parameters!
-  public void |OnAudioFilterRead|(1)|()|(2)
+  public void |OnAudioFilterRead|(2)|()|(3)
   {
   }
 
   // Should be unused - invalid return type!
-  public |bool|(3) |FixedUpdate|(4)()
+  public |bool|(4) |FixedUpdate|(5)()
   {
       return true;
   }
 
   // Should be unused - invalid static modifier!
-  public |static|(5) void |LateUpdate|(6)()
+  public |static|(6) void |LateUpdate|(7)()
   {
   }
 
@@ -52,7 +53,7 @@ public class A : MonoBehaviour
   }
 
   // Should mark collisionInfo as unused
-  public void OnCollisionExit(Collision |collisionInfo|(7))
+  public void OnCollisionExit(Collision |collisionInfo|(8))
   {
   }
 
@@ -64,12 +65,13 @@ public class A : MonoBehaviour
 }
 
 ---------------------------------------------------------
-(0): ReSharper Dead Code: Method 'UnusedPrivateMethod' is never used
-(1): ReSharper Dead Code: Method 'OnAudioFilterRead' is never used
-(2): ReSharper Warning: Incorrect method parameters. Expected '(float[] data, int channels)'
-(3): ReSharper Warning: Incorrect return type. Expected 'void'
-(4): ReSharper Dead Code: Method 'FixedUpdate' is never used
-(5): ReSharper Warning: Incorrect static modifier
-(6): ReSharper Dead Code: Method 'LateUpdate' is never used
-(7): ReSharper Dead Code: Parameter 'collisionInfo' is never used
+(0): ReSharper Dead Code: Method 'UnusedMethod' is never used
+(1): ReSharper Dead Code: Method 'UnusedPrivateMethod' is never used
+(2): ReSharper Dead Code: Method 'OnAudioFilterRead' is never used
+(3): ReSharper Warning: Incorrect method parameters. Expected '(float[] data, int channels)'
+(4): ReSharper Warning: Incorrect return type. Expected 'void'
+(5): ReSharper Dead Code: Method 'FixedUpdate' is never used
+(6): ReSharper Warning: Incorrect static modifier
+(7): ReSharper Dead Code: Method 'LateUpdate' is never used
+(8): ReSharper Dead Code: Parameter 'collisionInfo' is never used
 

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsSerializationNotText.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsSerializationNotText.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 // ReSharper disable ArrangeAccessorOwnerBody
 // ReSharper disable ConvertToAutoProperty
+
+// Only applicable when YAML supported is disabled
 public class A : MonoBehaviour
 {
   private string myThing;

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsSerializationNotText.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsSerializationNotText.gold
@@ -3,6 +3,8 @@ using UnityEngine;
 
 // ReSharper disable ArrangeAccessorOwnerBody
 // ReSharper disable ConvertToAutoProperty
+
+// Only applicable when YAML supported is disabled
 public class A : MonoBehaviour
 {
   private string myThing;

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsYamlDisabled.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsYamlDisabled.cs
@@ -1,0 +1,50 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable ArrangeAccessorOwnerBody
+// ReSharper disable ConvertToAutoProperty
+
+// Only applicable when YAML supported is disabled
+public class A : MonoBehaviour
+{
+  private string myThing;
+  private static string ourThing;
+
+  public void PotentialEventHandler()
+  {
+  }
+
+  public void PotentialEventHandler(string s, int i)
+  {
+  }
+
+  public string SetterPotentialEventHandler
+  {
+      get { return myThing; }
+      set { myThing = value; }
+  }
+
+  private void WrongAccessibility()
+  {
+  }
+
+  public string WrongReturnType()
+  {
+      return "Hello";
+  }
+
+  public static void WrongStatic()
+  {
+  }
+
+  public static string WrongStaticProperty
+  {
+      get { return ourThing; }
+      set { ourThing = value; }
+  }
+
+  [Obsolete]
+  public void ObsoleteNotConsidered()
+  {
+  }
+}

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsYamlDisabled.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/PotentialEventHandlerMethodsYamlDisabled.gold
@@ -1,0 +1,59 @@
+﻿using System;
+using UnityEngine;
+
+// ReSharper disable ArrangeAccessorOwnerBody
+// ReSharper disable ConvertToAutoProperty
+
+// Only applicable when YAML supported is disabled
+public class A : MonoBehaviour
+{
+  private string myThing;
+  private static string ourThing;
+
+  public void PotentialEventHandler()
+  {
+  }
+
+  public void PotentialEventHandler(string s, int i)
+  {
+  }
+
+  public string SetterPotentialEventHandler
+  {
+      |get|(0) { return myThing; }
+      set { myThing = value; }
+  }
+
+  private void |WrongAccessibility|(1)()
+  {
+  }
+
+  public string |WrongReturnType|(2)()
+  {
+      return "Hello";
+  }
+
+  public static void |WrongStatic|(3)()
+  {
+  }
+
+  public static string |WrongStaticProperty|(4)
+  {
+      get { return ourThing; }
+      set { ourThing = value; }
+  }
+
+  [Obsolete]
+  public void |ObsoleteNotConsidered|(5)()
+  {
+  }
+}
+
+---------------------------------------------------------
+(0): ReSharper Dead Code: Accessor 'SetterPotentialEventHandler.get' is never used
+(1): ReSharper Dead Code: Method 'WrongAccessibility' is never used
+(2): ReSharper Dead Code: Method 'WrongReturnType' is never used
+(3): ReSharper Dead Code: Method 'WrongStatic' is never used
+(4): ReSharper Dead Code: Property 'WrongStaticProperty' is never used
+(5): ReSharper Dead Code: Method 'ObsoleteNotConsidered' is never used
+

--- a/resharper/resharper-unity/test/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
@@ -1,3 +1,8 @@
+using System;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Tests.Yaml;
+using JetBrains.ReSharper.Plugins.Unity.Yaml;
+using JetBrains.ReSharper.Plugins.Yaml.Settings;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.UsageChecking
@@ -6,10 +11,68 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.UsageChecking
     public class UsageInspectionsSuppressorTest : UsageCheckBaseTest
     {
         protected override string RelativeTestDataPath => @"CSharp\Daemon\UsageChecking";
+        private Action<IProject> myOnProjectStarted;
+        private Action<IProject> myOnProjectFinished;
 
         [Test] public void MonoBehaviourMethods01() { DoNamedTest(); }
         [Test] public void MonoBehaviourFields01() { DoNamedTest(); }
-        [Test] public void PotentialEventHandlerMethods() { DoNamedTest(); }
         [Test] public void SerializableClassFields01() { DoNamedTest(); }
+
+        protected override void DoTest(IProject project)
+        {
+            myOnProjectStarted?.Invoke(project);
+            try
+            {
+                base.DoTest(project);
+            }
+            finally
+            {
+                myOnProjectFinished?.Invoke(project);
+            }
+
+            myOnProjectStarted = myOnProjectFinished = null;
+        }
+
+        [Test]
+        public void PotentialEventHandlerMethodsYamlDisabled()
+        {
+            // TODO: Support testing when YAML is enabled
+            // It's currently enabled by default, but nothing is processed, because the PSI module is disabled to work
+            // around a R# issue
+            var oldValue = false;
+            myOnProjectStarted = project =>
+            {
+                var yamlSupport = project.GetSolution().GetComponent<YamlSupport>();
+                oldValue = yamlSupport.IsParsingEnabled.Value;
+                yamlSupport.IsParsingEnabled.Value = false;
+            };
+
+            myOnProjectFinished = project =>
+            {
+                var yamlSupport = project.GetSolution().GetComponent<YamlSupport>();
+                yamlSupport.IsParsingEnabled.Value = oldValue;
+            };
+
+            DoNamedTest();
+        }
+
+        [Test]
+        public void PotentialEventHandlerMethodsSerializationNotText()
+        {
+            var oldMode = AssetSerializationMode.SerializationMode.Unknown;
+            myOnProjectStarted = project =>
+            {
+                var assetSerializationMode = Solution.GetComponent<TestableAssetSerializationMode>();
+                oldMode = assetSerializationMode.SetMode(AssetSerializationMode.SerializationMode.Mixed);
+            };
+
+            myOnProjectFinished = project =>
+            {
+                var assetSerializationMode = Solution.GetComponent<TestableAssetSerializationMode>();
+                assetSerializationMode.SetMode(oldMode);
+            };
+
+            DoNamedTest();
+        }
     }
 }

--- a/resharper/resharper-unity/test/src/Yaml/TestableAssetSerializationMode.cs
+++ b/resharper/resharper-unity/test/src/Yaml/TestableAssetSerializationMode.cs
@@ -1,0 +1,23 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests.Yaml
+{
+    [SolutionComponent]
+    public class TestableAssetSerializationMode : AssetSerializationMode
+    {
+        public TestableAssetSerializationMode(ISolution solution, ILogger logger)
+            : base(solution, logger)
+        {
+            Mode = SerializationMode.ForceText;
+        }
+
+        public SerializationMode SetMode(SerializationMode mode)
+        {
+            var oldMode = Mode;
+            Mode = mode;
+            return oldMode;
+        }
+    }
+}

--- a/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
+++ b/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
@@ -12,8 +12,11 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     }
 
     [CanBeNull]
-    public static IBlockMappingEntry FindChildBySimpleKey(this IBlockMappingNode mapNode, string keyName)
+    public static IBlockMappingEntry FindMapEntryBySimpleKey([CanBeNull] this IBlockMappingNode mapNode, string keyName)
     {
+      if (mapNode == null)
+        return null;
+
       foreach (var mappingEntry in mapNode.EntriesEnumerable)
       {
         if (mappingEntry.Key.GetPlainScalarText() == keyName)
@@ -24,9 +27,12 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     }
 
     [CanBeNull]
-    public static IFlowMapEntry FindChildBySimpleKey(this IFlowMappingNode mapNode, string keyName)
+    public static IFlowMapEntry FindMapEntryBySimpleKey([CanBeNull] this IFlowMappingNode mapNode, string keyName)
     {
-      foreach (var sequenceEntry in mapNode.EntriesEnumerable)
+      if (mapNode == null)
+        return null;
+
+      foreach (var sequenceEntry in mapNode?.EntriesEnumerable)
       {
         if (sequenceEntry.Key.GetPlainScalarText() == keyName)
           return sequenceEntry;

--- a/resharper/resharper-yaml/src/Psi/Search/YamlUsageSearchFactory.cs
+++ b/resharper/resharper-yaml/src/Psi/Search/YamlUsageSearchFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.ExtensionsAPI;
 using JetBrains.ReSharper.Psi.Impl.Search.SearchDomain;
@@ -19,9 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi.Search
 
     public IDomainSpecificSearcher CreateReferenceSearcher(IDeclaredElementsSet elements, bool findCandidates)
     {
-      if (elements.All(e => e is IMethod))
-        return new YamlReferenceSearcher(elements, findCandidates);
-      return null;
+      return new YamlReferenceSearcher(elements, findCandidates);
     }
 
     // Used to filter files before searching for references

--- a/resharper/resharper-yaml/src/Settings/YamlSettings.cs
+++ b/resharper/resharper-yaml/src/Settings/YamlSettings.cs
@@ -6,8 +6,7 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Settings
   [SettingsKey(typeof(CodeEditingSettings), "Yaml plugin settings")]
   public class YamlSettings
   {
-    // NOTE: Disabled by default!
-    [SettingsEntry(false, "Enables syntax error highlighting, brace matching and more of YAML files.")]
+    [SettingsEntry(true, "Enables syntax error highlighting, brace matching and more of YAML files.")]
     public bool EnableYamlParsing;
   }
 }

--- a/resharper/resharper-yaml/test/src/UnityTestsSpecificYamlFileExtensionMapping.cs
+++ b/resharper/resharper-yaml/test/src/UnityTestsSpecificYamlFileExtensionMapping.cs
@@ -44,13 +44,4 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Tests
 
     public ISimpleSignal Changed { get; }
   }
-
-  [ShellComponent]
-  public class EnsureEnabledForTests
-  {
-    public EnsureEnabledForTests(YamlSupport yamlSupport)
-    {
-      yamlSupport.IsParsingEnabled.SetValue(true);
-    }
-  }
 }

--- a/rider/src/main/resources/META-INF/PluginYamlPluginPart.xml
+++ b/rider/src/main/resources/META-INF/PluginYamlPluginPart.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <lang.syntaxHighlighterFactory language="UnityYaml" implementationClass="org.jetbrains.yaml.YAMLSyntaxHighlighterFactory" />
+    </extensions>
+</idea-plugin>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
   <idea-version since-build="173.3389" until-build="173.3389.*" />
 
   <depends>com.intellij.modules.rider</depends>
+  <depends optional="true" config-file="PluginYamlPluginPart.xml">org.jetbrains.plugins.yaml</depends>
   <depends optional="true" config-file="PluginAppenderPluginPart.xml">rider.intellij.plugin.appender</depends>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
* Support references in all asset types, not just scenes
* Group by type for event handler references in Find Usages - "Unity event handler"
* Group by type for component usage in assets - "Unity component usage"
* Group results by component and parent game objects
* Lexer based syntax highlighter for Unity YAML types (`.asset`, `.unity`, `.prefab` and `.meta` only)
* Add references for `MonoBehaviour` usage in Unity YAML types (e.g. using a script as a component)
* YAML parsing is now on by default
* Asset files only parsed if text serialisation is enabled for the project
* Disable rename refactoring for UnityEvent handlers. We'll implement it properly later (#906)