### PR TITLE
[WIP] Add empty folders to first csproj

### DIFF
--- a/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
+++ b/unity/EditorPlugin/AssetPostprocessors/CsprojAssetPostprocessor.cs
@@ -17,6 +17,8 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
   {
     private static readonly ILog ourLogger = Log.GetLog<CsprojAssetPostprocessor>();
 
+    private static bool ourIncludeEmptyFoldersDone;
+    
     // Note that this does not affect the order in which postprocessors are evaluated. Order of execution is undefined.
     // https://github.com/Unity-Technologies/UnityCsReference/blob/2018.2/Editor/Mono/AssetPostprocessor.cs#L152
     public override int GetPostprocessOrder()
@@ -134,6 +136,11 @@ namespace JetBrains.Rider.Unity.Editor.AssetPostprocessors
 
     private static bool IncludeEmptyFolders(XElement projectContentElement, XNamespace xmlns)
     {
+      if (ourIncludeEmptyFoldersDone) // include empty folders to first csproj only
+        return false;
+      
+      ourIncludeEmptyFoldersDone = true;
+      
       var currentDirectory = Directory.GetCurrentDirectory();
       // <Folder Include="Assets\Empty" />
       var emptyFolders = new DirectoryInfo("Assets")


### PR DESCRIPTION
Users are complaining about refactorings and drag-n-drop not working for empty folders. The reason is that empty folders are not in any csproj, so nothings works.
This PR adds all folders without cs files to **first** csproj. (I decided to avoid complicated logic for adding folders to corresponding csproj-s, specifically because csproj can be missing, but folder can be there and user may want to drag-n-drop file to it.)

https://youtrack.jetbrains.com/issue/RIDER-23169
https://github.com/JetBrains/resharper-unity/issues/383 (edited) 