### PR TITLE
force msbuild 15.9 for restore packages

### DIFF
--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -96,6 +96,7 @@ task restoreReSharperHostPluginPackages(type: nugetRestore.class) {
         sources.add(project.backend.getRiderSdkPath())
         sources.add(project.backend.getReSharperSdkPath())
     }
+    msBuildVersion = "15.9"
 }
 
 task restoreUnityEditorPluginPackages(type: nugetRestore.class) {


### PR DESCRIPTION
On Mac it fails with 

Restoring packages for /Users/user/Work/resharper-unity/resharper/rider-unity.sln
Cannot find the specified version of msbuild: '15.9'
