### PR TITLE
Add project name to list of debuggable players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Add support for marking ECS types and fields as "in use" ([#1010](https://github.com/JetBrains/resharper-unity/issues/1010), [#1036](https://github.com/JetBrains/resharper-unity/pull/1036))
 - Rider: Add support for git packages in Unity Explorer ([#1028](https://github.com/JetBrains/resharper-unity/issues/1028))
 - Rider: Add notification if there isn't a player log to show ([#820](https://github.com/JetBrains/resharper-unity/issues/820), [#1006](https://github.com/JetBrains/resharper-unity/pull/1006) - thanks @ajon542!)
-- Add dialog with proposition to install mono for Unity project with new Scripting runtime ([RIDER-24005](https://youtrack.jetbrains.com/issue/RIDER-24005)
+- Rider: Add dialog to prompt to install mono for Unity project with new Scripting runtime ([RIDER-24005](https://youtrack.jetbrains.com/issue/RIDER-24005))
+- Rider: Add project name to list of debuggable players (Unity 2019.2 only) ([#1114](https://github.com/JetBrains/resharper-unity/pull/1114))
 
 ### Changed
 - Performance critical context now works cross files ([#1037](https://github.com/JetBrains/resharper-unity/pull/1037))
@@ -26,6 +27,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 ### Fixed
 - Rider: Show packages from correct per-project cache in Unity Explorer
 - Rider: Fix creation of Unity class library project if can't find Unity install ([#1013](https://github.com/JetBrains/resharper-unity/issue/1013), [#1014](https://github.com/JetBrains/resharper-unity/pull/1014))
+- Rider: Minor UI annoyances in "Attach to Unity process" dialog ([#1114](https://github.com/JetBrains/resharper-unity/pull/1114))
 - Unity Editor: Use unique name for log file ([#1020](https://github.com/JetBrains/resharper-unity/pull/1020))
 - Unity Editor: Don't call Unity API in batch mode ([#1020](https://github.com/JetBrains/resharper-unity/pull/1020))
 - Unity Editor: Fix exception during Unity shutdown ([RIDER-19688](https://youtrack.jetbrains.com/issue/RIDER-19688), [#979](https://github.com/JetBrains/resharper-unity/pull/979))

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityPlayer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityPlayer.kt
@@ -2,4 +2,17 @@ package com.jetbrains.rider.plugins.unity.run.attach
 
 data class UnityPlayer(val host: String, val port: Int, val debuggerPort: Int,
                        val flags: Long, val guid: Long, val editorId: Long, val version: Int,
-                       val id: String, val allowDebugging: Boolean, val isEditor: Boolean)
+                       val id: String, val allowDebugging: Boolean, val packageName: String? = null,
+                       val projectName: String? = null, val isEditor: Boolean = false) {
+    companion object {
+        fun createEditorPlayer(host: String, port: Int, id: String, projectName: String?): UnityPlayer {
+            return UnityPlayer(host, port, port, flags = 0, guid = port.toLong(), editorId = port.toLong(), version = 0,
+                id = id, allowDebugging = true, projectName = projectName, isEditor = true)
+        }
+
+        fun createRemotePlayer(host: String, port: Int): UnityPlayer {
+            return UnityPlayer(host, port, port, flags = 0, guid = port.toLong(), editorId = port.toLong(), version = 0,
+                id = host, allowDebugging = true)
+        }
+    }
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -202,18 +202,22 @@
   <li>Add inspection and quick fix to avoid inefficient order of multiplication operations (<a href="https://github.com/JetBrains/resharper-unity/issues/1031">#1031</a>)</li>
   <li>Add warning for string literal use in <tt>Animator.ResetTrigger</tt> (<a href="https://youtrack.jetbrains.com/issue/RIDER-24421">RIDER-24421</a>, <a href="https://github.com/JetBrains/resharper-unity/issues/1035">#1035</a>)</li>
   <li>Add support for marking ECS types and fields as "in use" (<a href="https://github.com/JetBrains/resharper-unity/issues/1010">#1010</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1036">#1036</a>)</li>
-  <li>Rider: Support for git packages in Unity Explorer</li>
-  <li>Rider: Add notification if there isn't a player log to show (<a href="https://github.com/JetBrains/resharper-unity/issues/820">#820</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1006">#1006</a> - thanks @ajon542!)</li>
+  <li>Add support for git packages in Unity Explorer</li>
+  <li>Add notification if there isn't a player log to show (<a href="https://github.com/JetBrains/resharper-unity/issues/820">#820</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1006">#1006</a> - thanks @ajon542!)</li>
+  <li>Add dialog to prompt to install mono for Unity project with new Scripting runtime (<a href="https://youtrack.jetbrains.com/issue/RIDER-24005">RIDER-24005</a>)</li>
+  <li>Add project name to list of debuggable players (Unity 2019.2 only) (<a href="https://github.com/JetBrains/resharper-unity/pull/1114">#1114</a>)</li>
 </ul>
 <em>Changed:</em>
 <ul>
-  <li>Rider: Graceful handling of out of sync Unity Editor plugin versions (<a href="https://github.com/JetBrains/resharper-unity/pull/963">#963</a>)</li>
+  <li>Performance critical context now works cross files (<a href="https://github.com/JetBrains/resharper-unity/pull/1037">#1037</a>)</li>
+  <li>Graceful handling of out of sync Unity Editor plugin versions (<a href="https://github.com/JetBrains/resharper-unity/pull/963">#963</a>)</li>
   <li>Unity Editor: Allow opening assets imported by <tt>ScriptedImporters</tt> (<a href="https://github.com/JetBrains/resharper-unity/issues/981">#981</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/995">#995</a>)</li>
 </ul>
 <em>Fixed:</em>
 <ul>
-  <li>Rider: Show packages from correct per-project cache in Unity Explorer</li>
-  <li>Rider: Fix creation of Unity class library project if can't find Unity install (<a href="https://github.com/JetBrains/resharper-unity/issue/1013">#1013</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1014">#1014</a>)</li>
+  <li>Show packages from correct per-project cache in Unity Explorer</li>
+  <li>Fix creation of Unity class library project if can't find Unity install (<a href="https://github.com/JetBrains/resharper-unity/issue/1013">#1013</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1014">#1014</a>)</li>
+  <li>Minor UI annoyances in "Attach to Unity process" dialog (<a href="https://github.com/JetBrains/resharper-unity/pull/1114">#1114</a>)</li>
   <li>Unity Editor: Use unique name for log file (<a href="https://github.com/JetBrains/resharper-unity/pull/1020">#1020</a>)</li>
   <li>Unity Editor: Don't call Unity API in batch mode (<a href="https://github.com/JetBrains/resharper-unity/pull/1020">#1020</a>)</li>
   <li>Unity Editor: Fix exception during Unity shutdown (<a href="https://youtrack.jetbrains.com/issue/RIDER-19688">RIDER-19688</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/979">#979</a>)</li>


### PR DESCRIPTION
Only lists the project name for players, which must be built with Unity 2019.2.

See #1009 to add project name to editor instances.

Also fixes minor UI issues - ESC will cancel the dialog if nothing is focussed, and Enter will accept the manual entry dialog while the port field is being edited.