### PR TITLE
Resolve local packages with fully qualified paths

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesManager.kt
@@ -194,7 +194,8 @@ class PackagesManager(private val project: Project) {
         if (version.startsWith("file:")) {
             return try {
                 val path = version.substring(5)
-                val filePath = Paths.get(packagesFolder.path, path)
+                val packagesPath = Paths.get(packagesFolder.path)
+                val filePath = packagesPath.resolve(path)
                 val packageFolder = VfsUtil.findFile(filePath, true)
                 if (packageFolder != null && packageFolder.isDirectory) {
                     getPackageDataFromFolder(name, packageFolder, PackageSource.Local)


### PR DESCRIPTION
Correctly handles `file:` based packages as local or fully qualified paths (Windows, with drive letters).

Fixes [RIDER-21734](https://youtrack.jetbrains.com/issue/RIDER-21734).