### PR TITLE
Fix for "get_unityVersion is not allowed to be called while application is terminating"

### DIFF
--- a/resharper/resharper-unity.sln.DotSettings
+++ b/resharper/resharper-unity.sln.DotSettings
@@ -41,6 +41,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Intellisense/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lnks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playmode/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=postprocessors/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resharper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scriptable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serisalisation/@EntryIndexedValue">True</s:Boolean>

--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -264,7 +264,7 @@ namespace JetBrains.Rider.Unity.Editor
           model.FullPluginPath.AdviseNotNull(connectionLifetime, AdditionalPluginsInstaller.UpdateSelf);
           model.ApplicationPath.SetValue(EditorApplication.applicationPath);
           model.ApplicationContentsPath.SetValue(EditorApplication.applicationContentsPath);
-          model.ApplicationVersion.SetValue(Application.unityVersion);
+          model.ApplicationVersion.SetValue(UnityUtils.UnityApplicationVersion);
           model.ScriptingRuntime.SetValue(UnityUtils.ScriptingRuntime);
           
           if (UnityUtils.UnityVersion >= new Version(2018, 2) && EditorPrefsWrapper.ScriptChangesDuringPlayOptions == 0)
@@ -463,7 +463,7 @@ namespace JetBrains.Rider.Unity.Editor
 
       File.WriteAllText(editorInstanceJsonPath, $@"{{
   ""process_id"": {Process.GetCurrentProcess().Id},
-  ""version"": ""{Application.unityVersion}""
+  ""version"": ""{UnityUtils.UnityApplicationVersion}""
 }}");
 
       AppDomain.CurrentDomain.DomainUnload += (sender, args) =>

--- a/unity/EditorPlugin/RiderMenu.cs
+++ b/unity/EditorPlugin/RiderMenu.cs
@@ -15,6 +15,10 @@ namespace JetBrains.Rider.Unity.Editor
     [MenuItem("Assets/Open C# Project in Rider", false, 1000)]
     public static void MenuOpenProject()
     {
+      // method can be called via commandline
+      if (!PluginEntryPoint.Enabled)
+        return; 
+      
       // Force the project files to be sync
       UnityUtils.SyncSolution();
 

--- a/unity/EditorPlugin/UnityUtils.cs
+++ b/unity/EditorPlugin/UnityUtils.cs
@@ -12,6 +12,7 @@ namespace JetBrains.Rider.Unity.Editor
   public static class UnityUtils
   {
     private static readonly ILog ourLogger = Log.GetLog("UnityUtils");
+    internal static readonly string UnityApplicationVersion = Application.unityVersion;
 
     /// <summary>
     /// Force Unity To Write Project File
@@ -27,7 +28,7 @@ namespace JetBrains.Rider.Unity.Editor
     {
       get
       {
-        var ver = Application.unityVersion.Split(".".ToCharArray()).Take(2).Aggregate((a, b) => a + "." + b);
+        var ver = UnityApplicationVersion.Split(".".ToCharArray()).Take(2).Aggregate((a, b) => a + "." + b);
         return new Version(ver);
       }
     }


### PR DESCRIPTION
Previously RIDER-19688 was fixed by disabling Rider Editor plugin in batch mode, but this fix avoids the same problem by caching unityVersion and thus not trying to get it during AppDomain termination