### PR TITLE
UX improvement

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityEventFunctionAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityEventFunctionAnalyzer.cs
@@ -64,7 +64,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
                     // Only one function, mark it as a unity function, even if it's not an exact match
                     // We'll let other inspections handle invalid signatures
                     var method = candidates[0].Method;
-                    PutIconToCustomData( method, data);
+                    PutEventToCustomData( method, data);
                     AddMethodSignatureInspections(consumer, method, function, candidates[0].Match);
                 }
                 else
@@ -77,7 +77,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
                     {
                         if (candidate.Match == MethodSignatureMatch.ExactMatch)
                         {
-                            PutIconToCustomData(candidate.Method, data);
+                            PutEventToCustomData(candidate.Method, data);
                             hasExactMatch = true;
                             duplicates.Add(candidate.Method);
                         }
@@ -103,7 +103,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
                         foreach (var candidate in candidates)
                         {
                             var method = candidate.Method;
-                            PutIconToCustomData(method, data);
+                            PutEventToCustomData(method, data);
                             AddMethodSignatureInspections(consumer, method, function, candidate.Match);
                         }
                     }
@@ -111,7 +111,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
             }
         }
 
-        private void PutIconToCustomData(IMethod method, ElementProblemAnalyzerData data)
+        private void PutEventToCustomData(IMethod method, ElementProblemAnalyzerData data)
         {
             lock (mySyncObject)
             {   

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/EventHandlerDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/EventHandlerDetector.cs
@@ -28,8 +28,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 : element.DeclaredElement as IMethod;
             if (declaredElement != null && myCache.IsEventHandler(declaredElement))
             {
-                myImplicitUsageHighlightingContributor.AddUnityEventHandler(consumer, element, "Unity event handler",
-                    element is IMethodDeclaration ? "Event function" : "Implicit usage", kind);
+                myImplicitUsageHighlightingContributor.AddUnityEventHandler(consumer, element as ICSharpDeclaration, "Unity event handler",
+                    element is IMethodDeclaration ? "Event handler" : "Implicit usage", kind);
                 return declaredElement;
             }
 

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
@@ -25,7 +25,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 return null;
 
             var declaredElement = field.DeclaredElement;
-            if (myUnityApi.IsSerialisedField(declaredElement) || myUnityApi.IsInjectedField(declaredElement))
+            
+            if (myUnityApi.IsSerialisedField(declaredElement) && (
+                    myUnityApi.IsDescendantOfMonoBehaviour(declaredElement?.GetContainingType()) ||
+                    myUnityApi.IsDescendantOfScriptableObject(declaredElement?.GetContainingType())
+                )
+                || myUnityApi.IsInjectedField(declaredElement))
             {
                 myImplicitUsageHighlightingContributor.AddUnityImplicitFieldUsage(consumer, field,
                     "This field is initialised by Unity", "Set by Unity", kind);

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -36,11 +36,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                     myContributor.AddUnityImplicitClassUsage(consumer, element,
                         "Unity entity component system object", "Unity ECS", kind);
                 }
-                else if (myUnityApi.IsSerializableType(typeElement))
-                {
-                    myContributor.AddUnityImplicitClassUsage(consumer, element,
-                        "Unity custom serializable type", "Unity serializable", kind);
-                }
 
                 return typeElement;
             }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingAbstractStage.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingAbstractStage.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Application.Settings;
-using JetBrains.Collections.Viewable;
 using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Daemon.CSharp.Stages;
@@ -23,15 +22,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings
     {
         protected readonly IEnumerable<IUnityDeclarationHiglightingProvider> HiglightingProviders;
         protected readonly UnityApi API;
-        private readonly UnitySolutionTracker mySolutionTracker;
         protected readonly UnityHighlightingContributor UnityHighlightingContributor;
 
-        public UnityHighlightingAbstractStage(IEnumerable<IUnityDeclarationHiglightingProvider> higlightingProviders, UnityApi api, UnitySolutionTracker solutionTracker,
-            UnityHighlightingContributor unityHighlightingContributor, SolutionAnalysisService swa, PerformanceCriticalCodeCallGraphAnalyzer analyzer)
+        public UnityHighlightingAbstractStage(IEnumerable<IUnityDeclarationHiglightingProvider> higlightingProviders, UnityApi api,
+            UnityHighlightingContributor unityHighlightingContributor)
         {
             HiglightingProviders = higlightingProviders;
             API = api;
-            mySolutionTracker = solutionTracker;
             UnityHighlightingContributor = unityHighlightingContributor;
         }
         protected override IDaemonStageProcess CreateProcess(IDaemonProcess process, IContextBoundSettingsStore settings,

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingGlobalStage.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingGlobalStage.cs
@@ -12,10 +12,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings
     public class UnityHighlightingGlobalStage : UnityHighlightingAbstractStage
     {
         public UnityHighlightingGlobalStage(IEnumerable<IUnityDeclarationHiglightingProvider> higlightingProviders,
-            UnityApi api, UnitySolutionTracker solutionTracker,
-            UnityHighlightingContributor unityHighlightingContributor, SolutionAnalysisService swa,
-            PerformanceCriticalCodeCallGraphAnalyzer analyzer)
-            : base(higlightingProviders, api, solutionTracker, unityHighlightingContributor, swa, analyzer)
+            UnityApi api, UnityHighlightingContributor unityHighlightingContributor)
+            : base(higlightingProviders, api, unityHighlightingContributor)
         {
         }
     }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingStage.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingStage.cs
@@ -12,10 +12,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings
     public class UnityHighlightingStage : UnityHighlightingAbstractStage
     {
         public UnityHighlightingStage(IEnumerable<IUnityDeclarationHiglightingProvider> higlightingProviders,
-            UnityApi api, UnitySolutionTracker solutionTracker,
-            UnityHighlightingContributor unityHighlightingContributor, SolutionAnalysisService swa,
-            PerformanceCriticalCodeCallGraphAnalyzer analyzer)
-            : base(higlightingProviders, api, solutionTracker, unityHighlightingContributor, swa, analyzer)
+            UnityApi api, UnityHighlightingContributor unityHighlightingContributor)
+            : base(higlightingProviders, api, unityHighlightingContributor)
         {
         }
     }

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/Bulbs/ShowUsagesInUnityBulbAction.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/Bulbs/ShowUsagesInUnityBulbAction.cs
@@ -1,0 +1,61 @@
+using System;
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Bulbs;
+using JetBrains.ReSharper.Plugins.Unity.Yaml;
+using JetBrains.ReSharper.Psi;
+using JetBrains.TextControl;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.Bulbs
+{
+    public class ShowUsagesInUnityBulbAction : BulbActionBase
+    {
+        private readonly IDeclaredElement myDeclaredElement;
+        private readonly AssetSerializationMode myAssetSerializationMode;
+        private readonly UnityEditorFindUsageResultCreator myCreator;
+        [NotNull] private readonly ConnectionTracker myTracker;
+
+        public ShowUsagesInUnityBulbAction([NotNull] IDeclaredElement method, AssetSerializationMode assetSerializationMode,
+            [NotNull] UnityEditorFindUsageResultCreator creator, [NotNull] ConnectionTracker tracker)
+        {
+            myDeclaredElement = method;
+            myAssetSerializationMode = assetSerializationMode;
+            myCreator = creator;
+            myTracker = tracker;
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution,
+            IProgressIndicator progress)
+        {
+            
+            if (!myAssetSerializationMode.IsForceText)
+            {
+                return textControl => ShowTooltip(textControl, "Feature is unavailable when the Unity asset serialisation mode is not set to “Force Text");
+            }
+            
+            if (!myTracker.IsConnectionEstablished())
+            {
+                return textControl => ShowTooltip(textControl, "Unity is not running");
+            }
+
+            
+            
+            myCreator.CreateRequestToUnity(myDeclaredElement, null, true);
+            return null;
+        }
+
+        public override string Text => "Show usages in Unity";
+        
+        public static bool IsAvailableFor(IDeclaredElement declaredElement, UnityApi api)
+        {
+            if (declaredElement == null)
+                return false;
+
+            if (declaredElement is IClass type && !api.IsUnityECSType(type))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/Bulbs/ShowUsagesInUnityBulbAction.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/Bulbs/ShowUsagesInUnityBulbAction.cs
@@ -31,7 +31,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.Bulbs
             
             if (!myAssetSerializationMode.IsForceText)
             {
-                return textControl => ShowTooltip(textControl, "Feature is unavailable when the Unity asset serialisation mode is not set to “Force Text");
+                return textControl => ShowTooltip(textControl, "Feature is unavailable when the Unity asset serialisation mode is not set to 'Force Text'");
             }
             
             if (!myTracker.IsConnectionEstablished())

--- a/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
+++ b/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
@@ -7,7 +7,6 @@ using JetBrains.Application.Threading.Tasks;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Host.Features.BackgroundTasks;
-using JetBrains.ReSharper.Plugins.Unity.Yaml;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;

--- a/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
+++ b/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
@@ -1,18 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Application.Threading;
 using JetBrains.Application.Threading.Tasks;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Host.Features.BackgroundTasks;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Psi.Files;
 using JetBrains.ReSharper.Psi.Impl.Search.Operations;
 using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Resources.Shell;
@@ -27,23 +26,23 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
     {
         private readonly Lifetime myLifetime;
         private readonly ISolution mySolution;
-        private readonly SearchDomainFactory mySearchDomainFactory;
+        private readonly ISearchDomain myYamlSearchDomain;
         private readonly IShellLocks myLocks;
+        private readonly RiderBackgroundTaskHost myBackgroundTaskHost;
         private readonly UnitySceneProcessor mySceneProcessor;
         private readonly UnityHost myUnityHost;
-        private readonly UnityExternalFilesPsiModule myModule;
         private readonly FileSystemPath mySolutionDirectoryPath;
 
         public UnityEditorFindUsageResultCreator(Lifetime lifetime, ISolution solution, SearchDomainFactory searchDomainFactory, IShellLocks locks, 
-            UnitySceneProcessor sceneProcessor, UnityHost unityHost, UnityExternalFilesModuleFactory externalFilesModuleFactory)
+            RiderBackgroundTaskHost backgroundTaskHost, UnitySceneProcessor sceneProcessor, UnityHost unityHost, UnityExternalFilesModuleFactory externalFilesModuleFactory)
         {
             myLifetime = lifetime;
             mySolution = solution;
-            mySearchDomainFactory = searchDomainFactory;
             myLocks = locks;
+            myBackgroundTaskHost = backgroundTaskHost;
             mySceneProcessor = sceneProcessor;
+            myYamlSearchDomain = searchDomainFactory.CreateSearchDomain(externalFilesModuleFactory.PsiModule);
             myUnityHost = unityHost;
-            myModule = externalFilesModuleFactory.PsiModule;
             mySolutionDirectoryPath = solution.SolutionDirectory;
         }
 
@@ -65,15 +64,28 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                 ? null
                 : CreateRequest(mySolutionDirectoryPath, mySceneProcessor, selectedReference, null);
 
+            var lifetimeDef = myLifetime.CreateNested();
+            var pi = new ProgressIndicator(myLifetime);
+            
+            var task = RiderBackgroundTaskBuilder.Create()
+                .WithTitle("Finding usages in Unity for: " + declaredElement.ShortName)
+                .AsIndeterminate()
+                .AsCancelable(() =>
+                {
+                    pi.Cancel();
+                })
+                .Build();
+
+            myBackgroundTaskHost.AddNewTask(lifetimeDef.Lifetime, task);
+            
             myLocks.Tasks.StartNew(myLifetime, Scheduling.MainGuard, () =>
             {
                 using (ReadLockCookie.Create())
                 {
-
-                    finder.FindAsync(new[] {declaredElement}, declaredElement.GetSearchDomain(),
-                        consumer, SearchPattern.FIND_USAGES ,new ProgressIndicator(myLifetime),
-                        FinderSearchRoot.Empty, new UnityUsagesAsyncFinderCallback(consumer, myUnityHost, declaredElement.ShortName,
-                            selectRequest, focusUnity));
+                    finder.FindAsync(new[] {declaredElement}, myYamlSearchDomain,
+                        consumer, SearchPattern.FIND_USAGES ,pi,
+                        FinderSearchRoot.Empty, new UnityUsagesAsyncFinderCallback(lifetimeDef, consumer, myUnityHost, myLocks,
+                            declaredElement.ShortName, selectRequest, focusUnity));
                 }
             });
         }
@@ -117,7 +129,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
 
             extension = path.ExtensionWithDot;
             fileName = path.NameWithoutExtension;
-            filePath =  String.Join("/", pathComponents);
+            filePath =  String.Join("/", pathComponents.Select(t => t.ToString()));
 
             return true;
         }
@@ -127,6 +139,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             private readonly UnitySceneProcessor mySceneProcessor;
             private readonly FileSystemPath mySolutionDirectoryPath;
             private readonly IUnityYamlReference mySelectedReference;
+            private FindExecution myFindExecution = FindExecution.Continue;
+            
             public List<FindUsageResultElement> Result = new List<FindUsageResultElement>();
 
             public UnityUsagesFinderConsumer(UnitySceneProcessor sceneProcessor, FileSystemPath solutionDirectoryPath, IUnityYamlReference selectedReference)
@@ -138,7 +152,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             
             public IUnityYamlReference Build(FindResult result)
             {
-                return null;
+                return (result as FindResultReference)?.Reference as IUnityYamlReference;
             }
 
             public FindExecution Merge(IUnityYamlReference data)
@@ -147,48 +161,52 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                 if (request != null)
                     Result.Add(request);
                 
-                return FindExecution.Continue;
+                return myFindExecution;
             }
+
         }
         
+
         private class UnityChildPathSceneConsumer : IUnitySceneProcessorConsumer
         {
             public readonly List<int> RootIndices = new List<int>();
             
             public void ConsumeGameObject(IYamlDocument gameObject, IBlockMappingNode modifications)
             {
+                int rootOrder = -1;
+                var transform = UnityObjectPsiUtil.FindTransformComponentForGameObject(gameObject);
+                if (modifications != null)
                 {
-                    int rootOrder = -1;
-                    var transform = UnityObjectPsiUtil.FindTransformComponentForGameObject(gameObject);
-                    if (modifications != null)
-                    {
-                        if (!int.TryParse(UnityObjectPsiUtil.GetValueFromModifications(modifications, transform.GetFileId(), UnityYamlConstants.RootOrderProperty)
-                            , out rootOrder))
-                            rootOrder = -1;
-                    }
-                    if (rootOrder == -1)
-                    {
-                        var rootOrderAsString = transform.GetUnityObjectPropertyValue(UnityYamlConstants.RootOrderProperty).AsString();
-                        if (!int.TryParse(rootOrderAsString, out rootOrder))
-                            rootOrder = -1;
-                    }
-                    RootIndices.Add(rootOrder);
+                    if (!int.TryParse(UnityObjectPsiUtil.GetValueFromModifications(modifications, transform.GetFileId(), UnityYamlConstants.RootOrderProperty), out rootOrder))
+                        rootOrder = -1;
                 }
+                if (rootOrder == -1)
+                {
+                    var rootOrderAsString = transform.GetUnityObjectPropertyValue(UnityYamlConstants.RootOrderProperty).AsString();
+                    if (!int.TryParse(rootOrderAsString, out rootOrder))
+                        rootOrder = -1;
+                }
+                RootIndices.Add(rootOrder);
             }
         }
-
+        
         private class UnityUsagesAsyncFinderCallback : IFinderAsyncCallback
         {
+            private readonly LifetimeDefinition myLifetimeDef;
             private readonly UnityUsagesFinderConsumer myConsumer;
             private readonly UnityHost myUnityHost;
+            private readonly IShellLocks myShellLocks;
             private readonly string myDisplayName;
             private readonly FindUsageResultElement mySelected;
             private readonly bool myFocusUnity;
 
-            public UnityUsagesAsyncFinderCallback(UnityUsagesFinderConsumer consumer, UnityHost unityHost, string displayName, FindUsageResultElement selected, bool focusUnity)
+            public UnityUsagesAsyncFinderCallback(LifetimeDefinition lifetimeDef, UnityUsagesFinderConsumer consumer, UnityHost unityHost, IShellLocks shellLocks, 
+                string displayName, FindUsageResultElement selected, bool focusUnity)
             {
+                myLifetimeDef = lifetimeDef;
                 myConsumer = consumer;
                 myUnityHost = unityHost;
+                myShellLocks = shellLocks;
                 myDisplayName = displayName;
                 mySelected = selected;
                 myFocusUnity = focusUnity;
@@ -196,16 +214,27 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
 
             public void Complete()
             {
-                if (myFocusUnity)
-                    UnityFocusUtil.FocusUnity(myUnityHost.GetValue(t => t.UnityProcessId.Value));
-            
-                if (mySelected != null)
-                    myUnityHost.PerformModelAction(t => t.ShowGameObjectOnScene.Fire(mySelected));
-                myUnityHost.PerformModelAction(t => t.FindUsageResults.Fire(new FindUsageResult(myDisplayName, myConsumer.Result.ToArray())));
+                if (myConsumer.Result.Count == 0)
+                    return;
+                
+                myShellLocks.Tasks.StartNew(myLifetimeDef.Lifetime, Scheduling.MainGuard, () =>
+                {
+                    if (myFocusUnity)
+                        UnityFocusUtil.FocusUnity(myUnityHost.GetValue(t => t.UnityProcessId.Value));
+
+                    if (mySelected != null)
+                        myUnityHost.PerformModelAction(t => t.ShowGameObjectOnScene.Fire(mySelected));
+                    myUnityHost.PerformModelAction(t =>
+                        t.FindUsageResults.Fire(new FindUsageResult(myDisplayName, myConsumer.Result.ToArray())));
+                    
+                    myLifetimeDef.Terminate();
+                });
+
             }
 
             public void Error(string message)
             {
+                myLifetimeDef.Terminate();
             }
         }
     }

--- a/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
+++ b/resharper/resharper-unity/src/Rider/UnityEditorFindUsageResultCreator.cs
@@ -2,12 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.Application.Threading;
+using JetBrains.Application.Threading.Tasks;
+using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Impl.Search.Operations;
 using JetBrains.ReSharper.Psi.Search;
+using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Rider.Model;
 using JetBrains.Util;
 using JetBrains.Util.Extension;
@@ -17,55 +25,61 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
     [SolutionComponent]
     public class UnityEditorFindUsageResultCreator
     {
+        private readonly Lifetime myLifetime;
         private readonly ISolution mySolution;
+        private readonly SearchDomainFactory mySearchDomainFactory;
+        private readonly IShellLocks myLocks;
         private readonly UnitySceneProcessor mySceneProcessor;
         private readonly UnityHost myUnityHost;
+        private readonly UnityExternalFilesPsiModule myModule;
         private readonly FileSystemPath mySolutionDirectoryPath;
 
-        public UnityEditorFindUsageResultCreator(ISolution solution, UnitySceneProcessor sceneProcessor, UnityHost unityHost)
+        public UnityEditorFindUsageResultCreator(Lifetime lifetime, ISolution solution, SearchDomainFactory searchDomainFactory, IShellLocks locks, 
+            UnitySceneProcessor sceneProcessor, UnityHost unityHost, UnityExternalFilesModuleFactory externalFilesModuleFactory)
         {
+            myLifetime = lifetime;
             mySolution = solution;
+            mySearchDomainFactory = searchDomainFactory;
+            myLocks = locks;
             mySceneProcessor = sceneProcessor;
             myUnityHost = unityHost;
+            myModule = externalFilesModuleFactory.PsiModule;
             mySolutionDirectoryPath = solution.SolutionDirectory;
         }
 
-        public bool CreateRequestToUnity([NotNull] IUnityYamlReference yamlReference, bool focusUnity)
+        public void CreateRequestToUnity([NotNull] IUnityYamlReference yamlReference, bool focusUnity)
         {
             var declaredElement = yamlReference.Resolve().DeclaredElement;
             if (declaredElement == null)
-                return false;
+                return;
             
-            return CreateRequestToUnity(declaredElement, yamlReference, focusUnity);
+            CreateRequestToUnity(declaredElement, yamlReference, focusUnity);
         }
 
-        public bool CreateRequestToUnity([NotNull] IDeclaredElement declaredElement, [CanBeNull] IUnityYamlReference selectedReference, bool focusUnity)
+        public void CreateRequestToUnity([NotNull] IDeclaredElement declaredElement, [CanBeNull] IUnityYamlReference selectedReference, bool focusUnity)
         {
-            var finder = mySolution.GetPsiServices().Finder;
-            var references = finder.FindAllReferences(declaredElement).OfType<IUnityYamlReference>();
+            var finder = mySolution.GetPsiServices().AsyncFinder;
+            var consumer = new UnityUsagesFinderConsumer(mySceneProcessor, mySolutionDirectoryPath, selectedReference);
 
-            var result = new List<FindUsageResultElement>();
+            var selectRequest = selectedReference == null
+                ? null
+                : CreateRequest(mySolutionDirectoryPath, mySceneProcessor, selectedReference, null);
 
-            foreach (var reference in references)
+            myLocks.Tasks.StartNew(myLifetime, Scheduling.MainGuard, () =>
             {
-                var request = CreateRequest(reference, selectedReference);
-                if (request != null)
-                    result.Add(request);
-            }
+                using (ReadLockCookie.Create())
+                {
 
-            if (result.Count == 0)
-                return false;
-
-            if (focusUnity)
-                UnityFocusUtil.FocusUnity(myUnityHost.GetValue(t => t.UnityProcessId.Value));
-            
-            if (selectedReference != null)
-                myUnityHost.PerformModelAction(t => t.ShowGameObjectOnScene.Fire(CreateRequest(selectedReference, null)));
-            myUnityHost.PerformModelAction(t => t.FindUsageResults.Fire(new FindUsageResult(declaredElement.ShortName, result.ToArray())));
-            return true;
+                    finder.FindAsync(new[] {declaredElement}, declaredElement.GetSearchDomain(),
+                        consumer, SearchPattern.FIND_USAGES ,new ProgressIndicator(myLifetime),
+                        FinderSearchRoot.Empty, new UnityUsagesAsyncFinderCallback(consumer, myUnityHost, declaredElement.ShortName,
+                            selectRequest, focusUnity));
+                }
+            });
         }
-        
-        private FindUsageResultElement CreateRequest([NotNull] IUnityYamlReference currentReference, [CanBeNull] IUnityYamlReference selectedReference)
+
+        private static FindUsageResultElement CreateRequest([NotNull] FileSystemPath solutionDirPath, [NotNull]UnitySceneProcessor sceneProcessor, 
+            [NotNull] IUnityYamlReference currentReference, [CanBeNull] IUnityYamlReference selectedReference)
         {
             var monoScriptDocument = currentReference.ComponentDocument;
 
@@ -73,27 +87,28 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             if (sourceFile == null)
                 return null;
 
-            var pathElements = UnityObjectPsiUtil.GetGameObjectPathFromComponent(mySceneProcessor, currentReference.ComponentDocument).RemoveEnd("\\").Split("\\");
+            var pathElements = UnityObjectPsiUtil.GetGameObjectPathFromComponent(sceneProcessor, currentReference.ComponentDocument).RemoveEnd("\\").Split("\\");
             
             // Constructing path of child indices
             var consumer = new UnityChildPathSceneConsumer();
-            mySceneProcessor.ProcessSceneHierarchyFromComponentToRoot(monoScriptDocument, consumer);
+            sceneProcessor.ProcessSceneHierarchyFromComponentToRoot(monoScriptDocument, consumer);
 
 
-            if (!GetPathFromAssetFolder(sourceFile, out var pathFromAsset, out var fileName, out var extension))
+            if (!GetPathFromAssetFolder(solutionDirPath, sourceFile, out var pathFromAsset, out var fileName, out var extension))
                 return null;
             bool needExpand = currentReference == selectedReference;
             bool isPrefab = extension.Equals(UnityYamlConstants.Prefab, StringComparison.OrdinalIgnoreCase);
             
             return new FindUsageResultElement(isPrefab, needExpand, pathFromAsset, fileName, pathElements, consumer.RootIndices.ToArray().Reverse().ToArray());
         }
-
-        private bool GetPathFromAssetFolder([NotNull] IPsiSourceFile file, out string filePath, out string fileName, out string extension)
+        
+        private static bool GetPathFromAssetFolder([NotNull] FileSystemPath solutionDirPath, [NotNull] IPsiSourceFile file, 
+            out string filePath, out string fileName, out string extension)
         {
             extension = null;
             filePath = null;
             fileName = null;
-            var path = file.GetLocation().MakeRelativeTo(mySolutionDirectoryPath);
+            var path = file.GetLocation().MakeRelativeTo(solutionDirPath);
             var assetFolder = path.Components.FirstOrEmpty;
             if (!assetFolder.Equals(UnityYamlConstants.AssetsFolder)) 
                 return false;
@@ -106,7 +121,36 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
 
             return true;
         }
+        
+        private class UnityUsagesFinderConsumer : IFindResultConsumer<IUnityYamlReference>
+        {
+            private readonly UnitySceneProcessor mySceneProcessor;
+            private readonly FileSystemPath mySolutionDirectoryPath;
+            private readonly IUnityYamlReference mySelectedReference;
+            public List<FindUsageResultElement> Result = new List<FindUsageResultElement>();
 
+            public UnityUsagesFinderConsumer(UnitySceneProcessor sceneProcessor, FileSystemPath solutionDirectoryPath, IUnityYamlReference selectedReference)
+            {
+                mySceneProcessor = sceneProcessor;
+                mySolutionDirectoryPath = solutionDirectoryPath;
+                mySelectedReference = selectedReference;
+            }
+            
+            public IUnityYamlReference Build(FindResult result)
+            {
+                return null;
+            }
+
+            public FindExecution Merge(IUnityYamlReference data)
+            {
+                var request = CreateRequest(mySolutionDirectoryPath, mySceneProcessor,  data, mySelectedReference);
+                if (request != null)
+                    Result.Add(request);
+                
+                return FindExecution.Continue;
+            }
+        }
+        
         private class UnityChildPathSceneConsumer : IUnitySceneProcessorConsumer
         {
             public readonly List<int> RootIndices = new List<int>();
@@ -130,6 +174,38 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                     }
                     RootIndices.Add(rootOrder);
                 }
+            }
+        }
+
+        private class UnityUsagesAsyncFinderCallback : IFinderAsyncCallback
+        {
+            private readonly UnityUsagesFinderConsumer myConsumer;
+            private readonly UnityHost myUnityHost;
+            private readonly string myDisplayName;
+            private readonly FindUsageResultElement mySelected;
+            private readonly bool myFocusUnity;
+
+            public UnityUsagesAsyncFinderCallback(UnityUsagesFinderConsumer consumer, UnityHost unityHost, string displayName, FindUsageResultElement selected, bool focusUnity)
+            {
+                myConsumer = consumer;
+                myUnityHost = unityHost;
+                myDisplayName = displayName;
+                mySelected = selected;
+                myFocusUnity = focusUnity;
+            }
+
+            public void Complete()
+            {
+                if (myFocusUnity)
+                    UnityFocusUtil.FocusUnity(myUnityHost.GetValue(t => t.UnityProcessId.Value));
+            
+                if (mySelected != null)
+                    myUnityHost.PerformModelAction(t => t.ShowGameObjectOnScene.Fire(mySelected));
+                myUnityHost.PerformModelAction(t => t.FindUsageResults.Fire(new FindUsageResult(myDisplayName, myConsumer.Result.ToArray())));
+            }
+
+            public void Error(string message)
+            {
             }
         }
     }

--- a/resharper/resharper-unity/src/Rider/UnityEditorOccurrence.cs
+++ b/resharper/resharper-unity/src/Rider/UnityEditorOccurrence.cs
@@ -25,7 +25,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                 return base.Navigate(solution, windowContext, transferFocus, tabOptions);
             
             var findRequestCreator = solution.GetComponent<UnityEditorFindUsageResultCreator>();
-            return findRequestCreator.CreateRequestToUnity(myUnityEventTargetReference, true);
+            findRequestCreator.CreateRequestToUnity(myUnityEventTargetReference, true);
+            return true;
         }
     }
 }

--- a/resharper/resharper-unity/src/Settings/UnitySettings.cs
+++ b/resharper/resharper-unity/src/Settings/UnitySettings.cs
@@ -26,6 +26,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
 
         [SettingsEntry(true, "Should yaml heuristic be applied?")]
         public bool ShouldApplyYamlHugeFileHeuristic;
+        
+        [SettingsEntry(true, "Is asset mode notification enabled?")]
+        public bool IsAssetModeNotificationEnabled;
 
         [SettingsEntry(true, "Enables syntax error highlighting, brace matching and more of YAML files for Unity")]
         public bool IsYamlParsingEnabled;

--- a/resharper/resharper-unity/src/Settings/UnitySettings.cs
+++ b/resharper/resharper-unity/src/Settings/UnitySettings.cs
@@ -27,9 +27,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
         [SettingsEntry(true, "Should yaml heuristic be applied?")]
         public bool ShouldApplyYamlHugeFileHeuristic;
         
-        [SettingsEntry(true, "Is asset mode notification enabled?")]
-        public bool IsAssetModeNotificationEnabled;
-
         [SettingsEntry(true, "Enables syntax error highlighting, brace matching and more of YAML files for Unity")]
         public bool IsYamlParsingEnabled;
 

--- a/resharper/resharper-unity/src/UnityApi.cs
+++ b/resharper/resharper-unity/src/UnityApi.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Util;
+using JetBrains.ReSharper.Psi.JavaScript.Tree.JsDoc;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.Util;
 
@@ -180,6 +182,25 @@ namespace JetBrains.ReSharper.Plugins.Unity
                 }
             }
             return null;
+        }
+
+        public bool IsDescendantOf([NotNull] IClrTypeName unityTypeClrName, [CanBeNull] ITypeElement type)
+        {
+            if (type == null)
+                return false;
+            var mb = TypeFactory.CreateTypeByCLRName(unityTypeClrName, type.Module);
+            return type.IsDescendantOf(mb.GetTypeElement());
+        }
+        
+        public bool IsDescendantOfMonoBehaviour([CanBeNull] ITypeElement type)
+        {
+            return IsDescendantOf(KnownTypes.MonoBehaviour, type);
+        }
+        
+        
+        public bool IsDescendantOfScriptableObject([CanBeNull] ITypeElement type)
+        {
+            return IsDescendantOf(KnownTypes.ScriptableObject, type);
         }
 
         public Version GetNormalisedActualVersion(IProject project)

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Caches;
 using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.Util;
@@ -12,25 +14,40 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     [SolutionComponent]
     public class UnityYamlDisableStrategy
     {
+        private const string SolutionCachesId = "ShouldApplyYamlHugeFileHeuristic";
         private const ulong AssetFileSizeThreshold = 40 * (1024 * 1024); // 40 MB
         private const ulong TotalFileSizeThreshold = 700 * (1024 * 1024); // 700 MB
 
-        private readonly IProperty<bool> myShouldRunHeuristic;
+        private readonly bool myShouldRunHeuristic;
+        private readonly SolutionCaches mySolutionCaches;
         private readonly UnityYamlSupport myUnityYamlSupport;
 
         private ulong myTotalSize;
 
-        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore, UnityYamlSupport unityYamlSupport)
+        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore, UnityYamlSupport unityYamlSupport)
         {
+            mySolutionCaches = solutionCaches;
             myUnityYamlSupport = unityYamlSupport;
             var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
-            myShouldRunHeuristic = boundStore.GetValueProperty(lifetime, (UnitySettings s) => s.ShouldApplyYamlHugeFileHeuristic);
+            var oldValue = boundStore.GetValue((UnitySettings s) => s.ShouldApplyYamlHugeFileHeuristic);
+            if (!oldValue)
+                mySolutionCaches.PersistentProperties[SolutionCachesId] = false.ToString();
+
+            if (mySolutionCaches.PersistentProperties.TryGetValue(SolutionCachesId, out var result))
+            {
+                myShouldRunHeuristic = Boolean.Parse(result);
+            }
+            else
+            {
+                myShouldRunHeuristic = true;
+            }
         }
 
         public void Run(List<DirectoryEntryData> directoryEntries)
         {
-            if (myShouldRunHeuristic.Value && myUnityYamlSupport.IsUnityYamlParsingEnabled.Value)
+            if (myShouldRunHeuristic && myUnityYamlSupport.IsUnityYamlParsingEnabled.Value)
             {
+                mySolutionCaches.PersistentProperties[SolutionCachesId] = false.ToString();
                 if (IsAnyFilePreventYamlParsing(directoryEntries) || myTotalSize > TotalFileSizeThreshold)
                 {
                     myUnityYamlSupport.IsUnityYamlParsingEnabled.Value = false;

--- a/resharper/resharper-unity/src/Yaml/Rider/AssetModeNotification.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/AssetModeNotification.cs
@@ -1,0 +1,33 @@
+using JetBrains.Application.Settings;
+using JetBrains.Collections.Viewable;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Rider;
+using JetBrains.ReSharper.Plugins.Unity.Settings;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Yaml
+{
+    [SolutionComponent]
+    public class AssetModeNotification
+    {
+        public AssetModeNotification(UnitySolutionTracker solutionTracker, AssetSerializationMode assetSerializationMode,
+            ISettingsStore settingsStore, UnityHost unityHost)
+        {
+            if (!solutionTracker.IsUnityProject.HasTrueValue())
+                return;
+
+            var settings = settingsStore.BindToContextTransient(ContextRange.ApplicationWide);
+            var enabled = settings.GetValue((UnitySettings key) => key.IsAssetModeNotificationEnabled);
+
+            if (enabled)
+            {
+                if (!assetSerializationMode.IsForceText)
+                {
+                    settings.SetValue((UnitySettings key) => key.IsAssetModeNotificationEnabled, false);
+                    unityHost.PerformModelAction(t => t.NotifyAssetModeForceText());
+                }
+            }
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Rider/AssetModeNotification.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/AssetModeNotification.cs
@@ -11,22 +11,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
     [SolutionComponent]
     public class AssetModeNotification
     {
-        public AssetModeNotification(UnitySolutionTracker solutionTracker, AssetSerializationMode assetSerializationMode,
-            ISettingsStore settingsStore, UnityHost unityHost)
+        public AssetModeNotification(UnitySolutionTracker solutionTracker, AssetSerializationMode assetSerializationMode, UnityHost unityHost)
         {
             if (!solutionTracker.IsUnityProject.HasTrueValue())
                 return;
 
-            var settings = settingsStore.BindToContextTransient(ContextRange.ApplicationWide);
-            var enabled = settings.GetValue((UnitySettings key) => key.IsAssetModeNotificationEnabled);
-
-            if (enabled)
+            if (!assetSerializationMode.IsForceText)
             {
-                if (!assetSerializationMode.IsForceText)
-                {
-                    settings.SetValue((UnitySettings key) => key.IsAssetModeNotificationEnabled, false);
-                    unityHost.PerformModelAction(t => t.NotifyAssetModeForceText());
-                }
+                unityHost.PerformModelAction(t => t.NotifyAssetModeForceText());
             }
         }
     }

--- a/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
@@ -1,6 +1,7 @@
 using JetBrains.Application.Settings;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Caches;
 using JetBrains.ReSharper.Plugins.Unity.Rider;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
@@ -10,9 +11,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         private readonly UnityHost myUnityHost;
 
-        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore,
+        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore,
                                              UnityYamlSupport unityYamlSupport, UnityHost unityHost)
-            : base(lifetime, solution, settingsStore, unityYamlSupport)
+            : base(lifetime, solution, solutionCaches, settingsStore, unityYamlSupport)
         {
             myUnityHost = unityHost;
 

--- a/resharper/resharper-unity/src/Yaml/VisualStudio/Psi/Modules/ReSharperUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/VisualStudio/Psi/Modules/ReSharperUnityYamlDisableStrategy.cs
@@ -2,6 +2,7 @@ using JetBrains.Application.Notifications;
 using JetBrains.Application.Settings;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Caches;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.VisualStudio.Psi.Modules
@@ -12,9 +13,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.VisualStudio.Psi.Modules
         private readonly Lifetime myLifetime;
         private readonly UserNotifications myNotifications;
 
-        public ReSharperUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, ISettingsStore settingsStore,
+        public ReSharperUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore,
                                                  UnityYamlSupport unityYamlSupport, UserNotifications notifications)
-            : base(lifetime, solution, settingsStore, unityYamlSupport)
+            : base(lifetime, solution, solutionCaches, settingsStore, unityYamlSupport)
         {
             myLifetime = lifetime;
             myNotifications = notifications;

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/resharper/Test01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/resharper/Test01.cs.gold
@@ -97,64 +97,64 @@ class MyClass
 }
 
 [Serializable]
-class ||SerialisableClass|(25)|(26)
+class SerialisableClass
 {
     // All serialised by Unity - gutter icons
-    public string ||ImplicitlyAssignedField|(27)|(28);
-    public string ||ImplicitlyAssignedMultiField1|(29)|(30), ||ImplicitlyAssignedMultiField2|(31)|(32);
-    [SerializeField] private int ||myImplicitlyAssignedPrivateField|(33)|(34);
+    public string ||ImplicitlyAssignedField|(25)|(26);
+    public string ||ImplicitlyAssignedMultiField1|(27)|(28), ||ImplicitlyAssignedMultiField2|(29)|(30);
+    [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(35)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(31)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(36)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(37)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(32)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(33)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(38)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(34)] private static string ourUnusedPrivateStaticField;
 }
 
 [Serializable]
-struct ||SerialisableStruct|(39)|(40)
+struct SerialisableStruct
 {
     // All serialised by Unity - gutter icons
-    public string ||ImplicitlyAssignedField|(41)|(42);
-    public string ||ImplicitlyAssignedMultiField1|(43)|(44), ||ImplicitlyAssignedMultiField2|(45)|(46);
-    [SerializeField] private int ||myImplicitlyAssignedPrivateField|(47)|(48);
+    public string ||ImplicitlyAssignedField|(35)|(36);
+    public string ||ImplicitlyAssignedMultiField1|(37)|(38), ||ImplicitlyAssignedMultiField2|(39)|(40);
+    [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(49)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(41)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(50)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(51)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(42)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(43)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(52)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(44)] private static string ourUnusedPrivateStaticField;
 }
 
 class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(53)] public string NotSerialised2;
+    [|SerializeField|(45)] public string NotSerialised2;
 }
 
 struct NotSerialisableStruct
 {
     public string NotSerialised1;
-    [|SerializeField|(54)] public string NotSerialised2;
+    [|SerializeField|(46)] public string NotSerialised2;
 }
 
 [Serializable]
 static class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(55)] public string NotSerialised2;
+    [|SerializeField|(47)] public string NotSerialised2;
 }
 
 ---------------------------------------------------------
@@ -191,34 +191,26 @@ This function can be a coroutine.
 (22): Unity Gutter Icon: Called when Unity first launches the editor, the player, or recompiles scripts
 (23): ReSharper Warning: Missing static modifier
 (24): ReSharper Warning: Missing static modifier
-(25): Unity Gutter Icon: Unity custom serializable type
+(25): Unity Gutter Icon: This field is serialized by Unity
 (26): ReSharper Unity Implicitly Used Identifier: 
-(27): Unity Gutter Icon: This field is initialised by Unity
+(27): Unity Gutter Icon: This field is serialized by Unity
 (28): ReSharper Unity Implicitly Used Identifier: 
-(29): Unity Gutter Icon: This field is initialised by Unity
+(29): Unity Gutter Icon: This field is serialized by Unity
 (30): ReSharper Unity Implicitly Used Identifier: 
-(31): Unity Gutter Icon: This field is initialised by Unity
-(32): ReSharper Unity Implicitly Used Identifier: 
-(33): Unity Gutter Icon: This field is initialised by Unity
-(34): ReSharper Unity Implicitly Used Identifier: 
-(35): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(36): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(37): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(38): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(39): Unity Gutter Icon: Unity custom serializable type
+(31): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(32): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(33): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(34): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(35): Unity Gutter Icon: This field is serialized by Unity
+(36): ReSharper Unity Implicitly Used Identifier: 
+(37): Unity Gutter Icon: This field is serialized by Unity
+(38): ReSharper Unity Implicitly Used Identifier: 
+(39): Unity Gutter Icon: This field is serialized by Unity
 (40): ReSharper Unity Implicitly Used Identifier: 
-(41): Unity Gutter Icon: This field is initialised by Unity
-(42): ReSharper Unity Implicitly Used Identifier: 
-(43): Unity Gutter Icon: This field is initialised by Unity
-(44): ReSharper Unity Implicitly Used Identifier: 
-(45): Unity Gutter Icon: This field is initialised by Unity
-(46): ReSharper Unity Implicitly Used Identifier: 
-(47): Unity Gutter Icon: This field is initialised by Unity
-(48): ReSharper Unity Implicitly Used Identifier: 
-(49): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(50): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(51): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(52): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(53): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(54): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(55): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(41): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(42): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(43): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(44): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(45): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(46): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(47): ReSharper Dead Code: Redundant 'SerializeField' attribute

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/rider/Test01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/rider/Test01.cs.gold
@@ -100,61 +100,61 @@ class MyClass
 class SerialisableClass
 {
     // All serialised by Unity - gutter icons
-    public string ImplicitlyAssignedField;
-    public string ImplicitlyAssignedMultiField1, ImplicitlyAssignedMultiField2;
+    public string ||ImplicitlyAssignedField|(25)|(26);
+    public string ||ImplicitlyAssignedMultiField1|(27)|(28), ||ImplicitlyAssignedMultiField2|(29)|(30);
     [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(25)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(31)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(26)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(27)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(32)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(33)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(28)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(34)] private static string ourUnusedPrivateStaticField;
 }
 
 [Serializable]
 struct SerialisableStruct
 {
     // All serialised by Unity - gutter icons
-    public string ImplicitlyAssignedField;
-    public string ImplicitlyAssignedMultiField1, ImplicitlyAssignedMultiField2;
+    public string ||ImplicitlyAssignedField|(35)|(36);
+    public string ||ImplicitlyAssignedMultiField1|(37)|(38), ||ImplicitlyAssignedMultiField2|(39)|(40);
     [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(29)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(41)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(30)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(31)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(42)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(43)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(32)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(44)] private static string ourUnusedPrivateStaticField;
 }
 
 class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(33)] public string NotSerialised2;
+    [|SerializeField|(45)] public string NotSerialised2;
 }
 
 struct NotSerialisableStruct
 {
     public string NotSerialised1;
-    [|SerializeField|(34)] public string NotSerialised2;
+    [|SerializeField|(46)] public string NotSerialised2;
 }
 
 [Serializable]
 static class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(35)] public string NotSerialised2;
+    [|SerializeField|(47)] public string NotSerialised2;
 }
 
 ---------------------------------------------------------
@@ -183,14 +183,26 @@ static class NotSerialisableClass
 (22): UnityCodeInsights: 
 (23): ReSharper Warning: Missing static modifier
 (24): ReSharper Warning: Missing static modifier
-(25): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(26): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(27): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(28): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(29): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(30): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(25): ReSharper Unity Implicitly Used Identifier: 
+(26): UnityCodeInsights: 
+(27): ReSharper Unity Implicitly Used Identifier: 
+(28): UnityCodeInsights: 
+(29): ReSharper Unity Implicitly Used Identifier: 
+(30): UnityCodeInsights: 
 (31): ReSharper Dead Code: Redundant 'SerializeField' attribute
 (32): ReSharper Dead Code: Redundant 'SerializeField' attribute
 (33): ReSharper Dead Code: Redundant 'SerializeField' attribute
 (34): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(35): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(35): ReSharper Unity Implicitly Used Identifier: 
+(36): UnityCodeInsights: 
+(37): ReSharper Unity Implicitly Used Identifier: 
+(38): UnityCodeInsights: 
+(39): ReSharper Unity Implicitly Used Identifier: 
+(40): UnityCodeInsights: 
+(41): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(42): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(43): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(44): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(45): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(46): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(47): ReSharper Dead Code: Redundant 'SerializeField' attribute

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/rider/Test01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/GutterMark/rider/Test01.cs.gold
@@ -97,64 +97,64 @@ class MyClass
 }
 
 [Serializable]
-class ||SerialisableClass|(25)|(26)
+class SerialisableClass
 {
     // All serialised by Unity - gutter icons
-    public string ||ImplicitlyAssignedField|(27)|(28);
-    public string ||ImplicitlyAssignedMultiField1|(29)|(30), ||ImplicitlyAssignedMultiField2|(31)|(32);
-    [SerializeField] private int ||myImplicitlyAssignedPrivateField|(33)|(34);
+    public string ImplicitlyAssignedField;
+    public string ImplicitlyAssignedMultiField1, ImplicitlyAssignedMultiField2;
+    [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(35)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(25)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(36)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(37)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(26)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(27)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(38)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(28)] private static string ourUnusedPrivateStaticField;
 }
 
 [Serializable]
-struct ||SerialisableStruct|(39)|(40)
+struct SerialisableStruct
 {
     // All serialised by Unity - gutter icons
-    public string ||ImplicitlyAssignedField|(41)|(42);
-    public string ||ImplicitlyAssignedMultiField1|(43)|(44), ||ImplicitlyAssignedMultiField2|(45)|(46);
-    [SerializeField] private int ||myImplicitlyAssignedPrivateField|(47)|(48);
+    public string ImplicitlyAssignedField;
+    public string ImplicitlyAssignedMultiField1, ImplicitlyAssignedMultiField2;
+    [SerializeField] private int myImplicitlyAssignedPrivateField;
 
     // Not serialized by Unity
     public const string UnusedConst = "hello";
     private const string UnusedPrivateConst = "hello";
-    [|SerializeField|(49)] private const string UnusedPrivateConst2 = "hello";
+    [|SerializeField|(29)] private const string UnusedPrivateConst2 = "hello";
     private string myUnusedField;
     public readonly string UnusedReadonlyField;
     [NonSerialized] public string ExplicitlyUnusedField;
-    [NonSerialized, |SerializeField|(50)] public string ExplicitlyUnusedField2;
-    [NonSerialized, |SerializeField|(51)] private string myExplicitlyUnusedField3;
+    [NonSerialized, |SerializeField|(30)] public string ExplicitlyUnusedField2;
+    [NonSerialized, |SerializeField|(31)] private string myExplicitlyUnusedField3;
     public static string UnusedStaticField;
-    [|SerializeField|(52)] private static string ourUnusedPrivateStaticField;
+    [|SerializeField|(32)] private static string ourUnusedPrivateStaticField;
 }
 
 class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(53)] public string NotSerialised2;
+    [|SerializeField|(33)] public string NotSerialised2;
 }
 
 struct NotSerialisableStruct
 {
     public string NotSerialised1;
-    [|SerializeField|(54)] public string NotSerialised2;
+    [|SerializeField|(34)] public string NotSerialised2;
 }
 
 [Serializable]
 static class NotSerialisableClass
 {
     public string NotSerialised1;
-    [|SerializeField|(55)] public string NotSerialised2;
+    [|SerializeField|(35)] public string NotSerialised2;
 }
 
 ---------------------------------------------------------
@@ -183,34 +183,14 @@ static class NotSerialisableClass
 (22): UnityCodeInsights: 
 (23): ReSharper Warning: Missing static modifier
 (24): ReSharper Warning: Missing static modifier
-(25): ReSharper Unity Implicitly Used Identifier: 
-(26): UnityCodeInsights: 
-(27): ReSharper Unity Implicitly Used Identifier: 
-(28): UnityCodeInsights: 
-(29): ReSharper Unity Implicitly Used Identifier: 
-(30): UnityCodeInsights: 
-(31): ReSharper Unity Implicitly Used Identifier: 
-(32): UnityCodeInsights: 
-(33): ReSharper Unity Implicitly Used Identifier: 
-(34): UnityCodeInsights: 
+(25): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(26): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(27): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(28): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(29): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(30): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(31): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(32): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(33): ReSharper Dead Code: Redundant 'SerializeField' attribute
+(34): ReSharper Dead Code: Redundant 'SerializeField' attribute
 (35): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(36): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(37): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(38): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(39): ReSharper Unity Implicitly Used Identifier: 
-(40): UnityCodeInsights: 
-(41): ReSharper Unity Implicitly Used Identifier: 
-(42): UnityCodeInsights: 
-(43): ReSharper Unity Implicitly Used Identifier: 
-(44): UnityCodeInsights: 
-(45): ReSharper Unity Implicitly Used Identifier: 
-(46): UnityCodeInsights: 
-(47): ReSharper Unity Implicitly Used Identifier: 
-(48): UnityCodeInsights: 
-(49): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(50): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(51): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(52): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(53): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(54): ReSharper Dead Code: Redundant 'SerializeField' attribute
-(55): ReSharper Dead Code: Redundant 'SerializeField' attribute

--- a/rider/protocol/src/main/kotlin/model/rider/RdUnityModel.kt
+++ b/rider/protocol/src/main/kotlin/model/rider/RdUnityModel.kt
@@ -82,6 +82,7 @@ object RdUnityModel : Ext(SolutionModel.Solution) {
         sink("startUnity", void)
         sink("notifyIsRecompileAndContinuePlaying", string)
         sink("notifyYamlHugeFiles", void)
+        sink("notifyAssetModeForceText", void)
         source("setScriptCompilationDuringPlay", ScriptCompilationDuringPlay)
         source("enableYamlParsing", void)
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
@@ -1,0 +1,48 @@
+package com.jetbrains.rider.plugins.unity.notifications
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.project.Project
+import com.jetbrains.rd.util.reactive.adviseNotNullOnce
+import com.jetbrains.rd.util.reactive.fire
+import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
+import com.jetbrains.rider.plugins.unity.UnityHost
+import javax.swing.event.HyperlinkEvent
+
+class AssetModeForceTextNotification(project: Project, private val unityHost: UnityHost): LifetimedProjectComponent(project) {
+
+    companion object {
+        private val notificationGroupId = NotificationGroup.balloonGroup("Unity Asset Mode")
+    }
+
+    init {
+        unityHost.model.notifyAssetModeForceText.adviseNotNullOnce(componentLifetime){
+            showNotificationIfNeeded()
+        }
+    }
+
+    private fun showNotificationIfNeeded() {
+
+        val message = """Some advanced integration features are unavailable when the Unity asset serialisation mode is not set to “Force Text”. Enable text serialisation to allow Rider to learn more about the structure of your scenes and assets.
+            <ul style="margin-left:10px">
+              <li><a href="LearnMoreNavigateAction">Learn more</a></li>
+            </ul>
+            """
+        val assetModeNotification = Notification(notificationGroupId.displayId, "Recommend switching to text asset serialisation mode", message, NotificationType.WARNING)
+        assetModeNotification.setListener { notification, hyperlinkEvent ->
+            if (hyperlinkEvent.eventType != HyperlinkEvent.EventType.ACTIVATED)
+                return@setListener
+
+            if (hyperlinkEvent.description == "LearnMoreNavigateAction"){
+                BrowserUtil.browse("https://github.com/JetBrains/resharper-unity/wiki/Asset-serialization-mode")
+                notification.hideBalloon()
+            }
+        }
+
+
+        Notifications.Bus.notify(assetModeNotification, project)
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
@@ -12,7 +12,7 @@ import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.plugins.unity.UnityHost
 import javax.swing.event.HyperlinkEvent
 
-class AssetModeForceTextNotification(private val propertiesComponent: PropertiesComponent, project: Project, private val unityHost: UnityHost): LifetimedProjectComponent(project) {
+class AssetModeForceTextNotification(private val propertiesComponent: PropertiesComponent, project: Project, unityHost: UnityHost): LifetimedProjectComponent(project) {
 
     companion object {
         private const val settingName = "do_not_show_unity_asset_mode_notification"
@@ -32,7 +32,7 @@ class AssetModeForceTextNotification(private val propertiesComponent: Properties
         val message = """Some advanced integration features are unavailable when the Unity asset serialisation mode is not set to “Force Text”. Enable text serialisation to allow Rider to learn more about the structure of your scenes and assets.
             <ul style="margin-left:10px">
               <a href="LearnMoreNavigateAction">Learn more</a>
-              <a href="doNotShow">Do not show</a> this notification for this solution. <a href="learnMore">Learn more</a>
+              <a href="doNotShow">Do not show</a> this notification for this solution.
             </ul>
             """
         val assetModeNotification = Notification(notificationGroupId.displayId, "Recommend switching to text asset serialisation mode", message, NotificationType.WARNING)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/AssetModeForceTextNotification.kt
@@ -1,20 +1,21 @@
 package com.jetbrains.rider.plugins.unity.notifications
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
 import com.jetbrains.rd.util.reactive.adviseNotNullOnce
-import com.jetbrains.rd.util.reactive.fire
 import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.plugins.unity.UnityHost
 import javax.swing.event.HyperlinkEvent
 
-class AssetModeForceTextNotification(project: Project, private val unityHost: UnityHost): LifetimedProjectComponent(project) {
+class AssetModeForceTextNotification(private val propertiesComponent: PropertiesComponent, project: Project, private val unityHost: UnityHost): LifetimedProjectComponent(project) {
 
     companion object {
+        private const val settingName = "do_not_show_unity_asset_mode_notification"
         private val notificationGroupId = NotificationGroup.balloonGroup("Unity Asset Mode")
     }
 
@@ -26,9 +27,12 @@ class AssetModeForceTextNotification(project: Project, private val unityHost: Un
 
     private fun showNotificationIfNeeded() {
 
+        if (propertiesComponent.getBoolean(AssetModeForceTextNotification.settingName)) return
+
         val message = """Some advanced integration features are unavailable when the Unity asset serialisation mode is not set to “Force Text”. Enable text serialisation to allow Rider to learn more about the structure of your scenes and assets.
             <ul style="margin-left:10px">
-              <li><a href="LearnMoreNavigateAction">Learn more</a></li>
+              <a href="LearnMoreNavigateAction">Learn more</a>
+              <a href="doNotShow">Do not show</a> this notification for this solution. <a href="learnMore">Learn more</a>
             </ul>
             """
         val assetModeNotification = Notification(notificationGroupId.displayId, "Recommend switching to text asset serialisation mode", message, NotificationType.WARNING)
@@ -38,6 +42,11 @@ class AssetModeForceTextNotification(project: Project, private val unityHost: Un
 
             if (hyperlinkEvent.description == "LearnMoreNavigateAction"){
                 BrowserUtil.browse("https://github.com/JetBrains/resharper-unity/wiki/Asset-serialization-mode")
+                notification.hideBalloon()
+            }
+
+            if (hyperlinkEvent.description == "doNotShow"){
+                propertiesComponent.setValue(AssetModeForceTextNotification.settingName, true)
                 notification.hideBalloon()
             }
         }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/ProcessesPanel.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/ProcessesPanel.kt
@@ -82,8 +82,10 @@ class ProcessesPanel : PanelWithButtons() {
 
             setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
             selectionModel.addListSelectionListener {
-                if (selectedRow > -1)
+                if (selectedRow > -1) {
                     vm.pid.value = vm.editorProcesses[selectedRow].pid
+                    vm.isUserSelectedPid.value = true
+                }
             }
 
             updateSelection(this)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorRunConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorRunConfiguration.kt
@@ -35,10 +35,12 @@ class UnityAttachToEditorRunConfiguration(project: Project, factory: UnityAttach
     override var port: Int = -1
     override var address: String = "127.0.0.1"
     var pid: Int? = null
+    var isUserSelectedPid = false
 
     override fun clone(): RunConfiguration {
         val configuration = super.clone() as UnityAttachToEditorRunConfiguration
         configuration.pid = pid
+        configuration.isUserSelectedPid = isUserSelectedPid
         return configuration
     }
 
@@ -67,7 +69,6 @@ class UnityAttachToEditorRunConfiguration(project: Project, factory: UnityAttach
             return UnityAttachToEditorProfileState(this, environment)
 
 
-
         return null
     }
 
@@ -85,7 +86,12 @@ class UnityAttachToEditorRunConfiguration(project: Project, factory: UnityAttach
         val processList = OSProcessUtil.getProcessList()
 
         // We might have a pid from a previous run, but the editor might have died
-        pid = checkValidEditorInstance(pid, processList) ?: findUnityEditorInstance(processList)
+        pid = if (isUserSelectedPid) {
+            checkValidEditorInstance(pid, processList) ?: findUnityEditorInstance(processList)
+        } else {
+            findUnityEditorInstance(processList)
+        }
+
         if (pid == null)
             return false
 
@@ -94,6 +100,7 @@ class UnityAttachToEditorRunConfiguration(project: Project, factory: UnityAttach
     }
 
     private fun findUnityEditorInstance(processList: Array<ProcessInfo>): Int? {
+        isUserSelectedPid = false
         return findUnityEditorInstanceFromEditorInstanceJson(processList)
             ?: findUnityEditorInstanceFromProcesses(processList)
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorSettingsEditor.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorSettingsEditor.kt
@@ -21,6 +21,7 @@ class UnityAttachToEditorSettingsEditor(project: Project) : SettingsEditor<Unity
 
     override fun checkEditorData(configuration: UnityAttachToEditorRunConfiguration) {
         configuration.pid = viewModel.pid.value
+        configuration.isUserSelectedPid = viewModel.isUserSelectedPid.value
     }
 
     override fun resetEditorFrom(configuration: UnityAttachToEditorRunConfiguration) {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorViewModel.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/configurations/UnityAttachToEditorViewModel.kt
@@ -16,7 +16,7 @@ class UnityAttachToEditorViewModel(val lifetime: Lifetime, project: Project) {
     val editorInstanceJsonStatus: EditorInstanceJsonStatus
     val editorProcesses: ViewableList<EditorProcessInfo> = ViewableList()
     val pid: IProperty<Int?> = Property(null)
-
+    val isUserSelectedPid : Property<Boolean> = Property(false)
     data class EditorProcessInfo(val name: String, val pid: Int?)
 
     init {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,7 @@
     <component><implementation-class>com.jetbrains.rider.plugins.unity.notifications.AutoSaveNotification</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.plugins.unity.notifications.OutOfSyncEditorNotification</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.plugins.unity.notifications.YamlHugeFileNotification</implementation-class></component>
+    <component><implementation-class>com.jetbrains.rider.plugins.unity.notifications.AssetModeForceTextNotification</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.settings.RiderUnitySettings</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.plugins.unity.run.DefaultRunConfigurationGenerator</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.plugins.unity.UnityHost</implementation-class></component>


### PR DESCRIPTION
1. "Show usages in Unity" Action is cancelable 
2.  "Show usages in Unity" executed on background thread 
3. Fix bug with attaching and entering playmode in different unity 
4. Add notification when "Show usages in Unity" is clicked and Unity asset mode is not "force text"
5. Do not create .dotSettings.user file when yaml heuristic is applied
6. Remove redundant code vision/highlightings for serializable types and fields
7. Remove "set by unity" for fields which are not in MonoBehaviour or Scriptable Object
8. Event function -> event handler for user functions
9. Do not suggest generate event function for non unity types