### PR TITLE
Fix ReSharper support for YAML asset files

### DIFF
--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleFactory.cs
@@ -2,6 +2,8 @@ using JetBrains.Annotations;
 using JetBrains.Application.FileSystemTracker;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.Util.DataStructures;
 using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
@@ -10,8 +12,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     // (so we can create references from YAML to methods) and .cs.meta files (so we can build an index of GUIDs for
     // MonoScript assets which then allows us to locate the methods referenced in YAML).
     // The files are added, removed and updated by UnityExternalFilesModuleProcessor
-    [SolutionComponent]
-    public class UnityExternalFilesModuleFactory
+    [PsiModuleFactory]
+    public class UnityExternalFilesModuleFactory : IPsiModuleFactory
     {
         public UnityExternalFilesModuleFactory(Lifetime lifetime, ISolution solution,
                                                IFileSystemTracker fileSystemTracker)
@@ -20,7 +22,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             // See changeBuilder.AddAssembly(module, ADDED)
             PsiModule = new UnityExternalFilesPsiModule(solution, "Unity external files", "UnityExternalFilesPsiModule",
                 TargetFrameworkId.Default, lifetime);
+
+            Modules = new HybridCollection<IPsiModule>(PsiModule);
         }
+
+        public HybridCollection<IPsiModule> Modules { get; }
 
         [CanBeNull] public UnityExternalFilesPsiModule PsiModule { get; }
     }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
@@ -209,26 +209,41 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             myRootPaths.Add(directory);
         }
 
+        // We add scenes, assets and prefabs to the Misc Files project in Rider. This is so that:
+        // * The Find Usages results list expects project files and throws if any occurrence is a project file
+        // * Only project files are included in SWEA, and we want that for the usage count Code Vision metric
+        // Unfortunately, ReSharper keeps the Misc Files project in sync with Visual Studio's idea of the Misc Files
+        // project (i.e. files open in the editor that aren't part of a project). This means ReSharper will remove our
+        // files from Misc Files and we end up with invalid PSI source files and loads of exceptions.
+        // Fortunately, ReSharper doesn't require project files for find usages or rename, and doesn't have Code Vision,
+        // so we don't need to worry about a usage count (usage suppression is already handled in the suppressor). So
+        // for ReSharper, we just treat all of our files as PSI source files
         private void AddExternalFiles(ExternalFiles externalFiles)
         {
             var builder = new PsiModuleChangeBuilder();
-            AddExternalMetaFiles(externalFiles, builder);
+            AddExternalPsiSourceFiles(externalFiles.MetaFiles, builder);
+
+#if RESHARPER
+            AddExternalPsiSourceFiles(externalFiles.AssetFiles, builder);
+#endif
             FlushChanges(builder);
 
-            AddExternalAssetFiles(externalFiles);
+#if RIDER
+            AddExternalProjectFiles(externalFiles.AssetFiles);
+#endif
 
             // We should only start watching for file system changes after adding the files we know about
             foreach (var directory in externalFiles.Directories)
                 myFileSystemTracker.AdviseDirectoryChanges(myLifetime, directory, true, OnProjectDirectoryChange);
         }
 
-        private void AddExternalMetaFiles(ExternalFiles externalFiles, PsiModuleChangeBuilder builder)
+        private void AddExternalPsiSourceFiles(List<DirectoryEntryData> files, PsiModuleChangeBuilder builder)
         {
-            foreach (var directoryEntry in externalFiles.MetaFiles)
-                AddMetaPsiSourceFile(builder, directoryEntry.GetAbsolutePath());
+            foreach (var directoryEntry in files)
+                AddExternalPsiSourceFile(builder, directoryEntry.GetAbsolutePath());
         }
 
-        private void AddMetaPsiSourceFile(PsiModuleChangeBuilder builder, FileSystemPath path)
+        private void AddExternalPsiSourceFile(PsiModuleChangeBuilder builder, FileSystemPath path)
         {
             Assertion.AssertNotNull(myModuleFactory.PsiModule, "myModuleFactory.PsiModule != null");
             if (myModuleFactory.PsiModule.ContainsPath(path))
@@ -238,16 +253,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             builder.AddFileChange(sourceFile, PsiModuleChange.ChangeType.Added);
         }
 
-        private void AddExternalAssetFiles(ExternalFiles externalFiles)
+#if RIDER
+        private void AddExternalProjectFiles(List<DirectoryEntryData> files)
         {
-            if (externalFiles.AssetFiles.Count == 0)
+            if (files.Count == 0)
                 return;
 
-            var files = externalFiles.AssetFiles.Select(e => e.GetAbsolutePath()).ToList();
-            AddAssetProjectFiles(files);
+            var paths = files.Select(e => e.GetAbsolutePath()).ToList();
+            AddExternalProjectFiles(paths);
         }
+#endif
 
-        private void AddAssetProjectFiles(List<FileSystemPath> paths)
+        private void AddExternalProjectFiles(List<FileSystemPath> paths)
         {
             if (paths.Count == 0)
                 return;
@@ -258,11 +275,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             {
                 foreach (var path in paths)
                 {
-                    var projectFile = AddAssetProjectFile(path);
+                    var projectFile = AddExternalProjectFile(path);
                     if (projectFile != null)
                         projectFiles.Add(projectFile);
                 }
-
             }
 
             AddProjectFilesToSwea(projectFiles);
@@ -272,7 +288,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         // automatically get an IPsiSourceFile created for it, and attached to our module via
         // UnityMiscFilesProjectPsiModuleProvider
         [MustUseReturnValue, CanBeNull]
-        private IProjectFile AddAssetProjectFile(FileSystemPath path)
+        private IProjectFile AddExternalProjectFile(FileSystemPath path)
         {
             if (mySolution.FindProjectItemsByLocation(path).Count > 0)
                 return null;
@@ -370,7 +386,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
                     var builder = new PsiModuleChangeBuilder();
                     var projectFilesToAdd = new List<FileSystemPath>();
                     ProcessFileSystemChangeDelta(delta, builder, projectFilesToAdd);
-                    AddAssetProjectFiles(projectFilesToAdd);
+                    AddExternalProjectFiles(projectFilesToAdd);
                     FlushChanges(builder);
                 });
         }
@@ -392,7 +408,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
                             projectFilesToAdd.Add(delta.NewPath);
                     }
                     else if (delta.NewPath.IsInterestingMeta())
-                        AddMetaPsiSourceFile(builder, delta.NewPath);
+                        AddExternalPsiSourceFile(builder, delta.NewPath);
                     break;
 
                 case FileSystemChangeType.DELETED:

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlAssetPsiSourceFile.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlAssetPsiSourceFile.cs
@@ -10,7 +10,11 @@ using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 {
-    public class UnityYamlAssetPsiSourceFile : PsiSourceFileFromPath, IExternalPsiSourceFile, IPsiProjectFile
+    // ReSharper doesn't want us to use project files. See UnityExternalFilesModuleProcessor
+    public class UnityYamlAssetPsiSourceFile : PsiSourceFileFromPath, IExternalPsiSourceFile
+#if RIDER
+        , IPsiProjectFile
+#endif
     {
         public UnityYamlAssetPsiSourceFile([NotNull] IProjectFile projectFile,
                                            [NotNull] IProjectFileExtensions projectFileExtensions,
@@ -22,9 +26,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             : base(projectFileExtensions, projectFileTypeCoordinator, module, path, JetFunc<PsiSourceFileFromPath>.True,
                 propertiesFactory, documentManager, resolveContext)
         {
+#if RIDER
             ProjectFile = projectFile;
+#endif
         }
 
+#if RIDER
         public IProjectFile ProjectFile { get; }
+#endif
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlPsiSourceFileFactory.cs
@@ -29,7 +29,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
             myDocumentManager = documentManager;
         }
 
-        public IPsiProjectFile CreatePsiProjectFile(IPsiModule psiModule, IProjectFile projectFile)
+        public IPsiSourceFile CreatePsiProjectFile(IPsiModule psiModule, IProjectFile projectFile)
         {
             var file = new UnityYamlAssetPsiSourceFile(projectFile, myProjectFileExtensions, myProjectFileTypeCoordinator,
                 psiModule, projectFile.Location, Memoize(PropertiesFactory), myDocumentManager, UniversalModuleReferenceContext.Instance);

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiSourceFileExtensions.cs
@@ -10,9 +10,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
             return sourceFile is UnityYamlAssetPsiSourceFile || sourceFile.GetLocation().IsInterestingAsset();
         }
 
+        // ReSharper doesn't want us to use project files. See UnityExternalFilesModuleProcessor
         public static bool IsMeta(this IPsiSourceFile sourceFile)
         {
+#if RESHARPER
+            return sourceFile is UnityYamlAssetPsiSourceFile || sourceFile.GetLocation().IsMeta();
+#else
             return sourceFile is UnityYamlExternalPsiSourceFile || sourceFile.GetLocation().IsMeta();
+#endif
         }
     }
 }


### PR DESCRIPTION
This PR fixes support for ReSharper for Find Usages, rename, etc. in YAML based asset files.

Rider requires that the external YAML files are added as project files, so we add them to the Misc Files project. This is because:

* Find Usages results requires a project item, or it will throw an exception
* SWEA only processes project files, and we want to be processed so that YAML usages of methods and classes is included in the Code Vision usage count metric

Unfortunately, ReSharper keeps the Misc Files project in sync with Visual Studio's view of the Misc Files project, which is limited to files currently open in the editor that aren't part of any other project. This means that our YAML files are removed from Misc Files and leaves orphaned PSI source files and causes lots of exceptions.

Fortunately, ReSharper does not need our files to be project files for Find Usages, and does not have Code Vision usage metrics, so it doesn't matter if the YAML files aren't processed by SWEA (usage highlighting is already handled by the usage inspections suppressor).

This PR adds conditional compilation (😢) to make the YAML files project files for Rider, and normal PSI source files for ReSharper.