### PR TITLE
on mac empty string in quotes is causing additional solution to be opened 

### DIFF
--- a/unity/EditorPlugin/OnOpenAssetHandler.cs
+++ b/unity/EditorPlugin/OnOpenAssetHandler.cs
@@ -100,7 +100,8 @@ namespace JetBrains.Rider.Unity.Editor
         }
       }
 
-      var args = string.Format("{0}{1}{0} --line {2} {0}{3}{0}", "\"", mySlnFile, line, assetFilePath);
+      var argsString = assetFilePath == "" ? "" : $" --line {line} \"{assetFilePath}\""; // on mac empty string in quotes is causing additional solution to be opened https://github.cds.internal.unity3d.com/unity/com.unity.ide.rider/issues/21
+      var args = string.Format("{0}{1}{0}{2}", "\"", mySlnFile, argsString);
       return CallRider(args);
     }
 
@@ -117,7 +118,7 @@ namespace JetBrains.Rider.Unity.Editor
       if (myPluginSettings.OperatingSystemFamilyRider == OperatingSystemFamilyRider.MacOSX)
       {
         proc.StartInfo.FileName = "open";
-        proc.StartInfo.Arguments = string.Format("-n {0}{1}{0} --args {2}", "\"", "/" + defaultApp, args);
+        proc.StartInfo.Arguments = string.Format("-n {0}{1}{0} --args {2}", "\"", defaultApp, args);
         myLogger.Verbose("{0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
       }
       else


### PR DESCRIPTION
issue 21 in package

on mac empty string in quotes is causing additional solution to be opened https://github.cds.internal.unity3d.com/unity/com.unity.ide.rider/issues/21

Workarounds a bug on mac:
`open -n “//Users/user/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-2/191.7141.355/Rider.app” --args “/Users/user/Work/com.unity.ide.rider/com.unity.ide.rider.sln” --line -1 “”`
opes 2 solutions, where first is good and second one is
`/Users/user/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-2/191.7141.355/Rider.app/Contents/bin`