### PR TITLE
Fixes in processing Unity scene hierarchy

### DIFF
--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFileProperties.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFileProperties.cs
@@ -18,6 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         public string GetDefaultNamespace() => string.Empty;
         public ICollection<PreProcessingDirective> GetDefines() => EmptyList<PreProcessingDirective>.InstanceList;
         public bool ShouldBuildPsi => myEnabled.Value;
+        // ClrToDoManager takes a lot of time inside yaml files, but if file is generated, it will be ignored by todomanager
         public bool IsGeneratedFile => true;
         public bool IsICacheParticipant => true;
         public bool ProvidesCodeModel => true;

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityPathSceneConsumer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityPathSceneConsumer.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
+{
+    public class UnityPathSceneConsumer : IUnitySceneProcessorConsumer
+    {
+        public readonly List<string> NameParts = new List<string>();
+        public void ConsumeGameObject(IYamlDocument gameObject, IBlockMappingNode modifications)
+        {
+            string name = null;
+            if (modifications != null)
+            {
+                var documentId = gameObject.GetFileId();
+                name = UnityObjectPsiUtil.GetValueFromModifications(modifications, documentId, UnityYamlConstants.NameProperty);
+            }
+            if (name == null)
+            {
+                name = gameObject.GetUnityObjectPropertyValue(UnityYamlConstants.NameProperty).AsString();
+            }
+
+            if (name?.Equals(string.Empty) == true)
+                name = null;
+            NameParts.Add(name ?? "INVALID");
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityPathSceneConsumer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityPathSceneConsumer.cs
@@ -21,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
 
             if (name?.Equals(string.Empty) == true)
                 name = null;
-            NameParts.Add(name ?? "INVALID");
+            NameParts.Add(name ?? "Unknown");
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/UnitySceneProcessor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnitySceneProcessor.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
+using JetBrains.ReSharper.Plugins.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Parsing;
+using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
+{
+    [SolutionComponent]
+    public class UnitySceneProcessor
+    {
+        private readonly UnityVersion myVersion;
+        private readonly MetaFileGuidCache myMetaFileGuidCache;
+        private readonly UnityExternalFilesModuleFactory myFactory;
+
+        public UnitySceneProcessor(UnityVersion version, MetaFileGuidCache metaFileGuidCache, UnityExternalFilesModuleFactory factory)
+        {
+            myVersion = version;
+            myMetaFileGuidCache = metaFileGuidCache;
+            myFactory = factory;
+        }
+
+        private static bool IsStripped(IYamlDocument element)
+        {
+            return ((element.Body.BlockNode as IChameleonBlockMappingNode)?.Properties?.LastChild as YamlTokenType.GenericTokenElement)?
+                   .GetText().Equals("stripped") == true;
+        }
+        
+        public void ProcessSceneHierarchyFromComponentToRoot(IYamlDocument startComponent, IUnitySceneProcessorConsumer consumer)
+        {
+            if (startComponent == null)
+                return;
+
+            var start = startComponent;
+            if (!IsStripped(startComponent)) // start component can be stripped, e.g : prefab's MonoBehavior's function is passed to button event handler
+            {
+                 // Component must be attached to game object
+                start = start.GetUnityObjectDocumentFromFileIDProperty(UnityYamlConstants.GameObjectProperty);
+                
+                // GameObject could be stripped, if another prefab's gameobject is modified via adding MonoBehaviour
+                if (!IsStripped(start))
+                {
+                    // Each GameObject must have Transform. We will use it to process scene hierarcy
+                    start = UnityObjectPsiUtil.FindTransformComponentForGameObject(start);
+                }
+            }
+            ProcessSceneHierarchyFromComponentToRootInner(start, consumer, null);   
+        }
+
+        
+        // Invariant : startGameObject is Transform Component if it is not stripped 
+        // This method traverse scene hierarchy via visiting transform components and push corresponding to transform GameObject into consumer
+        private void ProcessSceneHierarchyFromComponentToRootInner(IYamlDocument startUnityObject, IUnitySceneProcessorConsumer consumer, IBlockMappingNode modifications)
+        {
+            var currentUnityObject = startUnityObject;
+            while (currentUnityObject != null)
+            {
+                // Unity object could be stripped, it means, that corresponding real object belongs to another yaml file
+                // Also, it has reference to prefab instance in current file, which stores all prefab modification
+                if (IsStripped(currentUnityObject))
+                {
+                    var file = (IYamlFile) currentUnityObject.GetContainingFile();
+                    var correspondingId = currentUnityObject.GetUnityObjectPropertyValue(GetCorrespondingSourceObjectProperty())?.AsFileID();
+                    var prefabInstanceId = currentUnityObject.GetUnityObjectPropertyValue(GetPrefabInstanceProperty())?.AsFileID();
+                    
+                    // assert not null
+                    if (correspondingId == null || prefabInstanceId == null)
+                        return;
+                    
+                    var prefabInstance = file.FindDocumentByAnchor(prefabInstanceId.fileID);
+                    var prefabSourceFile = myMetaFileGuidCache.GetAssetFilePathsFromGuid(correspondingId.guid);
+                    if (prefabSourceFile.Count > 1 || prefabSourceFile.Count == 0)
+                        return;
+
+                    myFactory.PsiModule.NotNull("externalFilesModuleFactory.PsiModule != null")
+                        .TryGetFileByPath(prefabSourceFile.First(), out var sourceFile);
+
+                    if (sourceFile == null)
+                        return;
+                    
+                    // [TODO] Is prefab file committed???
+                    var prefabFile = (IYamlFile)sourceFile.GetDominantPsiFile<YamlLanguage>();
+
+                    var prefabStartGameObject = prefabFile.FindDocumentByAnchor(correspondingId.fileID);
+                    if (!IsStripped(prefabStartGameObject))
+                    {
+                        // !u!4 is transform. If tag is different, let's extract transform, there are two cases:
+                        // 1) prefabStartGameObject is GameObject(!u!1), take its transform
+                        // 2) prefabStartGameObject is Component, so get attached gameobject and from this gameobject take transform component
+                        if (!GetUnityObjectTag(prefabStartGameObject).Equals("!u!4"))
+                        {
+                            var attachedGameObject= prefabStartGameObject;
+                            if (!GetUnityObjectTag(prefabStartGameObject).Equals("!u!1"))
+                            {
+                                attachedGameObject =
+                                    attachedGameObject.GetUnityObjectDocumentFromFileIDProperty(UnityYamlConstants
+                                        .GameObjectProperty);
+                            }
+                            prefabStartGameObject = UnityObjectPsiUtil.FindTransformComponentForGameObject(attachedGameObject);
+                        }
+                    }
+                    var localModifications = UnityObjectPsiUtil.GetPrefabModification(prefabInstance);
+                    ProcessSceneHierarchyFromComponentToRootInner(prefabStartGameObject, consumer, localModifications);
+                    currentUnityObject = UnityObjectPsiUtil.GetTransformFromPrefabInstance(prefabInstance);
+                }
+                else
+                {
+                    // assert that startGameObject is GameObject
+                    var father = currentUnityObject.GetUnityObjectDocumentFromFileIDProperty(UnityYamlConstants.FatherProperty);
+                    var gameObject = currentUnityObject.GetUnityObjectDocumentFromFileIDProperty(UnityYamlConstants.GameObjectProperty);
+                    consumer.ConsumeGameObject(gameObject, modifications);
+                    currentUnityObject = father;
+                }
+            }
+        }
+
+        public static string GetUnityObjectTag(IYamlDocument document)
+        {
+            var tag = (document.Body.BlockNode as IChameleonBlockMappingNode)?.Properties.TagProperty.GetText();
+            return tag;
+        }
+        
+        private string GetCorrespondingSourceObjectProperty()
+        {
+            return myVersion.GetActualVersionForSolution().Major == 2017
+                ? UnityYamlConstants.CorrespondingSourceObjectProperty2017
+                : UnityYamlConstants.CorrespondingSourceObjectProperty;
+        }
+        
+        private string GetPrefabInstanceProperty()
+        {
+            return myVersion.GetActualVersionForSolution().Major == 2017
+                ? UnityYamlConstants.PrefabInstanceProperty2017
+                : UnityYamlConstants.PrefabInstanceProperty;
+        }
+    }
+
+    public interface IUnitySceneProcessorConsumer
+    {
+        void ConsumeGameObject(IYamlDocument gameObject, IBlockMappingNode modifications);
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlConstants.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlConstants.cs
@@ -20,7 +20,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
         public static readonly string ScriptProperty = "m_Script";
         public static readonly string FatherProperty = "m_Father";
         public static readonly string CorrespondingSourceObjectProperty = "m_CorrespondingSourceObject";
+        public static readonly string CorrespondingSourceObjectProperty2017 = "m_PrefabParentObject";
         public static readonly string PrefabInstanceProperty = "m_PrefabInstance";
+        public static readonly string PrefabInstanceProperty2017 = "m_PrefabInternal";
         public static readonly string TransformParentProperty = "m_TransformParent";
         public static readonly string ModificationProperty = "m_Modification";
         public static readonly string ModificationsProperty = "m_Modifications";

--- a/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Host/Feature/UnityYamlExtraGroupingRulesProvider.cs
@@ -18,13 +18,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
     public class UnityYamlExtraGroupingRulesProvider : IRiderExtraGroupingRulesProvider
     {
         // IconHost is optional so that we don't fail if we're in tests
-        public UnityYamlExtraGroupingRulesProvider(UnitySolutionTracker unitySolutionTracker = null, IconHost iconHost = null)
+        public UnityYamlExtraGroupingRulesProvider(UnitySceneProcessor sceneProcessor = null, UnitySolutionTracker unitySolutionTracker = null, IconHost iconHost = null)
         {
-            if (unitySolutionTracker != null && unitySolutionTracker.IsUnityProject.HasValue() && unitySolutionTracker.IsUnityProject.Value)
+            if (unitySolutionTracker != null && unitySolutionTracker.IsUnityProject.HasValue() && unitySolutionTracker.IsUnityProject.Value
+                && iconHost != null && sceneProcessor != null)
             {
                 ExtraRules = new IRiderUsageGroupingRule[]
                 {
-                    new GameObjectUsageGroupingRule(iconHost),
+                    new GameObjectUsageGroupingRule(sceneProcessor, iconHost),
                     new ComponentUsageGroupingRule(iconHost)
                 };
             }
@@ -75,9 +76,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
     // The priorities here put us after directory, file, namespace, type and member
     public class GameObjectUsageGroupingRule : UnityYamlUsageGroupingRuleBase
     {
-        public GameObjectUsageGroupingRule([CanBeNull] IconHost iconHost)
+        [NotNull] private readonly UnitySceneProcessor mySceneProcessor;
+
+        public GameObjectUsageGroupingRule([NotNull] UnitySceneProcessor sceneProcessor, [NotNull] IconHost iconHost)
             : base("Unity Game Object", UnityObjectTypeThemedIcons.UnityGameObject.Id, iconHost, 7.0)
         {
+            mySceneProcessor = sceneProcessor;
         }
 
         public override RdUsageGroup CreateModel(IOccurrence occurrence, IOccurrenceBrowserDescriptor descriptor)
@@ -85,7 +89,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
             if (occurrence is ReferenceOccurrence referenceOccurrence &&
                 referenceOccurrence.PrimaryReference is IUnityYamlReference reference)
             {
-                return CreateModel(UnityObjectPsiUtil.GetGameObjectPathFromComponent(reference.ComponentDocument));
+                return CreateModel(UnityObjectPsiUtil.GetGameObjectPathFromComponent(mySceneProcessor, reference.ComponentDocument));
             }
             return EmptyModel();
         }
@@ -100,7 +104,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Host.Feature
 
     public class ComponentUsageGroupingRule : UnityYamlUsageGroupingRuleBase
     {
-        public ComponentUsageGroupingRule([CanBeNull] IconHost iconHost)
+        public ComponentUsageGroupingRule([NotNull] IconHost iconHost)
             : base("Unity Component", UnityObjectTypeThemedIcons.UnityComponent.Id, iconHost, 8.0)
         {
         }

--- a/unity/EditorPlugin/Navigation/EntryPoint.cs
+++ b/unity/EditorPlugin/Navigation/EntryPoint.cs
@@ -1,16 +1,8 @@
 using System;
-using System.Linq;
-using System.Reflection;
-using JetBrains.Platform.RdFramework.Base;
-using JetBrains.Platform.RdFramework.Util;
-using JetBrains.Platform.Unity.EditorPluginModel;
-using JetBrains.Util;
+using JetBrains.Rider.Unity.Editor.Navigation.Window;
 using JetBrains.Util.Logging;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.SceneManagement;
 
 namespace JetBrains.Rider.Unity.Editor.Navigation
 {

--- a/unity/EditorPlugin/Navigation/ShowUtil.cs
+++ b/unity/EditorPlugin/Navigation/ShowUtil.cs
@@ -63,7 +63,7 @@ namespace JetBrains.Rider.Unity.Editor.Navigation
       for (int i = 1; i < rootIndices.Length; i++)
       {
         var transform = toSelect.transform;
-        if (rootIndices[i] >= transform.childCount)
+        if (rootIndices[i] >= transform.childCount || rootIndices[i] < 0)
           return;
 
         toSelect = transform.GetChild(rootIndices[i]).gameObject;

--- a/unity/EditorPlugin/Navigation/Window/AbstractUsageElement.cs
+++ b/unity/EditorPlugin/Navigation/Window/AbstractUsageElement.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   [Serializable]
   [SuppressMessage("ReSharper", "FieldCanBeMadeReadOnly.Global")]

--- a/unity/EditorPlugin/Navigation/Window/FindUsagePathElement.cs
+++ b/unity/EditorPlugin/Navigation/Window/FindUsagePathElement.cs
@@ -1,28 +1,35 @@
 using System.Collections.Generic;
 using UnityEditor.IMGUI.Controls;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   internal class FindUsagePathElement : TreeViewItem
   {
-    private readonly Dictionary<string, FindUsagePathElement> myChildren = new Dictionary<string, FindUsagePathElement>();
+    private readonly int myChildId;
+
+    public FindUsagePathElement(int childId)
+    {
+      myChildId = childId;
+    }
+    
+    private readonly Dictionary<int, FindUsagePathElement> myChildren = new Dictionary<int, FindUsagePathElement>();
 
     public FindUsagePathElement CreateChild(FindUsagePathElement item)
     {
-      myChildren[item.displayName] = item;
+      myChildren[item.myChildId] = item;
       AddChild(item);
       return item;
     }
 
-    public FindUsagePathElement GetChild(string name)
+    public FindUsagePathElement GetChild(int childId)
     {
-      myChildren.TryGetValue(name, out var result);
+      myChildren.TryGetValue(childId, out var result);
       return result;
     }
     
-    public bool HasChild(string name)
+    public bool HasChild(int childId)
     {
-      return myChildren.ContainsKey(name);
+      return myChildren.ContainsKey(childId);
     }
   }
 }

--- a/unity/EditorPlugin/Navigation/Window/FindUsagesTreeViewItem.cs
+++ b/unity/EditorPlugin/Navigation/Window/FindUsagesTreeViewItem.cs
@@ -1,12 +1,10 @@
-using UnityEditor.IMGUI.Controls;
-
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   internal class FindUsagesTreeViewItem : FindUsagePathElement
   {
     public AbstractUsageElement UsageElement { get; }
 
-    public FindUsagesTreeViewItem(AbstractUsageElement sceneElement)
+    public FindUsagesTreeViewItem(int id, AbstractUsageElement sceneElement) : base(id)
     {
       UsageElement = sceneElement;
     } 

--- a/unity/EditorPlugin/Navigation/Window/FindUsagesWindow.cs
+++ b/unity/EditorPlugin/Navigation/Window/FindUsagesWindow.cs
@@ -1,12 +1,10 @@
 using System;
-using JetBrains.DataFlow;
 using JetBrains.Platform.Unity.EditorPluginModel;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   internal class FindUsagesWindow : EditorWindow
   {

--- a/unity/EditorPlugin/Navigation/Window/FindUsagesWindowTreeState.cs
+++ b/unity/EditorPlugin/Navigation/Window/FindUsagesWindowTreeState.cs
@@ -4,7 +4,7 @@ using JetBrains.Platform.Unity.EditorPluginModel;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   [Serializable]
   internal class FindUsagesWindowTreeState : TreeViewState

--- a/unity/EditorPlugin/Navigation/Window/PrefabElement.cs
+++ b/unity/EditorPlugin/Navigation/Window/PrefabElement.cs
@@ -1,7 +1,6 @@
 using System;
-using UnityEngine;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   [Serializable]
   internal class PrefabElement : AbstractUsageElement

--- a/unity/EditorPlugin/Navigation/Window/SceneElement.cs
+++ b/unity/EditorPlugin/Navigation/Window/SceneElement.cs
@@ -1,7 +1,6 @@
 using System;
-using UnityEngine;
 
-namespace JetBrains.Rider.Unity.Editor.Navigation
+namespace JetBrains.Rider.Unity.Editor.Navigation.Window
 {
   [Serializable]
   internal class SceneElement : AbstractUsageElement


### PR DESCRIPTION
1. Extract Unity scene hierarchy iterator into class
2. Find usages correctly returs result for Unity 2017 LTS
3. Do not merge different game objects with same names in Find Usages Window in Unity Editor
4. Refactoring