### PR TITLE
Use frontend plugin ID for extensions folder ID

### DIFF
--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -73,7 +73,7 @@ def debuggerDllFiles = [
 ]
 
 def annotationsFrom = '../resharper/resharper-unity/src/annotations'
-def annotationsTo = 'Extensions/JetBrains.plugin_com_intellij_resharper_unity/annotations'
+def annotationsTo = 'Extensions/com.intellij.resharper.unity/annotations'
 
 def unityeditorplugin_path = "$projectDir/../unity/build/JetBrains.Rider.Unity.Editor.Plugin/Assets/Plugins/Editor/JetBrains/JetBrains.Rider.Unity.Editor.Plugin.Repacked.dll"
 def unityeditorplugin_full_path = "$projectDir/../unity/build/JetBrains.Rider.Unity.Editor.Plugin.Full/Assets/Plugins/Editor/JetBrains/JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked.dll"


### PR DESCRIPTION
Loads annotations in Rider with latest SDK. ReSharper still uses the ReSharper extension ID (`Extensions\JetBrains.Unity\annotations`) and now Rider uses the Rider plugin ID (`Extensions/com.intellij.resharper.unity/annotations`)