### PR TITLE
Updates for rename performance

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -5,7 +5,6 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Plugins.Unity.Yaml;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
-using JetBrains.ReSharper.Plugins.Yaml.Settings;
 using JetBrains.ReSharper.Psi;
 using JetBrains.Util;
 
@@ -113,7 +112,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
 
             var solution = method.GetSolution();
             var assetSerializationMode = solution.GetComponent<AssetSerializationMode>();
-            var yamlParsingEnabled = solution.GetComponent<UnityYamlSupport>().IsYamlParsingEnabled;
+            var yamlParsingEnabled = solution.GetComponent<UnityYamlSupport>().IsUnityYamlParsingEnabled;
 
             // TODO: These two are usually used together. Consider combining in some way
             if (!yamlParsingEnabled.Value || !assetSerializationMode.IsForceText)

--- a/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -34,7 +34,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
                 /*
                  * TODO: radically rethink Unity / non-Unity project detection.
                  * Currently we check project's assemblies using extensions for IProject,
-                 * with no way to log errors and/or react to targetFrameworkChanges should they happen on the fly.                  
+                 * with no way to log errors and/or react to targetFrameworkChanges should they happen on the fly.
                  * This should be replaced with something more stable and fast.
                  */
                 myLogger.LogExceptionSilently(e);
@@ -117,26 +117,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
 
             // TODO: These two are usually used together. Consider combining in some way
             if (!yamlParsingEnabled.Value || !assetSerializationMode.IsForceText)
-                return IsPotentialEventHandler(unityApi, method);
+                return unityApi.IsPotentialEventHandler(method);
 
             return method.GetSolution().GetComponent<UnityEventHandlerReferenceCache>().IsEventHandler(method);
         }
-
-        // Best effort attempt at preventing false positives for type members that are actually being used inside a
-        // scene. We don't have enough information to do this by name, so we'll mark all potential event handlers as
-        // implicitly used by Unity
-        // See https://github.com/Unity-Technologies/UnityCsReference/blob/02f8e8ca594f156dd6b2088ad89451143ca1b87e/Editor/Mono/Inspector/UnityEventDrawer.cs#L397
-        private static bool IsPotentialEventHandler(UnityApi unityApi, IMethod method)
-        {
-            if (!method.ReturnType.IsVoid())
-                return false;
-
-            // Type.GetMethods() returns public instance methods only
-            if (method.GetAccessRights() != AccessRights.PUBLIC || method.IsStatic)
-                return false;
-
-            return unityApi.IsUnityType(method.GetContainingType()) &&
-                   !method.HasAttributeInstance(PredefinedType.OBSOLETE_ATTRIBUTE_CLASS, true);
-        }
     }
 }
+

--- a/resharper/resharper-unity/src/Internal/DumpPsiForFileAction.cs
+++ b/resharper/resharper-unity/src/Internal/DumpPsiForFileAction.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using JetBrains.Application.DataContext;
+using JetBrains.Application.UI.Actions;
+using JetBrains.Application.UI.ActionsRevised.Menu;
+using JetBrains.Application.UI.ActionSystem.ActionsRevised.Menu;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.DataContext;
+using JetBrains.ReSharper.Features.Internal.PsiModules;
+using JetBrains.ReSharper.Features.Internal.resources;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Internal
+{
+    [Action("Dump PSI for Current File")]
+    public class DumpPsiForFileAction : IExecutableAction, IInsertBefore<InternalPsiMenu, DumpPsiSourceFilePropertiesAction>
+    {
+        public bool Update(IDataContext context, ActionPresentation presentation, DelegateUpdate nextUpdate)
+        {
+            var projectFile = context.GetData(ProjectModelDataConstants.PROJECT_MODEL_ELEMENT) as IProjectFile;
+            return projectFile?.ToSourceFile() != null;
+        }
+
+        public void Execute(IDataContext context, DelegateExecute nextExecute)
+        {
+            var projectFile = context.GetData(ProjectModelDataConstants.PROJECT_MODEL_ELEMENT) as IProjectFile;
+            var sourceFile = projectFile?.ToSourceFile();
+            if (sourceFile == null)
+                return;
+
+            var path = CompanySpecificFolderLocations.TempFolder / (Path.GetRandomFileName() + ".txt");
+            using (var sw = new StreamWriter(path.OpenFileForWriting(), Encoding.UTF8))
+            {
+                foreach (var psiFile in sourceFile.EnumerateDominantPsiFiles())
+                {
+                    sw.WriteLine("Language: {0}", psiFile.Language.Name);
+                    DebugUtil.DumpPsi(sw, psiFile);
+                }
+            }
+
+            Process.Start(path.FullPath);
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Settings/UnitySettings.cs
+++ b/resharper/resharper-unity/src/Settings/UnitySettings.cs
@@ -29,7 +29,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
 
         [SettingsEntry(true, "Should yaml heuristic be applied?")]
         public bool ShouldApplyYamlHugeFileHeuristic;
-        
+
         [SettingsEntry(true, "Enables syntax error highlighting, brace matching and more of YAML files for Unity")]
         public bool IsYamlParsingEnabled;
     }

--- a/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetSerializationMode.cs
@@ -30,7 +30,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             if (assetsDir.ExistsDirectory && editorSettingsPath.ExistsFile)
             {
                 // If binary serialisation is enabled, the EditorSettings.asset file might be in binary. Sheesh
-                var isEditorSettingsInText = editorSettingsPath.IsYaml();
+                var isEditorSettingsInText = editorSettingsPath.SniffYamlHeader();
 
                 // At best, we can say that it's mixed. If the settings asset is in text, read it to get the proper value
                 Mode = SerializationMode.Mixed;

--- a/resharper/resharper-unity/src/Yaml/ProjectModel/UnityYamlProjectModelElementPresenter.cs
+++ b/resharper/resharper-unity/src/Yaml/ProjectModel/UnityYamlProjectModelElementPresenter.cs
@@ -1,4 +1,3 @@
-using System;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Resources.Icons;
 using JetBrains.ReSharper.Plugins.Yaml.ProjectModel;
@@ -15,14 +14,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.ProjectModel
         {
             if (projectModelElement is IProjectFile projectFile && projectFile.LanguageType.Is<YamlProjectFileType>())
             {
-                var extension = projectFile.Location.ExtensionNoDot;
-                if (extension.Equals("asset", StringComparison.InvariantCultureIgnoreCase))
+                var location = projectFile.Location;
+                if (location.IsAsset())
                     return UnityFileTypeThemedIcons.FileUnityAsset.Id;
-                if (extension.Equals("unity", StringComparison.InvariantCultureIgnoreCase))
+                if (location.IsScene())
                     return UnityFileTypeThemedIcons.FileUnity.Id;
-                if (extension.Equals("prefab", StringComparison.InvariantCultureIgnoreCase))
+                if (location.IsPrefab())
                     return UnityFileTypeThemedIcons.FileUnityPrefab.Id;
-                if (extension.Equals("meta", StringComparison.InvariantCultureIgnoreCase))
+                if (location.IsMeta())
                     return UnityFileTypeThemedIcons.FileUnityMeta.Id;
             }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/BinaryUnityFileCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/BinaryUnityFileCache.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Application.changes;
+using JetBrains.Application.Progress;
+using JetBrains.Application.Threading;
+using JetBrains.DataFlow;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Parsing;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.Threading;
+using JetBrains.Util.PersistentMap;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
+{
+    // We need to avoid binary "YAML" files - they're useless to us and bloat and case false positives in the trigram
+    // index. Ideally, we'd filter all binary files out before they could be processed by the PSI caches (and therefore
+    // the trigram index). The PSI module processor will filter out some, based on file name and by sniffing for the
+    // `%YAML` header. For performance reasons, we only sniff the header for large files, so some binary files will
+    // still be added (and added to the trigram index).
+    // This cache recognises binary YAML files, and the file's IPsiSourceFileProperties.ShouldBuildPsi will return false
+    // if the cache says it's binary. When the cache sees a binary file, it notifies the change manager that the PSI
+    // file has been modified (technically, the properties have been modified). Now that ShouldBuildPsi returns false,
+    // the file is dropped from all caches, including the trigram index, and the caches  are no longer called for this
+    // file.
+    //
+    // TODO: Support resetting a file back to non-binary
+    // Note that this means that once we mark a file as binary, it will never become not-binary. This cache is not
+    // called again when the file is modified, so we never check to see if it's become text. We even ignore the Drop
+    // request, so that we know (even though the file no longer has a PSI) that the file is binary. And because the Map
+    // is persistent, this survives application restarts.
+    [PsiComponent]
+    public class BinaryUnityFileCache : SimpleICache<BinaryUnityFileCache.BinaryFileCacheItem>
+    {
+        private readonly GroupingEvent myGroupingEvent;
+        private readonly JetHashSet<IPsiSourceFile> myChangedFiles;
+
+        public BinaryUnityFileCache(Lifetime lifetime, ISolution solution,
+                                    IPersistentIndexManager persistentIndexManager, IShellLocks locks,
+                                    ChangeManager changeManager)
+            : base(lifetime, persistentIndexManager, BinaryFileCacheItem.Marshaller)
+        {
+            myGroupingEvent = solution.Locks.GroupingEvents.CreateEvent(lifetime, "UnityRefresherOnSaveEvent",
+                TimeSpan.FromMilliseconds(500), Rgc.Guarded, () =>
+                {
+                    var changedFiles = new JetHashSet<IPsiSourceFile>(myChangedFiles);
+                    myChangedFiles.Clear();
+
+                    if (changedFiles.Count > 0)
+                    {
+                        locks.ExecuteWithWriteLock(() => changeManager.ExecuteAfterChange(() =>
+                        {
+                            var builder = new PsiModuleChangeBuilder();
+                            foreach (var file in changedFiles)
+                            {
+                                if (file.IsValid())
+                                    builder.AddFileChange(file, PsiModuleChange.ChangeType.Modified);
+                            }
+
+                            changeManager.OnProviderChanged(solution, builder.Result, SimpleTaskExecutor.Instance);
+                        }));
+                    }
+                });
+            myChangedFiles = new JetHashSet<IPsiSourceFile>();
+        }
+
+        public bool IsBinaryFile(IPsiSourceFile sourceFile)
+        {
+            return Map.TryGetValue(sourceFile, out var value) && value.IsBinary;
+        }
+
+        protected override bool IsApplicable(IPsiSourceFile sf)
+        {
+            return sf.IsLanguageSupported<YamlLanguage>();
+        }
+
+        public override object Build(IPsiSourceFile sourceFile, bool isStartup)
+        {
+            if (!IsApplicable(sourceFile))
+                return null;
+
+            if (!(sourceFile.GetDominantPsiFile<YamlLanguage>() is IYamlFile yamlFile))
+                return null;
+
+            var isBinary = yamlFile.CachingLexer.TokenBuffer[0].Type == YamlTokenType.NON_PRINTABLE;
+            return new BinaryFileCacheItem(isBinary);
+        }
+
+        public override void Merge(IPsiSourceFile sourceFile, object builtPart)
+        {
+            if (!Map.TryGetValue(sourceFile, out var oldValue))
+                oldValue = new BinaryFileCacheItem(false);
+
+            var newValue = builtPart as BinaryFileCacheItem ?? new BinaryFileCacheItem(false);
+            if (oldValue.IsBinary != newValue.IsBinary)
+            {
+                myChangedFiles.Add(sourceFile);
+                myGroupingEvent.FireIncoming();
+            }
+
+            base.Merge(sourceFile, builtPart);
+        }
+
+        public override void Drop(IPsiSourceFile sourceFile)
+        {
+            // Ignore drop of valid files so that old value is retained in the persistent Map
+            if (sourceFile.IsValid())
+            {
+                RemoveFromDirty(sourceFile);
+                return;
+            }
+
+            base.Drop(sourceFile);
+        }
+
+        public class BinaryFileCacheItem
+        {
+            public static readonly IUnsafeMarshaller<BinaryFileCacheItem> Marshaller =
+                new UniversalMarshaller<BinaryFileCacheItem>(Read, Write);
+
+            public readonly bool IsBinary;
+
+            public BinaryFileCacheItem(bool isBinary)
+            {
+                IsBinary = isBinary;
+            }
+
+            private static BinaryFileCacheItem Read(UnsafeReader reader)
+            {
+                var flag = reader.ReadBool();
+                return new BinaryFileCacheItem(flag);
+            }
+
+            private static void Write(UnsafeWriter writer, BinaryFileCacheItem value)
+            {
+                writer.Write(value.IsBinary);
+            }
+
+            public override string ToString() => $"IsBinary: {IsBinary}";
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityCacheUpdater.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityCacheUpdater.cs
@@ -18,11 +18,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             var module = factory.PsiModule;
             if (module != null)
             {
-                unityYamlSupport.IsYamlParsingEnabled.Change.Advise_NoAcknowledgement(lifetime, (handler) =>
+                unityYamlSupport.IsUnityYamlParsingEnabled.Change.Advise_NoAcknowledgement(lifetime, (handler) =>
                 {
                     if (handler.HasNew && handler.HasOld && handler.New == handler.Old)
                         return;
-                    
+
                     locks.ExecuteOrQueueReadLockEx(lifetime, "YamlParsingStateChange", () =>
                     {
                         var psiSourceFiles = module.SourceFiles.ToList();

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFileProperties.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFileProperties.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using JetBrains.DataFlow;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
 using JetBrains.ReSharper.Psi;
 using JetBrains.Util;
 
@@ -7,22 +7,28 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 {
     public class UnityExternalFileProperties : IPsiSourceFileProperties
     {
-        private readonly IProperty<bool> myEnabled;
+        private readonly IPsiSourceFile mySourceFile;
+        private readonly UnityYamlSupport myUnityYamlSupport;
+        private readonly BinaryUnityFileCache myBinaryUnityFileCache;
 
-        public UnityExternalFileProperties(IProperty<bool> enabled)
+        public UnityExternalFileProperties(IPsiSourceFile sourceFile, UnityYamlSupport unityYamlSupport,
+                                           BinaryUnityFileCache binaryUnityFileCache)
         {
-            myEnabled = enabled;
+            mySourceFile = sourceFile;
+            myUnityYamlSupport = unityYamlSupport;
+            myBinaryUnityFileCache = binaryUnityFileCache;
         }
 
         public IEnumerable<string> GetPreImportedNamespaces() => EmptyList<string>.InstanceList;
         public string GetDefaultNamespace() => string.Empty;
         public ICollection<PreProcessingDirective> GetDefines() => EmptyList<PreProcessingDirective>.InstanceList;
-        public bool ShouldBuildPsi => myEnabled.Value;
+
+        public bool ShouldBuildPsi => myUnityYamlSupport.IsUnityYamlParsingEnabled.Value &&
+                                      !myBinaryUnityFileCache.IsBinaryFile(mySourceFile);
+
         public bool IsGeneratedFile => true;
         public bool IsICacheParticipant => true;
         public bool ProvidesCodeModel => true;
-
-        // TODO: Setting this to true disables daemon. Do we want this?
         public bool IsNonUserFile => false;
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleFactory.cs
@@ -19,7 +19,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             // TODO: Conditionally create this module
             // See changeBuilder.AddAssembly(module, ADDED)
             PsiModule = new UnityExternalFilesPsiModule(solution, "Unity external files", "UnityExternalFilesPsiModule",
-                TargetFrameworkId.Default, fileSystemTracker, lifetime);
+                TargetFrameworkId.Default, lifetime);
         }
 
         [CanBeNull] public UnityExternalFilesPsiModule PsiModule { get; }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
@@ -103,7 +103,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             if (externalFiles.AssetFiles.Count > 0) myUnityYamlDisableStrategy.Run(externalFiles.AssetFiles);
 
             CollectExternalFilesForAsmDefProject(externalFiles, project);
-            AddExternalFiles(externalFiles, project);
+            AddExternalFiles(externalFiles);
             UpdateStatistics(externalFiles);
         }
 
@@ -192,11 +192,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             myRootPaths.Add(directory);
         }
 
-        private void AddExternalFiles(ExternalFiles externalFiles, IProject project)
+        private void AddExternalFiles(ExternalFiles externalFiles)
         {
             var builder = new PsiModuleChangeBuilder();
             AddExternalMetaFiles(externalFiles, builder);
-            AddModuleReference(builder, project);
             FlushChanges(builder);
 
             AddExternalAssetFiles(externalFiles);
@@ -431,20 +430,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
                         myChangeManager.OnProviderChanged(this, builder.Result, SimpleTaskExecutor.Instance);
                     }
                 });
-        }
-
-        // Add a module reference to the project, so our reference can "see" the target (more accurately, I think this
-        // is used to figure out the search domain for Find Usages)
-        private void AddModuleReference(PsiModuleChangeBuilder builder, IProject project)
-        {
-            var thisModule = myModuleFactory.PsiModule;
-            if (thisModule == null)
-                return;
-
-            foreach (var projectModule in project.GetPsiModules())
-                thisModule.AddModuleReference(projectModule);
-
-            builder.AddModuleChange(thisModule, PsiModuleChange.ChangeType.Modified);
         }
 
         public object Execute(IChangeMap changeMap) => null;

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesPsiModule.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesPsiModule.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Application.changes;
-using JetBrains.Application.FileSystemTracker;
 using JetBrains.DataFlow;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
@@ -20,18 +19,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         [NotNull] private readonly ISolution mySolution;
         private readonly string myPersistentId;
-        private readonly IFileSystemTracker myFileSystemTracker;
         private readonly Lifetime myLifetime;
         private readonly CompactMap<FileSystemPath, Pair<IPsiSourceFile, LifetimeDefinition>> mySourceFiles;
-        private readonly List<IPsiModuleReference> myModules = new List<IPsiModuleReference>();
 
         public UnityExternalFilesPsiModule([NotNull] ISolution solution, string moduleName, string persistentId,
-                                           TargetFrameworkId targetFrameworkId,
-                                           IFileSystemTracker fileSystemTracker, Lifetime lifetime)
+                                           TargetFrameworkId targetFrameworkId, Lifetime lifetime)
         {
             mySolution = solution;
             myPersistentId = persistentId;
-            myFileSystemTracker = fileSystemTracker;
             myLifetime = lifetime;
             Name = moduleName;
             TargetFrameworkId = targetFrameworkId;
@@ -44,12 +39,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         IEnumerable<IPsiModuleReference> IPsiModule.GetReferences(
             IModuleReferenceResolveContext moduleReferenceResolveContext)
         {
-            // TODO: There is a bug in PsiModuleAttrCache that causes tests to fail if this module has references
-            // Disable references in tests. Will fix up later...
-            if (JetBrains.ReSharper.Resources.Shell.Shell.Instance.IsTestShell)
-                return EmptyList<IPsiModuleReference>.Instance;
-
-            return myModules;
+            return EmptyList<IPsiModuleReference>.Instance;
         }
 
         public ICollection<PreProcessingDirective> GetAllDefines() => EmptyList<PreProcessingDirective>.InstanceList;
@@ -62,11 +52,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         public ProjectFileType ProjectFileType => UnknownProjectFileType.Instance;
         public IModule ContainingProjectModule => mySolution.MiscFilesProject;
         public IEnumerable<IPsiSourceFile> SourceFiles => mySourceFiles.Values.Select(pair => pair.First);
-
-        public void AddModuleReference(IPsiModule module)
-        {
-            myModules.Add(new PsiModuleReference(module));
-        }
 
         public bool ContainsPath(FileSystemPath path) => mySourceFiles.ContainsKey(path);
 

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesPsiModule.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesPsiModule.cs
@@ -89,17 +89,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 
             var fileLifetime = Lifetimes.Define(myLifetime, path.FullPath);
             mySourceFiles.Add(path, Pair.Of(file, fileLifetime));
-            if (processFileChange == null)
-                return;
 
-            // Not sure we need this. We do all our file modification via another tracker. But it's part of the API...
-            if (file is IPsiSourceFileWithLocation sourceFile)
-            {
-                sourceFile.TrackChanges(fileLifetime.Lifetime, myFileSystemTracker,
-                    (delta, externalChangeType) => processFileChange(delta));
-            }
-            else
-                myFileSystemTracker.AdviseFileChanges(fileLifetime.Lifetime, path, processFileChange);
+            // Explicitly assert if we're given a file change handler. We're expecting a lot of files in this module, it
+            // will be much better to add a couple of directory change handlers than to add several thousand file change
+            // handlers.
+            // We also need to call the equivalent of PsiSourceFileWithLocationEx.TrackChanges, without registering
+            // thousands of file change handlers.
+            if (processFileChange != null)
+                Assertion.Fail("Individual file change handler not supported. Use a directory change handler");
         }
 
         public void Remove(FileSystemPath path)

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityMiscFilesProjectPsiModuleProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityMiscFilesProjectPsiModuleProvider.cs
@@ -57,7 +57,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             switch (changeType)
             {
                 case PsiModuleChange.ChangeType.Added:
-                    if (projectFile.Location.IsAsset() && myAssetSerializationMode.IsForceText &&
+                    if (projectFile.Location.IsInterestingAsset() && myAssetSerializationMode.IsForceText &&
                         !module.ContainsPath(projectFile.Location))
                     {
                         // Create the PsiSourceFile, add it to the module, add the change to the builder

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
@@ -14,25 +14,25 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         private const ulong AssetFileSizeThreshold = 40 * (1024 * 1024); // 40 MB
         private const ulong TotalFileSizeThreshold = 700 * (1024 * 1024); // 700 MB
 
-        private ulong myTotalSize = 0;
-
         private readonly IProperty<bool> myShouldRunHeuristic;
-        protected readonly IProperty<bool> IsUnityYamlParsingEnabled;
+        private readonly UnityYamlSupport myUnityYamlSupport;
 
-        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore, UnityYamlSupport unityYamlEnabled)
+        private ulong myTotalSize;
+
+        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore, UnityYamlSupport unityYamlSupport)
         {
+            myUnityYamlSupport = unityYamlSupport;
             var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
             myShouldRunHeuristic = boundStore.GetValueProperty(lifetime, (UnitySettings s) => s.ShouldApplyYamlHugeFileHeuristic);
-            IsUnityYamlParsingEnabled = unityYamlEnabled.IsUnityYamlParsingEnabled;
         }
 
         public void Run(List<DirectoryEntryData> directoryEntries)
         {
-            if (myShouldRunHeuristic.Value && IsUnityYamlParsingEnabled.Value)
+            if (myShouldRunHeuristic.Value && myUnityYamlSupport.IsUnityYamlParsingEnabled.Value)
             {
                 if (IsAnyFilePreventYamlParsing(directoryEntries) || myTotalSize > TotalFileSizeThreshold)
                 {
-                    IsUnityYamlParsingEnabled.Value = false;
+                    myUnityYamlSupport.IsUnityYamlParsingEnabled.Value = false;
                     NotifyYamlParsingDisabled();
                 }
             }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
@@ -31,14 +31,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 
         public IPsiProjectFile CreatePsiProjectFile(IPsiModule psiModule, IProjectFile projectFile)
         {
-            return new UnityYamlAssetPsiSourceFile(projectFile, myProjectFileExtensions, myProjectFileTypeCoordinator,
+            var file = new UnityYamlAssetPsiSourceFile(projectFile, myProjectFileExtensions, myProjectFileTypeCoordinator,
                 psiModule, projectFile.Location, Memoize(PropertiesFactory), myDocumentManager, UniversalModuleReferenceContext.Instance);
+            // Prime the file system cache
+            file.GetCachedFileSystemData();
+            return file;
         }
 
         public IExternalPsiSourceFile CreateExternalPsiSourceFile(IPsiModule psiModule, FileSystemPath path)
         {
-            return new UnityYamlExternalPsiSourceFile(myProjectFileExtensions, myProjectFileTypeCoordinator, psiModule,
+            var file = new UnityYamlExternalPsiSourceFile(myProjectFileExtensions, myProjectFileTypeCoordinator, psiModule,
                 path, Memoize(PropertiesFactory), myDocumentManager, UniversalModuleReferenceContext.Instance);
+            // Prime the file system cache
+            file.GetCachedFileSystemData();
+            return file;
         }
 
         // The PropertiesFactory passed to PsiSourceFileFromPath is called on EVERY access to IPsiSourceFile.Properties.

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
@@ -1,6 +1,8 @@
+using System;
 using JetBrains.DocumentManagers;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Psi.Modules.ExternalFileModules;
@@ -13,8 +15,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         private readonly IProjectFileExtensions myProjectFileExtensions;
         private readonly PsiProjectFileTypeCoordinator myProjectFileTypeCoordinator;
+        private readonly UnityYamlSupport myUnityYamlSupport;
         private readonly DocumentManager myDocumentManager;
-        private readonly IPsiSourceFileProperties myPsiSourceFileProperties;
 
         public UnityYamlPsiSourceFileFactory(IProjectFileExtensions projectFileExtensions,
                                              PsiProjectFileTypeCoordinator projectFileTypeCoordinator,
@@ -23,25 +25,36 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         {
             myProjectFileExtensions = projectFileExtensions;
             myProjectFileTypeCoordinator = projectFileTypeCoordinator;
+            myUnityYamlSupport = unityYamlSupport;
             myDocumentManager = documentManager;
-
-            myPsiSourceFileProperties = new UnityExternalFileProperties(unityYamlSupport.IsUnityYamlParsingEnabled);
         }
 
         public IPsiProjectFile CreatePsiProjectFile(IPsiModule psiModule, IProjectFile projectFile)
         {
             return new UnityYamlAssetPsiSourceFile(projectFile, myProjectFileExtensions, myProjectFileTypeCoordinator,
-                psiModule, projectFile.Location, PropertiesFactory, myDocumentManager,
-                UniversalModuleReferenceContext.Instance);
+                psiModule, projectFile.Location, Memoize(PropertiesFactory), myDocumentManager, UniversalModuleReferenceContext.Instance);
         }
 
         public IExternalPsiSourceFile CreateExternalPsiSourceFile(IPsiModule psiModule, FileSystemPath path)
         {
             return new UnityYamlExternalPsiSourceFile(myProjectFileExtensions, myProjectFileTypeCoordinator, psiModule,
-                path, PropertiesFactory, myDocumentManager, UniversalModuleReferenceContext.Instance);
+                path, Memoize(PropertiesFactory), myDocumentManager, UniversalModuleReferenceContext.Instance);
         }
 
-        private IPsiSourceFileProperties PropertiesFactory(PsiSourceFileFromPath psiSourceFile) =>
-            myPsiSourceFileProperties;
+        // The PropertiesFactory passed to PsiSourceFileFromPath is called on EVERY access to IPsiSourceFile.Properties.
+        // This function allows us to create a single instance for each file. The cache variable (as well as the func
+        // parameter) are captured into a closure class. When the closure's is invoked, we can populate and return the
+        // cached value
+        private static Func<IPsiSourceFile, IPsiSourceFileProperties> Memoize(Func<IPsiSourceFile, IPsiSourceFileProperties> func)
+        {
+            IPsiSourceFileProperties cache = null;
+            return sf => cache ?? (cache = func(sf));
+        }
+
+        private IPsiSourceFileProperties PropertiesFactory(IPsiSourceFile psiSourceFile)
+        {
+            var binaryUnityFileCache = psiSourceFile.GetSolution().GetComponent<BinaryUnityFileCache>();
+            return new UnityExternalFileProperties(psiSourceFile, myUnityYamlSupport, binaryUnityFileCache);
+        }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
@@ -1,10 +1,6 @@
-using JetBrains.Application.Settings;
-using JetBrains.DataFlow;
 using JetBrains.DocumentManagers;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
-using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Psi.Modules.ExternalFileModules;
@@ -28,8 +24,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             myProjectFileExtensions = projectFileExtensions;
             myProjectFileTypeCoordinator = projectFileTypeCoordinator;
             myDocumentManager = documentManager;
-            
-            myPsiSourceFileProperties = new UnityExternalFileProperties(unityYamlSupport.IsYamlParsingEnabled);
+
+            myPsiSourceFileProperties = new UnityExternalFileProperties(unityYamlSupport.IsUnityYamlParsingEnabled);
         }
 
         public IPsiProjectFile CreatePsiProjectFile(IPsiModule psiModule, IProjectFile projectFile)

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlSearchGuru.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlSearchGuru.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using JetBrains.ReSharper.Feature.Services.Text;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
 using JetBrains.ReSharper.Psi;
@@ -56,6 +57,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
                     return null;
 
                 var guid = myMetaFileGuidCache.GetAssetGuid(sourceFile);
+                if (guid == null)
+                    return null;
 
                 // Class usage is in the form: "m_Script: {fileID: 11500000, guid: $guid, ... }"
                 // Get the set of files that contain ALL of these terms
@@ -75,6 +78,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
                     return null;
 
                 var guid = myMetaFileGuidCache.GetAssetGuid(sourceFile);
+                if (guid == null)
+                    return null;
 
                 // Searching for an event handler method requires matching something like
                 // Event handlers are in the form:
@@ -111,7 +116,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
             return true;
         }
 
-        private UnityYamlSearchGuruId GetElementId(params string[] searchTerms)
+        private UnityYamlSearchGuruId GetElementId([ItemNotNull] params string[] searchTerms)
         {
             var foundFiles = new JetHashSet<IPsiSourceFile>();
             foreach (var trigramIndex in myIndices)

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlSearchGuru.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityYamlSearchGuru.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using JetBrains.ReSharper.Feature.Services.Text;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Finder;
+using JetBrains.ReSharper.Psi.Search;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
+{
+    // Allows extra filtering in FinderUtil.NarrowSearchDomain. This can have a positive impact on any find operation,
+    // such as plain old Find Usages and also the find usages that happens before rename.
+    // E.g. when performing a rename, ReSharper will use the finder to collect all element usages after a new name has
+    // been entered. The search domain will include all files that contain, as text, the name of the item being renamed.
+    // So renaming something called "GameObject" would include nearly all assets, scenes and prefabs, because
+    // "GameObject" is used EVERYWHERE in Unity YAML files.
+    // Our UnityYamlUsageSearchFactory.GetAllPossibleWordsInFile can add extra search terms, but this becomes an ANY
+    // search rather than an ALL search. And UnityYamlUsageSearchFactory.CreateReferenceSearcher can return null if the
+    // target declared element is not interesting, but finder will still process the file. Admittedly, this is fairly
+    // lightweight, but we can do even better if we remove the files from the search domain early on.
+    // Sadly, this doesn't affect scanning for suspicious references after a rename, which can still be very expensive
+    // if we've renamed a commonly used term (such as "GameObject" or "x")
+    //
+    // NOTE: If someone adds a reference that this class doesn't know about, the file will be removed from the search
+    // domain and any usages won't be found!
+    [SearchGuru(SearchGuruPerformanceEnum.FastFilterOutByIndex)]
+    public class UnityYamlSearchGuru : ISearchGuru
+    {
+        private readonly UnityApi myUnityApi;
+        private readonly MetaFileGuidCache myMetaFileGuidCache;
+        private readonly IEnumerable<ITrigramIndex> myIndices;
+
+        public UnityYamlSearchGuru(UnityApi unityApi, MetaFileGuidCache metaFileGuidCache, IEnumerable<ITrigramIndex> indices)
+        {
+            myUnityApi = unityApi;
+            myMetaFileGuidCache = metaFileGuidCache;
+            myIndices = indices;
+        }
+
+        // Allows us to filter the words that are collected from IDomainSpecificSearchFactory.GetAllPossibleWordsInFile
+        // This is an ANY search
+        public IEnumerable<string> BuzzWordFilter(IDeclaredElement searchFor, IEnumerable<string> containsWords) =>
+            containsWords;
+
+        public bool IsAvaliable(SearchPattern pattern) => (pattern & SearchPattern.FIND_USAGES) != 0;
+
+        // Return a context object for the item being searched for, or null if the element isn't interesting.
+        // CanContainReferences isn't called if we return null. Do the work once here, then use it multiple times for
+        // each file in CanContainReferences
+        public object GetElementId(IDeclaredElement element)
+        {
+            if (myUnityApi.IsUnityType(element as IClass))
+            {
+                var sourceFile = element.GetSourceFiles().FirstOrDefault();
+                if (sourceFile == null)
+                    return null;
+
+                var guid = myMetaFileGuidCache.GetAssetGuid(sourceFile);
+
+                // Class usage is in the form: "m_Script: {fileID: 11500000, guid: $guid, ... }"
+                // Get the set of files that contain ALL of these terms
+                return GetElementId("m_Script", "11500000", guid);
+            }
+
+            if (myUnityApi.IsPotentialEventHandler(element as IMethod)
+                || myUnityApi.IsPotentialEventHandler(element as IProperty))
+            {
+                // Get all files that contain GUID, m_MethodName, short name and 11500000
+                var sourceFile = element.GetSourceFiles().FirstOrDefault();
+                if (sourceFile == null)
+                    return null;
+
+                var shortName = element is IMethod ? element.ShortName : (element as IProperty)?.Setter?.ShortName;
+                if (shortName == null)
+                    return null;
+
+                var guid = myMetaFileGuidCache.GetAssetGuid(sourceFile);
+
+                // Searching for an event handler method requires matching something like
+                // Event handlers are in the form:
+                // OnSomeEvent:
+                //   m_PersistentCalls:
+                //     m_Calls:
+                //     - m_Target: {fileID: 878035745}
+                //       m_MethodName: $shortName
+                // and
+                // --- !u!114 &878035745
+                // MonoBehaviour:
+                //   ...
+                //   m_Script: {fileID: 11500000, guid: $guid, type: 3}
+                return GetElementId("m_PersistentCalls", "m_MethodName", "11500000", guid, shortName);
+            }
+
+            return new UnityYamlSearchGuruId(JetHashSet<IPsiSourceFile>.Empty);
+        }
+
+        // False means definitely not, true means "maybe"
+        public bool CanContainReferences(IPsiSourceFile sourceFile, object elementId)
+        {
+            // Meta files never contain references
+            if (sourceFile.IsMeta())
+                return false;
+
+            if (sourceFile.IsAsset())
+            {
+                // We know the file matches ANY of the search terms, see if it also matches ALL of the search terms
+                return ((UnityYamlSearchGuruId) elementId).Files.Contains(sourceFile);
+            }
+
+            // Not a YAML file, don't exclude it
+            return true;
+        }
+
+        private UnityYamlSearchGuruId GetElementId(params string[] searchTerms)
+        {
+            var foundFiles = new JetHashSet<IPsiSourceFile>();
+            foreach (var trigramIndex in myIndices)
+            {
+                // Search for files that contain ALL terms. We've already been filtered to files containing ANY term.
+                // We can't check for word boundaries because the index requires a word to start with a letter, and we
+                // can't guarantee that a guid will do so (and we search for "11500000", too)
+                foundFiles.AddRange(trigramIndex.GetFilesContainingQueries(searchTerms));
+            }
+            return new UnityYamlSearchGuruId(foundFiles);
+        }
+
+        private class UnityYamlSearchGuruId
+        {
+            public JetHashSet<IPsiSourceFile> Files { get; }
+
+            public UnityYamlSearchGuruId(JetHashSet<IPsiSourceFile> files)
+            {
+                Files = files;
+            }
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityFileSystemPathExtension.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityFileSystemPathExtension.cs
@@ -4,7 +4,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
 {
     public static class UnityFileSystemPathExtension
     {
-        public static bool IsYaml(this FileSystemPath sourceFile)
+        public static bool SniffYamlHeader(this FileSystemPath sourceFile)
         {
             var isYaml = sourceFile.ReadBinaryStream(reader =>
             {

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
@@ -9,5 +9,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
         {
             return sourceFile is UnityYamlAssetPsiSourceFile || sourceFile.GetLocation().IsAsset();
         }
+
+        public static bool IsMeta(this IPsiSourceFile sourceFile)
+        {
+            return sourceFile is UnityYamlExternalPsiSourceFile || sourceFile.GetLocation().IsMeta();
+        }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
@@ -7,7 +7,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
     {
         public static bool IsAsset(this IPsiSourceFile sourceFile)
         {
-            return sourceFile is UnityYamlAssetPsiSourceFile || sourceFile.GetLocation().IsAsset();
+            return sourceFile is UnityYamlAssetPsiSourceFile || sourceFile.GetLocation().IsInterestingAsset();
         }
 
         public static bool IsMeta(this IPsiSourceFile sourceFile)

--- a/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
@@ -18,7 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             myUnityHost = unityHost;
 
             myUnityHost.PerformModelAction(t =>
-                t.EnableYamlParsing.Advise(lifetime, _ => IsUnityYamlParsingEnabled.Value = true));
+                t.EnableYamlParsing.Advise(lifetime, _ => unityYamlSupport.IsUnityYamlParsingEnabled.Value = true));
         }
 
         protected override void NotifyYamlParsingDisabled()

--- a/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
@@ -11,16 +11,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         private readonly UnityHost myUnityHost;
 
-        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore, AssetSerializationMode assetSerializationMode,
-            UnityYamlSupport unityYamlSupport, UnityHost unityHost)
-            : base(lifetime, solution, settingsStore, assetSerializationMode, unityYamlSupport)
+        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore,
+                                             UnityYamlSupport unityYamlSupport, UnityHost unityHost)
+            : base(lifetime, solution, settingsStore, unityYamlSupport)
         {
             myUnityHost = unityHost;
-            
-            myUnityHost.PerformModelAction(t => t.EnableYamlParsing.Advise(lifetime, _ =>  YamlParsingEnabled.Value = true));
+
+            myUnityHost.PerformModelAction(t =>
+                t.EnableYamlParsing.Advise(lifetime, _ => IsUnityYamlParsingEnabled.Value = true));
         }
 
-        protected override void CreateNotification()
+        protected override void NotifyYamlParsingDisabled()
         {
             myUnityHost.PerformModelAction(t => t.NotifyYamlHugeFiles.Fire(RdVoid.Instance));
         }

--- a/resharper/resharper-unity/src/Yaml/Rider/UnityYamlFileSizeLogContributor.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/UnityYamlFileSizeLogContributor.cs
@@ -8,13 +8,13 @@ using Newtonsoft.Json.Linq;
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml
 {
     [SolutionComponent]
-    public class UnityYamlStatistics : IActivityLogContributorSolutionComponent
+    public class UnityYamlFileSizeLogContributor : IActivityLogContributorSolutionComponent
     {
         private readonly UnitySolutionTracker myUnitySolutionTracker;
         private readonly UnityYamlSupport myUnityYamlSupport;
         private readonly UnityExternalFilesModuleProcessor myModuleProcessor;
 
-        public UnityYamlStatistics(UnitySolutionTracker unitySolutionTracker, UnityYamlSupport unityYamlSupport, UnityExternalFilesModuleProcessor moduleProcessor)
+        public UnityYamlFileSizeLogContributor(UnitySolutionTracker unitySolutionTracker, UnityYamlSupport unityYamlSupport, UnityExternalFilesModuleProcessor moduleProcessor)
         {
             myUnitySolutionTracker = unitySolutionTracker;
             myUnityYamlSupport = unityYamlSupport;
@@ -34,6 +34,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             unityYamlStats["s"] = JArray.FromObject(myModuleProcessor.SceneSizes);
             unityYamlStats["p"] = JArray.FromObject(myModuleProcessor.PrefabSizes);
             unityYamlStats["a"] = JArray.FromObject(myModuleProcessor.AssetSizes);
+            unityYamlStats["kba"] = JArray.FromObject(myModuleProcessor.KnownBinaryAssetSizes);
+            unityYamlStats["ebna"] = JArray.FromObject(myModuleProcessor.ExcludedByNameAssetsSizes);
             unityYamlStats["e"] = myUnityYamlSupport.IsUnityYamlParsingEnabled.Value;
         }
     }

--- a/resharper/resharper-unity/src/Yaml/Rider/UnityYamlStatistics.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/UnityYamlStatistics.cs
@@ -20,21 +20,21 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             myUnityYamlSupport = unityYamlSupport;
             myModuleProcessor = moduleProcessor;
         }
-        
+
         public void ProcessSolutionStatistics(JObject log)
         {
             if (!myUnitySolutionTracker.IsUnityProject.HasTrueValue())
                 return;
-            
+
             if (myModuleProcessor.SceneSizes.Count == 0 && myModuleProcessor.PrefabSizes.Count == 0 && myModuleProcessor.AssetSizes.Count == 0)
                 return;
-            
+
             var unityYamlStats = new JObject();
             log["uys"] = unityYamlStats;
             unityYamlStats["s"] = JArray.FromObject(myModuleProcessor.SceneSizes);
             unityYamlStats["p"] = JArray.FromObject(myModuleProcessor.PrefabSizes);
             unityYamlStats["a"] = JArray.FromObject(myModuleProcessor.AssetSizes);
-            unityYamlStats["e"] = myUnityYamlSupport.IsYamlParsingEnabled.Value;
+            unityYamlStats["e"] = myUnityYamlSupport.IsUnityYamlParsingEnabled.Value;
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/UnityYamlFileExtensions.cs
@@ -7,7 +7,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
     public static class UnityYamlFileExtensions
     {
         public const string MetaFileExtensionWithDot = ".meta";
-        public static readonly string[] AssetFileExtensionsWithDot = {".unity", ".asset", ".prefab"};
+        public const string AssetFileExtensionWithDot = ".asset";
+        public const string PrefabFileExtensionWithDot = ".prefab";
+        public const string SceneFileExtensionWithDot = ".unity";
+
+        public static readonly string[] AssetFileExtensionsWithDot =
+        {
+            SceneFileExtensionWithDot, AssetFileExtensionWithDot, PrefabFileExtensionWithDot
+        };
         public static readonly string[] AllFileExtensionsWithDot;
 
         static UnityYamlFileExtensions()
@@ -22,21 +29,50 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
             return AllFileExtensionsWithDot.Contains(extensionWithDot, StringComparer.InvariantCultureIgnoreCase);
         }
 
-        public static bool IsAsset([NotNull] this FileSystemPath path)
+        public static bool IsAsset([NotNull] this IPath path)
         {
-            var fullPath = path.FullPath;
-            foreach (var extension in AllFileExtensionsWithDot)
+            return SimplePathEndsWith(path, AssetFileExtensionWithDot);
+        }
+
+        public static bool IsPrefab([NotNull] this IPath path)
+        {
+            return SimplePathEndsWith(path, PrefabFileExtensionWithDot);
+        }
+
+        public static bool IsScene([NotNull] this IPath path)
+        {
+            return SimplePathEndsWith(path, SceneFileExtensionWithDot);
+        }
+
+        // Do we have a better name than "asset" here? It's confusingly overloaded with .asset
+        public static bool IsInterestingAsset([NotNull] this IPath path)
+        {
+            foreach (var extension in AssetFileExtensionsWithDot)
             {
-                if (fullPath.EndsWith(extension, StringComparison.InvariantCultureIgnoreCase))
+                if (SimplePathEndsWith(path, extension))
                     return true;
             }
 
             return false;
         }
 
-        public static bool IsMeta([NotNull] this FileSystemPath path)
+        public static bool IsMeta([NotNull] this IPath path)
         {
-            return path.FullPath.EndsWith(MetaFileExtensionWithDot, StringComparison.InvariantCultureIgnoreCase);
+            return SimplePathEndsWith(path, MetaFileExtensionWithDot);
+        }
+
+        public static bool IsInterestingMeta([NotNull] this IPath path)
+        {
+            return SimplePathEndsWith(path, ".cs.meta")
+                   || SimplePathEndsWith(path, ".prefab.meta")
+                   || SimplePathEndsWith(path, ".unity.meta");
+        }
+
+        // Not to be confused with FileSystemPathEx.EndsWith, which handles path components. This is a simple text
+        // comparison, which can handle extensions without allocating another string
+        private static bool SimplePathEndsWith(IPath path, string expected)
+        {
+            return path.FullPath.EndsWith(expected, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/UnityYamlSupport.cs
+++ b/resharper/resharper-unity/src/Yaml/UnityYamlSupport.cs
@@ -10,22 +10,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
     [SolutionComponent]
     public class UnityYamlSupport
     {
-        public readonly IProperty<bool> IsYamlParsingEnabled;
-        public UnityYamlSupport(Lifetime lifetime, YamlSupport support, ISolution solution, ISettingsStore settingsStore)
+        public readonly IProperty<bool> IsUnityYamlParsingEnabled;
+
+        public UnityYamlSupport(Lifetime lifetime, YamlSupport yamlSupport, ISolution solution, ISettingsStore settingsStore)
         {
             var settings = settingsStore.BindToContextLive(lifetime,
                 ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
-            IsYamlParsingEnabled = settings.GetValueProperty(lifetime, (UnitySettings key) => key.IsYamlParsingEnabled);
-            
-            
-            if (!support.IsParsingEnabled.Value)
-                IsYamlParsingEnabled.Value = false;
+            IsUnityYamlParsingEnabled = settings.GetValueProperty(lifetime, (UnitySettings key) => key.IsYamlParsingEnabled);
 
-            IsYamlParsingEnabled.Change.Advise(lifetime, v =>
+            if (!yamlSupport.IsParsingEnabled.Value)
+                IsUnityYamlParsingEnabled.Value = false;
+
+            IsUnityYamlParsingEnabled.Change.Advise(lifetime, v =>
             {
                 if (v.HasNew && v.New)
                 {
-                    support.IsParsingEnabled.Value = true;
+                    yamlSupport.IsParsingEnabled.Value = true;
                     if (v.HasOld)
                         settings.SetValue((UnitySettings key) => key.ShouldApplyYamlHugeFileHeuristic, false);
                 }

--- a/resharper/resharper-unity/test/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
@@ -2,7 +2,6 @@ using System;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Tests.Yaml;
 using JetBrains.ReSharper.Plugins.Unity.Yaml;
-using JetBrains.ReSharper.Plugins.Yaml.Settings;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.UsageChecking
@@ -43,14 +42,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Daemon.UsageChecking
             myOnProjectStarted = project =>
             {
                 var yamlSupport = project.GetSolution().GetComponent<UnityYamlSupport>();
-                oldValue = yamlSupport.IsYamlParsingEnabled.Value;
-                yamlSupport.IsYamlParsingEnabled.Value = false;
+                oldValue = yamlSupport.IsUnityYamlParsingEnabled.Value;
+                yamlSupport.IsUnityYamlParsingEnabled.Value = false;
             };
 
             myOnProjectFinished = project =>
             {
                 var yamlSupport = project.GetSolution().GetComponent<UnityYamlSupport>();
-                yamlSupport.IsYamlParsingEnabled.Value = oldValue;
+                yamlSupport.IsUnityYamlParsingEnabled.Value = oldValue;
             };
 
             DoNamedTest();

--- a/resharper/resharper-yaml/src/Psi/Search/YamlReferenceSearcher.cs
+++ b/resharper/resharper-yaml/src/Psi/Search/YamlReferenceSearcher.cs
@@ -33,8 +33,7 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi.Search
     // Words come from IDomainSpecificSearcherFactory.GetAllPossibleWordsInFile
     public bool ProcessProjectItem<TResult>(IPsiSourceFile sourceFile, IFindResultConsumer<TResult> consumer)
     {
-      // TODO: The YAML assembly shouldn't know anything about .meta files
-      if (sourceFile.GetPrimaryPsiFile() is IYamlFile yamlFile && sourceFile.GetLocation().ExtensionNoDot != "meta")
+      if (sourceFile.GetPrimaryPsiFile() is IYamlFile yamlFile)
         return ProcessElement(yamlFile, consumer);
       return false;
     }

--- a/resharper/resharper-yaml/src/Psi/Search/YamlReferenceSearcher.cs
+++ b/resharper/resharper-yaml/src/Psi/Search/YamlReferenceSearcher.cs
@@ -29,8 +29,11 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi.Search
       }
     }
 
+    // Note that some searchers (such as ReferenceSearchProcessorBase) will filter by word index before calling this.
+    // Words come from IDomainSpecificSearcherFactory.GetAllPossibleWordsInFile
     public bool ProcessProjectItem<TResult>(IPsiSourceFile sourceFile, IFindResultConsumer<TResult> consumer)
     {
+      // TODO: The YAML assembly shouldn't know anything about .meta files
       if (sourceFile.GetPrimaryPsiFile() is IYamlFile yamlFile && sourceFile.GetLocation().ExtensionNoDot != "meta")
         return ProcessElement(yamlFile, consumer);
       return false;


### PR DESCRIPTION
Several problems during rename:

* Search domain too wide as part of initial search for usages
* False positives in the trigram index for binary files
* Suspicious references search post rename (it will do the rename, then do a reference search on all files that contain the original text and the renamed text. This can be a huge number of YAML files if the symbol is e.g. `x` or `GameObject`)

This PR:

- [x] Make sure the PSI source file's cached file system data is correctly initialised and updated when the file is changed. This was causing up to date checks to fail for PSI caches. Fixes [RIDER-23204](https://youtrack.jetbrains.com/issue/RIDER-23204)
- [x] Only create yaml reference searcher for elements that can appear in a yaml file
- [x] Only add asset guid to list of names to search in a file if renaming a Unity based class
- [x] Add an implementation of `ISearchGuru` that will narrow the search domain further by looking for YAML files that contain ALL of a collection of words (the default is search is ANY). It also ignores all `.meta` files
- [x] Update PSI module processor to exclude large binary assets and `LightingData.asset`. Files over 10Mb are "sniffed" for the `%YAML` file header, and excluded if it doesn't match
- [x] Also exclude `NavMesh.asset` and `OcclusionCullingData.asset`
- [x] Update statistics to separately capture file sizes for "known binary assets" and "excluded by name assets"
- [x] Add PSI cache to recognise binary files that aren't captured by the PSI module processor at solution load
- [x] Remove reference from PSI module to C# projects. Fixes [RIDER-23451](https://youtrack.jetbrains.com/issue/RIDER-23451).

Things to check in review:

* Validate assumptions made in `ISearchGuru` that the files must contain ALL of the given words
* Threshold of "large binary file" in PSI module processor (currently 10Mb)
* Validate method of invalidating cache when binary file is modified. Do we want to sniff on each modification?

Note that this PR does NOT fix suspicious reference searching. This appears to be expected behaviour from ReSharper.