### PR TITLE
Updates to cache handling and property event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ rider/.idea/**/libraries
 # NOTE: We normally include *.iml for JetBrains IDEs, but Gradle based projects auto generate
 # this on import, so we can happily ignore them. Don't do this for the Rider controlled project!
 rider/.idea/**/modules.xml
-rider/.idea/**/modules/**/*.iml
+rider/.idea/**/*.iml
 rider/.idea/**/compiler.xml
 
 
@@ -94,7 +94,4 @@ UpgradeLog*.XML
 Thumbs.db
 Desktop.ini
 .DS_Store
-rider/.idea/.name
-rider/.idea/encodings.xml
-rider/.idea/gradle.xml
-rider/.idea/rider.iml
+

--- a/resharper/.idea/.idea.resharper-unity/.idea/encodings.xml
+++ b/resharper/.idea/.idea.resharper-unity/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/resharper/.idea/.idea.resharper-unity/.idea/misc.xml
+++ b/resharper/.idea/.idea.resharper-unity/.idea/misc.xml
@@ -3,4 +3,7 @@
   <component name="TaskProjectConfiguration">
     <server type="GitHub" url="https://github.com" />
   </component>
+  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
+    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
+  </component>
 </project>

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityFieldDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityFieldDetector.cs
@@ -2,37 +2,36 @@ using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings;
-#if RIDER
-using JetBrains.ReSharper.Plugins.Unity.Rider.CodeInsights;
-#endif
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.GutterMarks
 {
     [ElementProblemAnalyzer(typeof(IFieldDeclaration), HighlightingTypes = new[]
     {
-#if RIDER
-            typeof(UnityCodeInsightsHighlighting)
-#else
         typeof(UnityGutterMarkInfo),
+#if RIDER
+        typeof(Rider.CodeInsights.UnityCodeInsightsHighlighting)
 #endif
     })]
     public class UnityFieldDetector : UnityElementProblemAnalyzer<IFieldDeclaration>
     {
         private readonly UnityImplicitUsageHighlightingContributor myImplicitUsageHighlightingContributor;
 
-        public UnityFieldDetector(UnityApi unityApi, UnityImplicitUsageHighlightingContributor implicitUsageHighlightingContributor)
+        public UnityFieldDetector(UnityApi unityApi,
+                                  UnityImplicitUsageHighlightingContributor implicitUsageHighlightingContributor)
             : base(unityApi)
         {
             myImplicitUsageHighlightingContributor = implicitUsageHighlightingContributor;
         }
 
-        protected override void Analyze(IFieldDeclaration element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
+        protected override void Analyze(IFieldDeclaration element, ElementProblemAnalyzerData data,
+                                        IHighlightingConsumer consumer)
         {
             var field = element.DeclaredElement;
             if (field != null && Api.IsSerialisedField(field))
             {
-                myImplicitUsageHighlightingContributor.AddUnityImplicitFieldUsage(consumer, element, "This field is initialised by Unity");
+                myImplicitUsageHighlightingContributor.AddUnityImplicitFieldUsage(consumer, element,
+                    "This field is initialised by Unity");
             }
         }
     }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityInitialiseOnLoadCctorDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityInitialiseOnLoadCctorDetector.cs
@@ -2,40 +2,41 @@ using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings;
-#if RIDER
-using JetBrains.ReSharper.Plugins.Unity.Rider.CodeInsights;
-#endif
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.GutterMarks
 {
     [ElementProblemAnalyzer(typeof(IConstructorDeclaration), HighlightingTypes = new[]
     {
-#if RIDER
-            typeof(UnityCodeInsightsHighlighting)
-#else
         typeof(UnityGutterMarkInfo),
+#if RIDER
+        typeof(Rider.CodeInsights.UnityCodeInsightsHighlighting)
 #endif
     })]
     public class UnityInitialiseOnLoadCctorDetector : UnityElementProblemAnalyzer<IConstructorDeclaration>
     {
         private readonly UnityImplicitUsageHighlightingContributor myImplicitUsageHighlightingContributor;
 
-        public UnityInitialiseOnLoadCctorDetector(UnityApi unityApi, UnityImplicitUsageHighlightingContributor implicitUsageHighlightingContributor)
+        public UnityInitialiseOnLoadCctorDetector(UnityApi unityApi,
+                                                  UnityImplicitUsageHighlightingContributor
+                                                      implicitUsageHighlightingContributor)
             : base(unityApi)
         {
             myImplicitUsageHighlightingContributor = implicitUsageHighlightingContributor;
         }
 
-        protected override void Analyze(IConstructorDeclaration element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
+        protected override void Analyze(IConstructorDeclaration element, ElementProblemAnalyzerData data,
+                                        IHighlightingConsumer consumer)
         {
             if (!element.IsStatic)
                 return;
 
             var containingType = element.GetContainingTypeDeclaration()?.DeclaredElement;
-            if (containingType != null && containingType.HasAttributeInstance(KnownTypes.InitializeOnLoadAttribute, false))
+            if (containingType != null &&
+                containingType.HasAttributeInstance(KnownTypes.InitializeOnLoadAttribute, false))
             {
-                myImplicitUsageHighlightingContributor.AddInitializeOnLoadMethod(consumer, element, "Called when Unity first launches the editor, the player, or recompiles scripts");
+                myImplicitUsageHighlightingContributor.AddInitializeOnLoadMethod(consumer, element,
+                    "Called when Unity first launches the editor, the player, or recompiles scripts");
             }
         }
     }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityTypeDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/GutterMarks/UnityTypeDetector.cs
@@ -2,19 +2,15 @@ using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings;
-#if RIDER
-using JetBrains.ReSharper.Plugins.Unity.Rider.CodeInsights;
-#endif
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.GutterMarks
 {
     [ElementProblemAnalyzer(typeof(IClassLikeDeclaration), HighlightingTypes = new[]
     {
-#if RIDER
-            typeof(UnityCodeInsightsHighlighting)
-#else
         typeof(UnityGutterMarkInfo),
+#if RIDER
+        typeof(Rider.CodeInsights.UnityCodeInsightsHighlighting)
 #endif
     })]
     public class UnityTypeDetector : UnityElementProblemAnalyzer<IClassLikeDeclaration>
@@ -28,18 +24,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.GutterMarks
         }
 
         protected override void Analyze(IClassLikeDeclaration element, ElementProblemAnalyzerData data,
-            IHighlightingConsumer consumer)
+                                        IHighlightingConsumer consumer)
         {
             var typeElement = element.DeclaredElement;
             if (typeElement != null)
             {
                 if (Api.IsUnityType(typeElement))
                 {
-                    myImplicitUsageHighlightingContributor.AddUnityImplicitClassUsage(consumer, element, "Unity scripting component");
+                    myImplicitUsageHighlightingContributor.AddUnityImplicitClassUsage(consumer, element,
+                        "Unity scripting component");
                 }
                 else if (Api.IsSerializableType(typeElement))
                 {
-                    myImplicitUsageHighlightingContributor.AddUnityImplicitClassUsage(consumer, element, "Unity custom serializable type");
+                    myImplicitUsageHighlightingContributor.AddUnityImplicitClassUsage(consumer, element,
+                        "Unity custom serializable type");
                 }
             }
         }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/GenerateUnityEventFunctionsFix.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/GenerateUnityEventFunctionsFix.cs
@@ -1,3 +1,4 @@
+using JetBrains.ReSharper.Feature.Services.Generate;
 using JetBrains.ReSharper.Intentions.CSharp.QuickFixes;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Generate;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
@@ -19,5 +20,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
         }
 
         public override string Text => "Generate Unity event functions";
+
+        protected override void ConfigureContext(IGeneratorContext context)
+        {
+            // Do nothing. Calling base will add all values into InputElements, which means EVERYTHING is checked to be
+            // implemented, which never makes sense for our list of event functions.
+            // This base class is essentially for a Quick Fix that is to implement missing members, while we're really
+            // using it like a Context Action
+        }
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
@@ -19,6 +19,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
                 return eventHandlerCache.IsEventHandler(method);
             }
 
+
+            // TODO: Renaming properties
+
             return false;
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
@@ -28,9 +28,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         public MetaFileGuidCache(Lifetime lifetime, IPersistentIndexManager persistentIndexManager)
             : base(lifetime, persistentIndexManager, MetaFileCacheItem.Marshaller)
         {
-#if DEBUG
-            ClearOnLoad = true;
-#endif
         }
 
         // This will usually return a single value, but there's always a chance for copy/paste
@@ -87,41 +84,43 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
 
         public override void Merge(IPsiSourceFile sourceFile, object builtPart)
         {
-            if (builtPart == null)
-                CleanLocalCache(sourceFile);
-
+            RemoveFromLocalCache(sourceFile);
+            AddToLocalCache(sourceFile, builtPart as MetaFileCacheItem);
             base.Merge(sourceFile, builtPart);
-            PopulateLocalCache(sourceFile, builtPart as MetaFileCacheItem);
         }
 
         public override void MergeLoaded(object data)
         {
             base.MergeLoaded(data);
-
-            foreach (var (psiSourceFile, cacheItem) in Map)
-                PopulateLocalCache(psiSourceFile, cacheItem);
+            PopulateLocalCache();
         }
 
         public override void Drop(IPsiSourceFile sourceFile)
         {
-            CleanLocalCache(sourceFile);
+            RemoveFromLocalCache(sourceFile);
             base.Drop(sourceFile);
         }
 
-        private void PopulateLocalCache(IPsiSourceFile metaFile, [CanBeNull] MetaFileCacheItem data)
+        private void PopulateLocalCache()
         {
-            if (data == null) return;
+            foreach (var (psiSourceFile, cacheItem) in Map)
+                AddToLocalCache(psiSourceFile, cacheItem);
+        }
+
+        private void AddToLocalCache(IPsiSourceFile metaFile, [CanBeNull] MetaFileCacheItem cacheItem)
+        {
+            if (cacheItem == null) return;
 
             var metaFileLocation = metaFile.GetLocation();
             if (!metaFileLocation.IsEmpty)
             {
                 var assetLocation = GetAssetLocationFromMetaFile(metaFileLocation);
-                myAssetGuidToAssetFilePaths.AddValue(data.Guid, assetLocation);
-                myAssetFilePathToGuid.Add(assetLocation, data.Guid);
+                myAssetGuidToAssetFilePaths.AddValue(cacheItem.Guid, assetLocation);
+                myAssetFilePathToGuid.Add(assetLocation, cacheItem.Guid);
             }
         }
 
-        private void CleanLocalCache(IPsiSourceFile sourceFile)
+        private void RemoveFromLocalCache(IPsiSourceFile sourceFile)
         {
             if (Map.TryGetValue(sourceFile, out var cacheItem))
             {

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerCacheItem.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerCacheItem.cs
@@ -1,0 +1,34 @@
+using JetBrains.Util.PersistentMap;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
+{
+    public class UnityEventHandlerCacheItem
+    {
+        public static readonly IUnsafeMarshaller<UnityEventHandlerCacheItem> Marshaller =
+            new UniversalMarshaller<UnityEventHandlerCacheItem>(Read, Write);
+
+        public UnityEventHandlerCacheItem(string assetGuid, string referenceShortName)
+        {
+            AssetGuid = assetGuid;
+            ReferenceShortName = referenceShortName;
+        }
+
+        public string AssetGuid { get; }
+        public string ReferenceShortName { get; }
+
+        private static UnityEventHandlerCacheItem Read(UnsafeReader reader)
+        {
+            var assetGuid = reader.ReadString();
+            var referenceShortName = reader.ReadString();
+            return new UnityEventHandlerCacheItem(assetGuid, referenceShortName);
+        }
+
+        private static void Write(UnsafeWriter writer, UnityEventHandlerCacheItem value)
+        {
+            writer.Write(value.AssetGuid);
+            writer.Write(value.ReferenceShortName);
+        }
+
+        public override string ToString() => $"{AssetGuid}::{ReferenceShortName}";
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerReferenceCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityEventHandlerReferenceCache.cs
@@ -47,7 +47,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
                 n => new List<UnityEventHandlerCacheItem>(n));
         }
 
-        public bool IsEventHandler([NotNull] IDeclaredElement declaredElement)
+        public bool IsEventHandler([NotNull] IMethod declaredElement)
         {
             var sourceFiles = declaredElement.GetSourceFiles();
 
@@ -90,7 +90,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             if (file == null)
                 return null;
 
-            var cacheItems = new List<UnityEventHandlerCacheItem>();
+            var cacheItems = new JetHashSet<UnityEventHandlerCacheItem>();
             var referenceProcessor = new ConditionalRecursiveReferenceProcessor(reference =>
             {
                 var assetGuid = reference.GetScriptAssetGuid();
@@ -111,8 +111,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         {
             RemoveFromLocalCache(sourceFile);
             base.Merge(sourceFile, builtPart);
-            AddToLocalCache(builtPart as List<UnityEventHandlerCacheItem> ??
-                            EmptyList<UnityEventHandlerCacheItem>.InstanceList);
+            AddToLocalCache(builtPart as JetHashSet<UnityEventHandlerCacheItem> ??
+                            JetHashSet<UnityEventHandlerCacheItem>.Empty);
         }
 
         public override void MergeLoaded(object data)

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReference.cs
@@ -77,6 +77,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
             return document.GetUnityObjectTypeFromRootNode() == "MonoBehaviour";
         }
 
+        // Note that this is the guid of the script asset of the instance that the method should be called on. It is not
+        // necessarily the guid of the script asset that *declares* the method (property setter is a method). The method
+        // might be declared on a base type, or might be a virtual override
         [CanBeNull]
         public string GetScriptAssetGuid()
         {

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlUsageSearchFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlUsageSearchFactory.cs
@@ -24,7 +24,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
             bool findCandidates)
         {
             // We're interested in classes for usages of MonoScript references, and methods for UnityEvent usages
-            if (elements.All(e => e is IClass || e is IMethod))
+            if (elements.All(e => e is IClass || e is IMethod || e is IProperty))
                 return new YamlReferenceSearcher(this, elements, findCandidates);
             return null;
         }

--- a/rider/.idea/encodings.xml
+++ b/rider/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/rider/.idea/gradle.xml
+++ b/rider/.idea/gradle.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/buildSrc" />
+            <option value="$PROJECT_DIR$/protocol" />
+          </set>
+        </option>
+        <option name="useAutoImport" value="true" />
+        <option name="useQualifiedModuleNames" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
* Fix exception on startup - [RIDER-21929](https://youtrack.jetbrains.com/issue/RIDER-21929) (mistyped the ticket in the commit)
* Mark event handlers as in use if they're declared on a base type - #922 
* Fix highlighting for property used as event handler - gets gutter icon/code insight marker
* Fix find usages for properties used as event handlers

Plus sneaky, unrelated fix to stop the Generate event function dialog selecting all items by default when called from the gutter icon or code code insight marker. See [RIDER-22211](https://youtrack.jetbrains.com/issue/RIDER-22211)