### PR TITLE
Fix YAML reference error and better handle rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - No longer creates a `.sln.DotSettings.user` file when YAML size heuristic is applied ([#1087](https://github.com/JetBrains/resharper-unity/pull/1087))
 - Treat `AddComponent(Type)` as an expensive operation ([#1044](https://github.com/JetBrains/resharper-unity/issues/1044), [#1109](https://github.com/JetBrains/resharper-unity/pull/1109))
 - Include Unity YAML files in Solution Wide Error Analysis ([#1118](https://github.com/JetBrains/resharper-unity/pull/1118))
+- Updated API to 2019.2.0a9 ([#1055](https://github.com/JetBrains/resharper-unity/issues/1055), [#1056](https://github.com/JetBrains/resharper-unity/pull/1056))
 - Rider: Refresh assets before running unit tests ([#1070](https://github.com/JetBrains/resharper-unity/issues/1070), [#1078](https://github.com/JetBrains/resharper-unity/pull/1078))
 - Rider: Run configuration will start Unity if not already running ([#1086](https://github.com/JetBrains/resharper-unity/pull/1086))
 - Rider: Improve navigation from log viewer to code ([#367](https://github.com/JetBrains/resharper-unity/issues/367), [#1071](https://github.com/JetBrains/resharper-unity/pull/1071))
@@ -65,6 +66,8 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Fix exception when project contains empty YAML file ([RIDER-25787](https://youtrack.jetbrains.com/issue/RIDER-25787), [#1124](https://github.com/JetBrains/resharper-unity/pull/1124))
 - Fix parse error in YAML files with multiline text containing single quotes ([RIDER-26849](https://youtrack.jetbrains.com./issue/RIDER-26849), [#1145](https://github.com/JetBrains/resharper-unity/pull/1145))
 - Fix parse error in ShaderLab attribute values ([RIDER-26909](https://youtrack.jetbains.com/issue/RIDER-26909), [#857](https://github.com/JetBrains/resharper-unity/issues/857), [#1149](https://github.com/JetBrains/resharper-unity/pull/1149))
+- Fix invalid references to scripts or event handlers in read only/referenced packages ([RIDER-27009](https://youtrack.jetbrains.com/issue/RIDER-27009), [#1153](https://github.com/JetBrains/resharper-unity/pull/1153))
+- Fix rename of `MonoBehaviour` based classes being blocked by reported conflicts ([RIDER-27053](https://youtrack.jetbrains.com/issue/RIDER-27053), [#1153](https://github.com/JetBrains/resharper-unity/pull/1153))
 - Rider: Fix minor UI annoyances in "Attach to Unity process" dialog ([#1114](https://github.com/JetBrains/resharper-unity/pull/1114))
 - Rider: Show packages from correct per-project cache in Unity Explorer
 - Rider: Correctly handle file/git based packages in Unity Explorer ([RIDER-25971](https://youtrack.jetbrains.com/issue/RIDER-25971), [#1095](https://github.com/JetBrains/resharper-unity/issue/1095) [#1099](https://github.com/JetBrains/resharper-unity/pull/1099))
@@ -78,7 +81,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Unity Editor: Use unique name for log file ([#1020](https://github.com/JetBrains/resharper-unity/pull/1020))
 - Unity Editor: Don't call Unity API in batch mode ([#1020](https://github.com/JetBrains/resharper-unity/pull/1020))
 - Unity Editor: Fix exception during Unity shutdown ([RIDER-19688](https://youtrack.jetbrains.com/issue/RIDER-19688), [#979](https://github.com/JetBrains/resharper-unity/pull/979))
-- Rider: Fix Rider extra reloading projects on calling Refresh from Rider, applies to Unity pre-2018 ([#1116](https://github.com/JetBrains/resharper-unity/pull/1116) 
+- Rider: Fix Rider extra reloading projects on calling Refresh from Rider, applies to Unity pre-2018 ([#1116](https://github.com/JetBrains/resharper-unity/pull/1116)
 - Unity Editor: Fix issue connecting to editor when Rider was not default editor at startup ([RIDER-26142](https://youtrack.jetbrains.com/issue/RIDER-26142), [#1111](https://github.com/JetBrains/resharper-unity/pull/1111))
 
 ## 2018.3.3

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
@@ -72,7 +72,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
 
         public override IReference BindTo(IDeclaredElement element)
         {
-            // We don't need to do anything, as a rename doesn't change the guid that we have
+            // We don't need to update any source, as a rename doesn't change the guid that we have. But we do need to
+            // invalidate our cached result, or a rename will fail because we'll still be pointing at an old element
+            CurrentResolveResult = null;
             return this;
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/MonoScriptReference.cs
@@ -31,7 +31,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
             if (!resolveResultWithInfo.Result.IsEmpty)
                 return resolveResultWithInfo;
 
-            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.NOT_RESOLVED);
+            // TODO: Support references to scripts/event handlers in external packages
+            // Surprisingly, it's possible to have a reference to a script asset defined in a read-only package. We
+            // don't know anything about these assets, because read-only packages are not part of the C# project
+            // structure - they are compiled and added as assembly references. So we don't currently have a way to map
+            // an asset GUID back to a compiled class.
+            // See also UnityEventTargetReference
+//            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.NOT_RESOLVED);
+            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.IGNORABLE);
         }
 
         public override ISymbolTable GetReferenceSymbolTable(bool useReferenceName)

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReference.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/UnityEventTargetReference.cs
@@ -37,7 +37,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
             if (!resolveResultWithInfo.Result.IsEmpty)
                 return resolveResultWithInfo;
 
-            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.NOT_RESOLVED);
+            // TODO: Support references to scripts/event handlers in external packages
+            // Surprisingly, it's possible to have a reference to a script asset defined in a read-only package. We
+            // don't know anything about these assets, because read-only packages are not part of the C# project
+            // structure - they are compiled and added as assembly references. So we don't currently have a way to map
+            // an asset GUID back to a compiled class.
+            // See also UnityEventTargetReference
+//            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.NOT_RESOLVED);
+            return new ResolveResultWithInfo(EmptyResolveResult.Instance, ResolveErrorType.IGNORABLE);
         }
 
         public override ISymbolTable GetReferenceSymbolTable(bool useReferenceName)

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -51,6 +51,7 @@ Changed:
 - No longer creates a .sln.DotSettings.user file when YAML size heuristic is applied (#1087)
 - Treat AddComponent(Type) as an expensive operation (#1044, #1109)
 - Include Unity YAML files in Solution Wide Error Analysis (#1118)
+- Updated API to 2019.2.0a9 (#1055, #1056)
 
 Fixed:
 
@@ -67,6 +68,8 @@ Fixed:
 - Fix exception when project contains empty YAML file (RIDER-25787, #1124)
 - Fix parse error in YAML files with multiline text containing single quotes (RIDER-26849, #1145)
 - Fix parse error in ShaderLab attribute values (RIDER-26909, #857, #1149)
+- Fix invalid references to scripts or event handlers in read only/referenced packages (RIDER-27009, #1153)
+- Fix rename of MonoBehaviour based classes being blocked by reported conflicts (RIDER-27053, #1153)
 
 
 See CHANGELOG.md in the project repo for more details and history.

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -267,6 +267,7 @@
   <li>No longer creates a <tt>.sln.DotSettings.user</tt> file when YAML size heuristic is applied (<a href="https://github.com/JetBrains/resharper-unity/pull/1087">#1087</a>)</li>
   <li>Treat <tt>AddComponent(Type)</tt> as an expensive operation (<a href="https://github.com/JetBrains/resharper-unity/issues/1044">#1044</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1109">#1109</a>)</li>
   <li>Include Unity YAML files in Solution Wide Error Analysis (<a href="https://github.com/JetBrains/resharper-unity/pull/1118">#1118</a>)</li>
+  <li>Updated API to 2019.2.0a9 (<a href="https://github.com/JetBrains/resharper-unity/issues/1055">#1055</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1056">#1056</a>)</li>
   <li>Refresh assets before running unit tests (<a href="https://github.com/JetBrains/resharper-unity/issues/1070">#1070</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1078">#1078</a>)</li>
   <li>Run configuration will start Unity if not already running (<a href="https://github.com/JetBrains/resharper-unity/pull/1086">#1086</a>)</li>
   <li>Improve navigation from log viewer to code (<a href="https://github.com/JetBrains/resharper-unity/issues/367">#367</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1071">#1071</a>)</li>
@@ -297,6 +298,8 @@
   <li>Fix exception when project contains empty YAML file (<a href="https://youtrack.jetbrains.com/issue/RIDER-25787">RIDER-25787</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1124">#1124</a>)</li>
   <li>Fix parse error in YAML files with multiline text containing single quotes (<a href="https://youtrack.jetbrains.com./issue/RIDER-26849">RIDER-26849</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1145">#1145</a>)</li>
   <li>Fix parse error in ShaderLab attribute values (<a href="https://youtrack.jetbains.com/issue/RIDER-26909">RIDER-26909</a>, <a href="https://github.com/JetBrains/resharper-unity/issues/857">#857</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1149">#1149</a>)</li>
+  <li>Fix invalid references to scripts or event handlers in read only/referenced packages (<a href="https://youtrack.jetbrains.com/issue/RIDER-27009">RIDER-27009</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1153">#1153</a>)</li>
+  <li>Fix rename of <tt>MonoBehaviour</tt> based classes being blocked by reported conflicts (<a href="https://youtrack.jetbrains.com/issue/RIDER-27053">RIDER-27053</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1153">#1153</a>)</li>
   <li>Correctly handle file/git based packages in Unity Explorer (<a href="https://youtrack.jetbrains.com/issue/RIDER-25971">RIDER-25971</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1099">#1099</a>)</li>
   <li>Fix exception causing Unity Explorer to disappear (<a href="https://youtrack.jetbrains.com/issue/RIDER-25760">RIDER-25760</a>, <a href="https://github.com/JetBrains/resharper-unity/issue/1095">#1095</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1096">#1096</a>)</li>
   <li>Fix exception showing auto-save notification (<a href="https://youtrack.jetbrains.com/issue/RIDER-25830">RIDER-25830</a>, <a href="https://github.com/JetBrains/resharper-unity/issues/1092">#1092</a>)</li>


### PR DESCRIPTION
Fixes two issues:

- [x] [RIDER-27053](https://youtrack.jetbrains.com/issue/RIDER-27053) - unable to rename `MonoBehaviour` derived class
- [x] [RIDER-27009](https://youtrack.jetbrains.com/issue/RIDER-27009) - errors reported when referencing scripts or event handlers from read only/referenced packages. Note that this "fix" simply disables the error being reported. We need to better handle this in the future, but that will be tricky as the backend doesn't know about where these package files are (`Library/PackageCache`) and can't easily map back from an asset guid to a classname.