### PR TITLE
Fix finding of YAML files for file based packages

### DIFF
--- a/resharper/resharper-unity/src/ProjectExtensions.cs
+++ b/resharper/resharper-unity/src/ProjectExtensions.cs
@@ -46,6 +46,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         public static bool IsUnityGeneratedProject([CanBeNull] this IProject project)
         {
+            // TODO: This doesn't work for Packages folder or 'file:' based packages
             return project != null && project.HasSubItems(AssetsFolder) && IsUnityProject(project);
         }
 

--- a/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
@@ -24,7 +24,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
 
         public static bool IsAsset([NotNull] this FileSystemPath path)
         {
-            return Contains(path.ExtensionWithDot);
+            var fullPath = path.FullPath;
+            foreach (var extension in AllFileExtensionsWithDot)
+            {
+                if (fullPath.EndsWith(extension, StringComparison.InvariantCultureIgnoreCase))
+                    return true;
+            }
+
+            return false;
         }
 
         public static bool IsMeta([NotNull] this FileSystemPath path)


### PR DESCRIPTION
Looking at `project.Location` is a mistake, because that's the location of the `.csproj` file, which is the solution directory, so we'll look at way too many files and can parse files we shouldn't be looking at.

This PR changes YAML processing to look in the project model of each Unity project for a `.asmdef` file, and process that directory. Any assembly definitions inside `Assets` or `Packages` will already have been handled and will be skipped. So this will catch any source based packages that live outside of the normal solution structure.

Fixes RIDER-22673