### PR TITLE
Fix non-Windows build

### DIFF
--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -103,6 +103,8 @@ task publishCiBuildData {
     dependsOn publishCiBuildNumber, publishCiBackendArtifacts
 }
 
-if (buildServer.automatedBuild) {
+// Temporary workaround - we don't have full build data on any other platform than Windows, because the
+// ReSharper solution causes msbuild to crash on non-Windows platforms thanks to obfuscated assemblies
+if (buildServer.automatedBuild && ext.isWindows) {
     buildPlugin.finalizedBy publishCiBuildData
 }

--- a/rider/buildSrc/build.gradle.kts
+++ b/rider/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    "compile"("gradle.plugin.org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "0.4.3")
+    "compile"("gradle.plugin.org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "0.4.7")
 }
 
 plugins {

--- a/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/BackendPaths.kt
+++ b/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/BackendPaths.kt
@@ -25,7 +25,7 @@ class BackendPaths(private val project: Project, logger: Logger, val repositoryR
         unityPluginSolution = File(unityRoot, "JetBrains.Rider.Unity.Editor.sln")
 
         // Temporary workaround - the R# SDK contains yFile assembly that is obfuscated, and kills msbuild on mac
-        val sln = if (Os.isFamily(Os.FAMILY_MAC)) "rider-unity.sln" else "resharper-unity.sln"
+        val sln = if (!Os.isFamily(Os.FAMILY_WINDOWS)) "rider-unity.sln" else "resharper-unity.sln"
         resharperHostPluginSolution = File(backendRoot, sln)
         assert(resharperHostPluginSolution.isFile)
 

--- a/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/BackendPaths.kt
+++ b/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/BackendPaths.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.rider.plugins.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.jetbrains.intellij.IntelliJPluginExtension
@@ -23,7 +24,9 @@ class BackendPaths(private val project: Project, logger: Logger, val repositoryR
         unityRoot = File(repositoryRoot, "unity")
         unityPluginSolution = File(unityRoot, "JetBrains.Rider.Unity.Editor.sln")
 
-        resharperHostPluginSolution = File(backendRoot, "resharper-unity.sln")
+        // Temporary workaround - the R# SDK contains yFile assembly that is obfuscated, and kills msbuild on mac
+        val sln = if (Os.isFamily(Os.FAMILY_MAC)) "rider-unity.sln" else "resharper-unity.sln"
+        resharperHostPluginSolution = File(backendRoot, sln)
         assert(resharperHostPluginSolution.isFile)
 
         bundledRiderSdkPath = File(repositoryRoot, "rider/dependencies")


### PR DESCRIPTION
- [x] Update `gradle-intellij-plugin` to 0.4.7, which correctly sets file permissions in latest Rider SDK on Mac
- [x] Defaults to building rider-unity.sln on Mac and Linux, to work around issue with msbuild crashing on obfuscated files that are in the R# SDK, but not included in the Rider SDK
- [x] Does not run the "publish CI data" build step on non-Windows machines. This requires the ReSharper solution to be built and only actually does anything useful on TeamCity (on Windows)

This gives us a green build on CI again