### PR TITLE
Fix exception for file: and git based packages

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
@@ -1,0 +1,142 @@
+package com.jetbrains.rider.plugins.unity.explorer
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.SimpleTextAttributes
+import com.jetbrains.rd.util.getOrCreate
+import com.jetbrains.rider.model.*
+import com.jetbrains.rider.plugins.unity.util.UnityIcons
+import com.jetbrains.rider.projectView.ProjectModelViewHost
+import com.jetbrains.rider.projectView.nodes.*
+import com.jetbrains.rider.projectView.views.addAdditionalText
+
+class AssetsRoot(project: Project, virtualFile: VirtualFile)
+    : UnityExplorerNode(project, virtualFile, listOf(), true) {
+
+    private val referenceRoot = ReferenceRoot(project)
+    private val solutionNode = ProjectModelViewHost.getInstance(project).solutionNode
+
+    override fun update(presentation: PresentationData) {
+        if (!virtualFile.isValid) return
+        presentation.addText("Assets", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+        presentation.setIcon(UnityIcons.Explorer.AssetsRoot)
+
+        val descriptor = solutionNode.descriptor as? RdSolutionDescriptor ?: return
+        val state = getAggregateSolutionState(descriptor)
+        when (state) {
+            RdSolutionState.Loading -> presentation.addAdditionalText("loading...")
+            RdSolutionState.Sync -> presentation.addAdditionalText("synchronizing...")
+            RdSolutionState.Ready -> {
+                if (descriptor.projectsCount.failed + descriptor.projectsCount.unloaded > 0) {
+                    presentProjectsCount(presentation, descriptor.projectsCount, true)
+                }
+            }
+            RdSolutionState.ReadyWithErrors -> presentation.addAdditionalText("load failed")
+            RdSolutionState.ReadyWithWarnings -> presentProjectsCount(presentation, descriptor.projectsCount, true)
+            else -> {}
+        }
+    }
+
+    private fun getAggregateSolutionState(descriptor: RdSolutionDescriptor): RdSolutionState {
+        var state = descriptor.state
+
+        // Solution loading/synchronizing takes precedence
+        if (state == RdSolutionState.Loading || state == RdSolutionState.Sync) {
+            return state
+        }
+
+        state = RdSolutionState.Ready
+        val children = solutionNode.getChildren(false, false)
+        for (child in children) {
+            if (child.isProject()) {
+                val projectDescriptor = child.descriptor as? RdProjectDescriptor ?: continue
+
+                // Aggregate project loading and sync. Loading takes precedence over sync
+                if (projectDescriptor.state == RdProjectState.Loading) {
+                    state = RdSolutionState.Loading
+                }
+                else if (projectDescriptor.state == RdProjectState.Sync && state != RdSolutionState.Loading) {
+                    state = RdSolutionState.Sync
+                }
+            }
+        }
+
+        // Make sure we don't miss solution ReadWithErrors
+        if (state == RdSolutionState.Ready) {
+            state = descriptor.state
+        }
+
+        return state
+    }
+
+    private fun presentProjectsCount(presentation: PresentationData, count: RdProjectsCount, showZero: Boolean) {
+        if (count.total == 0 && !showZero) return
+
+        var text = "${count.total} ${StringUtil.pluralize("project", count.total)}"
+        val unloadedCount = count.failed + count.unloaded
+        if (unloadedCount > 0) {
+            text += ", $unloadedCount unloaded"
+        }
+        presentation.addAdditionalText(text)
+    }
+
+    override fun isAlwaysExpand() = true
+
+    override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
+        val result = super.calculateChildren()
+        result.add(0, referenceRoot)
+        return result
+    }
+}
+
+class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key), Comparable<AbstractTreeNode<*>> {
+
+    companion object {
+        val key = Any()
+    }
+
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = "References"
+        presentation.setIcon(UnityIcons.Explorer.ReferencesRoot)
+    }
+
+    override fun getChildren(): MutableCollection<AbstractTreeNode<*>> {
+        val referenceNames = hashMapOf<String, ArrayList<ProjectModelNodeKey>>()
+        val visitor = object : ProjectModelNodeVisitor() {
+            override fun visitReference(node: ProjectModelNode): Result {
+                if (node.isAssemblyReference()) {
+                    val keys = referenceNames.getOrCreate(node.name) { _ -> arrayListOf() }
+                    keys.add(node.key)
+                }
+                return Result.Stop
+            }
+        }
+        visitor.visit(project!!)
+
+        val children = arrayListOf<AbstractTreeNode<*>>()
+        for ((referenceName, keys) in referenceNames) {
+            children.add(ReferenceItem(project!!, referenceName, keys))
+        }
+        return children
+    }
+
+    override fun compareTo(other: AbstractTreeNode<*>): Int {
+        if (other is UnityExplorerNode) return -1
+        return 0
+    }
+}
+
+class ReferenceItem(project: Project, private val referenceName: String, val keys: ArrayList<ProjectModelNodeKey>)
+    : AbstractTreeNode<String>(project, referenceName) {
+
+    override fun getChildren(): MutableCollection<out AbstractTreeNode<Any>> = arrayListOf()
+    override fun isAlwaysLeaf() = true
+
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = referenceName
+        presentation.setIcon(UnityIcons.Explorer.Reference)
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
@@ -92,7 +92,7 @@ class AssetsRoot(project: Project, virtualFile: VirtualFile)
     }
 }
 
-class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key), Comparable<AbstractTreeNode<*>> {
+class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key) {
 
     companion object {
         val key = Any()
@@ -121,11 +121,6 @@ class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key), Com
             children.add(ReferenceItem(project!!, referenceName, keys))
         }
         return children
-    }
-
-    override fun compareTo(other: AbstractTreeNode<*>): Int {
-        if (other is UnityExplorerNode) return -1
-        return 0
     }
 }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -164,19 +164,13 @@ class PackageNode(project: Project, private val packagesManager: PackagesManager
     }
 
     override fun compareTo(other: AbstractTreeNode<*>): Int {
-        if (other is PackageNode) {
-            return String.CASE_INSENSITIVE_ORDER.compare(name, other.name)
-        }
-        else if (other is ReadOnlyPackagesRoot || other is BuiltinPackagesRoot) {
-            return 1
-        }
-        // Other is UnresolvedPackageNode
-        return -1
+        // Compare by name, rather than ID
+        return String.CASE_INSENSITIVE_ORDER.compare(name, other.name)
     }
 }
 
 class DependenciesRoot(project: Project, private val packagesManager: PackagesManager, private val packageData: PackageData)
-    : AbstractTreeNode<Any>(project, packageData), Comparable<AbstractTreeNode<*>> {
+    : AbstractTreeNode<Any>(project, packageData) {
 
     override fun update(presentation: PresentationData) {
         presentation.presentableText = "Dependencies"
@@ -190,12 +184,10 @@ class DependenciesRoot(project: Project, private val packagesManager: PackagesMa
         }
         return children
     }
-
-    override fun compareTo(other: AbstractTreeNode<*>) = -1
 }
 
 class DependencyItemNode(project: Project, private val packagesManager: PackagesManager, private val packageName: String, version: String)
-    : AbstractTreeNode<Any>(project, "$packageName@$version"), Comparable<AbstractTreeNode<*>> {
+    : AbstractTreeNode<Any>(project, "$packageName@$version") {
 
     init {
         myName = "$packageName@$version"
@@ -217,10 +209,6 @@ class DependencyItemNode(project: Project, private val packagesManager: Packages
         val packageData = packagesManager.getPackageData(packageName)
         if (packageData?.packageFolder == null) return
         project!!.navigateToSolutionView(packageData.packageFolder, requestFocus)
-    }
-
-    override fun compareTo(other: AbstractTreeNode<*>): Int {
-        return String.CASE_INSENSITIVE_ORDER.compare(this.name, other.name)
     }
 }
 
@@ -244,7 +232,7 @@ abstract class CompositeFolderRoot(project: Project, key: Any)
 }
 
 class ReadOnlyPackagesRoot(project: Project, private val packagesManager: PackagesManager)
-    : CompositeFolderRoot(project, key), Comparable<AbstractTreeNode<*>> {
+    : CompositeFolderRoot(project, key) {
 
     companion object {
         val key = Any()
@@ -274,12 +262,10 @@ class ReadOnlyPackagesRoot(project: Project, private val packagesManager: Packag
         }
         return children
     }
-
-    override fun compareTo(other: AbstractTreeNode<*>) = -1
 }
 
 class BuiltinPackagesRoot(project: Project, private val packagesManager: PackagesManager)
-    : CompositeFolderRoot(project, key), Comparable<AbstractTreeNode<*>> {
+    : CompositeFolderRoot(project, key) {
 
     companion object {
         val key = Any()
@@ -305,8 +291,6 @@ class BuiltinPackagesRoot(project: Project, private val packagesManager: Package
         }
         return children
     }
-
-    override fun compareTo(other: AbstractTreeNode<*>) = -1
 }
 
 // Represents a module, built in part of the Unity product. We show it as a single node with no children, unless we have
@@ -314,7 +298,7 @@ class BuiltinPackagesRoot(project: Project, private val packagesManager: Package
 // Note that a module can have dependencies. Perhaps we want to always show this as a folder, including the Dependencies
 // node?
 class BuiltinPackageNode(project: Project, private val packageData: PackageData)
-    : FileSystemNodeBase(project, packageData.packageFolder!!, listOf()), Comparable<AbstractTreeNode<*>> {
+    : FileSystemNodeBase(project, packageData.packageFolder!!, listOf()) {
 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
 
@@ -369,22 +353,11 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
             presentation.tooltip = newTooltip
         }
     }
-
-    override fun compareTo(other: AbstractTreeNode<*>): Int {
-        if (other is BuiltinPackageNode) {
-            return String.CASE_INSENSITIVE_ORDER.compare(name, other.name)
-        }
-        else if (other is PackageNode) {
-            return 1
-        }
-        // other is UnknownPackageNode
-        return -1
-    }
 }
 
 // Note that this might get a PackageData with source == PackageSource.Unknown
 class UnknownPackageNode(project: Project, private val packageData: PackageData)
-    : AbstractTreeNode<Any>(project, packageData), Comparable<AbstractTreeNode<*>> {
+    : AbstractTreeNode<Any>(project, packageData) {
 
     init {
         icon = when (packageData.source) {
@@ -403,17 +376,6 @@ class UnknownPackageNode(project: Project, private val packageData: PackageData)
         if (packageData.details.description.isNotEmpty()) {
             presentation.tooltip = packageData.details.description
         }
-    }
-
-    override fun compareTo(other: AbstractTreeNode<*>): Int {
-        if (other is UnknownPackageNode) {
-            return String.CASE_INSENSITIVE_ORDER.compare(name, other.name)
-        }
-        if (other is UnityExplorerNode && other.file.isDirectory) {
-            return -1
-        }
-        // other is PackageNode or BuiltinPackageNode
-        return 1
     }
 }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/ShowReferencePropertiesAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/ShowReferencePropertiesAction.kt
@@ -20,7 +20,7 @@ class ShowReferencePropertiesAction : AnAction("Properties"), DumbAware {
         EditPropertiesAction.showDialog(node)
     }
 
-    private fun getReference(e: AnActionEvent): UnityExplorerNode.ReferenceItem? {
+    private fun getReference(e: AnActionEvent): ReferenceItem? {
         return e.getData(UnityExplorer.SELECTED_REFERENCE_KEY)
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
@@ -30,7 +30,7 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
 
         val Icon = UnityIcons.ToolWindows.UnityExplorer
         val IgnoredExtensions = hashSetOf("meta", "tmp")
-        val SELECTED_REFERENCE_KEY: DataKey<UnityExplorerNode.ReferenceItem> = DataKey.create("selectedReference")
+        val SELECTED_REFERENCE_KEY: DataKey<ReferenceItem> = DataKey.create("selectedReference")
 
         fun getInstance(project: Project) = tryGetInstance(project)!!
 
@@ -51,7 +51,7 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
 
     override fun getData(dataId: String): Any? {
         return when {
-            SELECTED_REFERENCE_KEY.`is`(dataId) -> getSelectedNodes().filterIsInstance<UnityExplorerNode.ReferenceItem>().singleOrNull()
+            SELECTED_REFERENCE_KEY.`is`(dataId) -> getSelectedNodes().filterIsInstance<ReferenceItem>().singleOrNull()
             else -> super.getData(dataId)
         }
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -5,18 +5,14 @@ import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.scratch.ScratchProjectViewPane
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.SimpleTextAttributes
-import com.jetbrains.rd.util.getOrCreate
-import com.jetbrains.rider.model.*
 import com.jetbrains.rider.plugins.unity.util.UnityIcons
 import com.jetbrains.rider.projectDir
 import com.jetbrains.rider.projectView.ProjectModelViewHost
 import com.jetbrains.rider.projectView.nodes.*
 import com.jetbrains.rider.projectView.views.FileSystemNodeBase
 import com.jetbrains.rider.projectView.views.SolutionViewRootNodeBase
-import com.jetbrains.rider.projectView.views.addAdditionalText
 import javax.swing.Icon
 
 class UnityExplorerRootNode(project: Project, private val packagesManager: PackagesManager)
@@ -24,7 +20,7 @@ class UnityExplorerRootNode(project: Project, private val packagesManager: Packa
 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
         val assetsFolder = myProject.projectDir.findChild("Assets")!!
-        val assetsNode = UnityExplorerNode.AssetsRoot(myProject, assetsFolder)
+        val assetsNode = AssetsRoot(myProject, assetsFolder)
 
         val nodes = mutableListOf<AbstractTreeNode<*>>(assetsNode)
 
@@ -220,133 +216,5 @@ open class UnityExplorerNode(project: Project,
         }
 
         return true
-    }
-
-    class AssetsRoot(project: Project, virtualFile: VirtualFile)
-        : UnityExplorerNode(project, virtualFile, listOf(), true) {
-
-        private val referenceRoot = ReferenceRoot(project)
-        private val solutionNode = ProjectModelViewHost.getInstance(project).solutionNode
-
-        override fun update(presentation: PresentationData) {
-            if (!virtualFile.isValid) return
-            presentation.addText("Assets", SimpleTextAttributes.REGULAR_ATTRIBUTES)
-            presentation.setIcon(UnityIcons.Explorer.AssetsRoot)
-
-            val descriptor = solutionNode.descriptor as? RdSolutionDescriptor ?: return
-            val state = getAggregateSolutionState(descriptor)
-            when (state) {
-                RdSolutionState.Loading -> presentation.addAdditionalText("loading...")
-                RdSolutionState.Sync -> presentation.addAdditionalText("synchronizing...")
-                RdSolutionState.Ready -> {
-                    if (descriptor.projectsCount.failed + descriptor.projectsCount.unloaded > 0) {
-                        presentProjectsCount(presentation, descriptor.projectsCount, true)
-                    }
-                }
-                RdSolutionState.ReadyWithErrors -> presentation.addAdditionalText("load failed")
-                RdSolutionState.ReadyWithWarnings -> presentProjectsCount(presentation, descriptor.projectsCount, true)
-                else -> {}
-            }
-        }
-
-        private fun getAggregateSolutionState(descriptor: RdSolutionDescriptor): RdSolutionState {
-            var state = descriptor.state
-
-            // Solution loading/synchronizing takes precedence
-            if (state == RdSolutionState.Loading || state == RdSolutionState.Sync) {
-                return state
-            }
-
-            state = RdSolutionState.Ready
-            val children = solutionNode.getChildren(false, false)
-            for (child in children) {
-                if (child.isProject()) {
-                    val projectDescriptor = child.descriptor as? RdProjectDescriptor ?: continue
-
-                    // Aggregate project loading and sync. Loading takes precedence over sync
-                    if (projectDescriptor.state == RdProjectState.Loading) {
-                        state = RdSolutionState.Loading
-                    }
-                    else if (projectDescriptor.state == RdProjectState.Sync && state != RdSolutionState.Loading) {
-                        state = RdSolutionState.Sync
-                    }
-                }
-            }
-
-            // Make sure we don't miss solution ReadWithErrors
-            if (state == RdSolutionState.Ready) {
-                state = descriptor.state
-            }
-
-            return state
-        }
-
-        private fun presentProjectsCount(presentation: PresentationData, count: RdProjectsCount, showZero: Boolean) {
-            if (count.total == 0 && !showZero) return
-
-            var text = "${count.total} ${StringUtil.pluralize("project", count.total)}"
-            val unloadedCount = count.failed + count.unloaded
-            if (unloadedCount > 0) {
-                text += ", $unloadedCount unloaded"
-            }
-            presentation.addAdditionalText(text)
-        }
-
-        override fun isAlwaysExpand() = true
-
-        override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
-            val result = super.calculateChildren()
-            result.add(0, referenceRoot)
-            return result
-        }
-    }
-
-    class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key), Comparable<AbstractTreeNode<*>> {
-
-        companion object {
-            val key = Any()
-        }
-
-        override fun update(presentation: PresentationData) {
-            presentation.presentableText = "References"
-            presentation.setIcon(UnityIcons.Explorer.ReferencesRoot)
-        }
-
-        override fun getChildren(): MutableCollection<AbstractTreeNode<*>> {
-            val referenceNames = hashMapOf<String, ArrayList<ProjectModelNodeKey>>()
-            val visitor = object : ProjectModelNodeVisitor() {
-                override fun visitReference(node: ProjectModelNode): Result {
-                    if (node.isAssemblyReference()) {
-                        val keys = referenceNames.getOrCreate(node.name) { _ -> arrayListOf() }
-                        keys.add(node.key)
-                    }
-                    return Result.Stop
-                }
-            }
-            visitor.visit(project!!)
-
-            val children = arrayListOf<AbstractTreeNode<*>>()
-            for ((referenceName, keys) in referenceNames) {
-                children.add(ReferenceItem(project!!, referenceName, keys))
-            }
-            return children
-        }
-
-        override fun compareTo(other: AbstractTreeNode<*>): Int {
-            if (other is UnityExplorerNode) return -1
-            return 0
-        }
-    }
-
-    class ReferenceItem(project: Project, private val referenceName: String, val keys: ArrayList<ProjectModelNodeKey>)
-        : AbstractTreeNode<String>(project, referenceName) {
-
-        override fun getChildren(): MutableCollection<out AbstractTreeNode<Any>> = arrayListOf()
-        override fun isAlwaysLeaf() = true
-
-        override fun update(presentation: PresentationData) {
-            presentation.presentableText = referenceName
-            presentation.setIcon(UnityIcons.Explorer.Reference)
-        }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -34,6 +34,39 @@ class UnityExplorerRootNode(project: Project, private val packagesManager: Packa
 
         return nodes
     }
+
+    override fun createComparator(): Comparator<AbstractTreeNode<*>> {
+        val comparator = super.createComparator()
+        return Comparator { node1, node2 ->
+            val sortKey1 = getSortKey(node1)
+            val sortKey2 = getSortKey(node2)
+
+            if (sortKey1 != sortKey2) {
+                return@Comparator sortKey1.compareTo(sortKey2)
+            }
+
+            comparator.compare(node1, node2)
+        }
+    }
+
+    private fun getSortKey(node: AbstractTreeNode<*>): Int {
+        // Nodes of the same type should be sorted as the same. Different types should be in this order (although some
+        // are in different levels of the hierarchy)
+        return when (node) {
+            is AssetsRoot -> 1
+            is PackagesRoot -> 2
+            is ReferenceRoot -> 3
+            is ReadOnlyPackagesRoot -> 4
+            is BuiltinPackagesRoot -> 5
+            is PackageNode -> 6
+            is DependenciesRoot -> 7
+            is DependencyItemNode -> 8
+            is BuiltinPackageNode -> 9
+            is UnknownPackageNode -> 100
+            is UnityExplorerNode -> 1000
+            else -> 10000
+        }
+    }
 }
 
 open class UnityExplorerNode(project: Project,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerProjectModelViewUpdater.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerProjectModelViewUpdater.kt
@@ -45,7 +45,7 @@ class UnityExplorerProjectModelViewUpdater(project: Project) : ProjectModelViewU
         if (node?.descriptor is RdSolutionDescriptor || node?.descriptor is RdProjectDescriptor) {
             pane?.refresh(object : SolutionViewVisitor() {
                 override fun visit(node: AbstractTreeNode<*>): TreeVisitor.Action {
-                    if (node is UnityExplorerNode.AssetsRoot) {
+                    if (node is AssetsRoot) {
                         return TreeVisitor.Action.INTERRUPT
                     }
 


### PR DESCRIPTION
This PR will:

- [x] Correctly handle local `file:` and git based packages in Unity Explorer
- [x] Unresolved packages will no longer crash the Unity Explorer, but be displayed as unresolved nodes
- [x] Simplify sorting nodes in the Unity Explorer tree

Fixes #1095, fixes [RIDER-25971](https://youtrack.jetbrains.com/issue/RIDER-25971)