### PR TITLE
Remove Boo and UnityScript from import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0). Note that this project does not follow semantic versioning but uses version numbers based on JetBrains [Rider](https://www.jetbrains.com/rider/) and [ReSharper](https://www.jetbrains.com/resharper/) releases.
 
 This plugin has functionality that is common to both ReSharper and Rider. It also contains a plugin for the Unity editor that is used to communicate with Rider. Changes marked with a "Rider:" prefix are specific to Rider, while changes for the Unity editor plugin are marked with a "Unity editor:" prefix. No prefix means that the change is common to both Rider and ReSharper.
+
 ## 2019.2
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/191-eap8-rtm-2019.1.0...192)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/22?closed=1)
@@ -13,23 +14,25 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Add completion for scenes, tags, layers and inputs ([#1158](https://github.com/JetBrains/resharper-unity/pull/1158))
 - Add inspection for unknown scenes, tags, layers, inputs ([#1158](https://github.com/JetBrains/resharper-unity/pull/1158))
 - Add quickfix which specifies scene name when several scenes with same name are presented in build settings ([#1158](https://github.com/JetBrains/resharper-unity/pull/1158))
+- Methods and properties defined in `UnityEditor.Build.*` are now implicitly used([#686](https://github.com/JetBrains/resharper-unity/issues/686))
+- Exclude `Boo` and `UnityScript` namespaces from import completion ([#574](https://github.com/JetBrains/resharper-unity/issues/574), [#1252](https://github.com/JetBrains/resharper-unity/pull/1252))
 - Rider: Add quickfix for missed scenes in build settings ([#1158](https://github.com/JetBrains/resharper-unity/pull/1158))
 - Rider: Add quickfix for disabled scenes in build settings ([#1158](https://github.com/JetBrains/resharper-unity/pull/1158))
 
 
 
-## 2019.2
 ### Fixed
 - Disable automatic cleanup of Unity messages in Rider ([#1217]https://github.com/JetBrains/resharper-unity/pull/1217)
 - Fix dynamic unit tests with similar name and different child-index ([#1214]https://github.com/JetBrains/resharper-unity/pull/1214)
 - Fix mdb generation ([#1182]https://github.com/JetBrains/resharper-unity/pull/1182)
+
+
 
 ## 2019.1.2
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/191-eap8-rtm-2019.1.0...191-eap10-rtm-2019.1.2)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/28?closed=1)
 
 ### Added
-- Methods and properties defined in `UnityEditor.Build.*` are now implicitly used([#686](https://github.com/JetBrains/resharper-unity/issues/686))
 - Rider: Added support for the Rider integration package used by Unity 2019.2+. No longer copies Rider plugin to Assets folder, and is loaded directly from the Rider installation folder ([#1176](https://github.com/JetBrains/resharper-unity/pull/1176))
 
 ### Fixed

--- a/resharper/resharper-unity/src/Settings/AutoImportSolutionSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/AutoImportSolutionSettingsProvider.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using JetBrains.Application.Settings;
+using JetBrains.Application.Settings.Implementation;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.ImportType.BlackList;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Settings
+{
+    [SolutionComponent]
+    public class AutoImportSolutionSettingsProvider : IUnitySolutionSettingsProvider
+    {
+        private readonly ISettingsSchema mySettingsSchema;
+        private readonly ILogger myLogger;
+
+        public AutoImportSolutionSettingsProvider(ISettingsSchema settingsSchema, ILogger logger)
+        {
+            mySettingsSchema = settingsSchema;
+            myLogger = logger;
+        }
+
+        public void InitialiseSolutionSettings(ISettingsStorageMountPoint mountPoint)
+        {
+            // Remove everything in the Boo.Lang.* and UnityScript.* namespaces from all auto completion lists. They've
+            // been deprecated since late 2017, and most of the code here is not intended to be consumed by users. It's
+            // also really annoying that Boo.Lang.List`1 appears before System.Collections.Generic.List`1
+            // This means types won't show in import completion lists, the auto-import popup or any other quick fixes.
+            // If you want to use Boo.Lang.List`1, you'll need to add the using statement manually
+            //
+            // NOTE: This settings format is likely to change, as this overwrites any settings in the global layer.
+            // See RIDER-30397
+            SetIndexedValue(mountPoint, (AutoImportSettings s) => s.BlackLists, CSharpLanguage.Name,
+                "Boo.Lang.*;UnityScript.*");
+        }
+
+        private void SetIndexedValue<TKeyClass, TEntryIndex, TEntryValue>([NotNull] ISettingsStorageMountPoint mount,
+                                                                          [NotNull] Expression<Func<TKeyClass, IIndexedEntry<TEntryIndex, TEntryValue>>> lambdaexpression,
+                                                                          [NotNull] TEntryIndex index,
+                                                                          [NotNull] TEntryValue value,
+                                                                          IDictionary<SettingsKey, object> keyIndices = null)
+        {
+            ScalarSettingsStoreAccess.SetIndexedValue(mount, mySettingsSchema.GetIndexedEntry(lambdaexpression), index,
+                keyIndices, value, null, myLogger);
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Settings/LangVersionProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/LangVersionProjectSettingsProvider.cs
@@ -14,14 +14,14 @@ using JetBrains.Util;
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
     [SolutionComponent]
-    public class LangVersionSetting : IUnityProjectSettingsProvider
+    public class LangVersionProjectSettingsProvider : IUnityProjectSettingsProvider
     {
         private readonly ISettingsSchema mySettingsSchema;
         private readonly ILogger myLogger;
         private readonly UnityProjectFileCacheProvider myUnityProjectFileCache;
         private static readonly Version ourVersion46 = new Version(4, 6);
 
-        public LangVersionSetting(ISettingsSchema settingsSchema, ILogger logger,
+        public LangVersionProjectSettingsProvider(ISettingsSchema settingsSchema, ILogger logger,
                                   UnityProjectFileCacheProvider unityProjectFileCache)
         {
             mySettingsSchema = settingsSchema;

--- a/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
@@ -12,12 +12,12 @@ using JetBrains.Util;
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
     [SolutionComponent]
-    public class NamespaceProviderSettings : IUnityProjectSettingsProvider
+    public class NamespaceProviderProjectSettingsProvider : IUnityProjectSettingsProvider
     {
         private readonly ISettingsSchema mySettingsSchema;
         private readonly ILogger myLogger;
 
-        public NamespaceProviderSettings(ISettingsSchema settingsSchema, ILogger logger)
+        public NamespaceProviderProjectSettingsProvider(ISettingsSchema settingsSchema, ILogger logger)
         {
             mySettingsSchema = settingsSchema;
             myLogger = logger;

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -35,7 +35,8 @@
 </description>
 <releaseNotes>
 Added:
-- Methods and properties defined in `UnityEditor.Build.*` are now implicitly used([#686](https://github.com/JetBrains/resharper-unity/issues/686))
+- Exclude `Boo` and `UnityScript` namespaces from import completion (#574, #1252)
+- Methods and properties defined in `UnityEditor.Build.*` are now implicitly used (#686)
 
 Fixed:
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -242,25 +242,13 @@
   <change-notes>
 <![CDATA[
 <p>
-<strong>New in 2019.1.2</strong>
+<strong>New in 2019.2</strong>
 <em>Added:</em>
 <ul>
-  <li>Rider: Methods and properties defined in `UnityEditor.Build.*` are now implicitly used (<a href="https://github.com/JetBrains/resharper-unity/issues/686">#686</a>)</li>
-  <li>Rider: Added support for the Rider integration package used by Unity 2019.2+. No longer copies Rider plugin to Assets folder, and is loaded directly from the Rider installation folder (<a href="https://github.com/JetBrains/resharper-unity/pull/1176">#1176</a>)</li>
-</ul>
-<em>Fixed:</em>
-<ul>
-  <li>Fix parse errors in YAML for strings that begin with quotes, braces or tildes (<a href="https://github.com/JetBrains/resharper-unity/issues/1169">#1169</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-27475">RIDER-27475</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1192">#1192</a>)</li>
-  <li>Fix errors in scene files for unresolved methods (<a href="https://youtrack.jetbrains.com/issue/RIDER-27445">RIDER-27445</a>, <a href="https://github.com/JetBrains/resharper-unity/1178">#1178</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1174">#1174</a>)</li>
-  <li>Fix rename of script components not being able to update correctly (<a href="https://github.com/JetBrains/resharper-unity/pull/1196">#1196</a>)</li>
-  <li>Rider: Fix usage counter not always correct for methods used in scene files (<a href="https://youtrack.jetbrains.com/issue/RIDER-27684">RIDER-27684</a>, <a href="https://github.com/JetBrains/resharper-unity/1178">#1178</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1174">#1174</a>)</li>
-  <li>Rider: Fix high CPU usage on Linux (<a href="https://github.com/JetBrains/resharper-unity/issues/1163">#1163</a>, <a href="https://github.com/JetBrains/resharper-unity/1171">#1171</a>)</li>
-  <li>Rider: Fix issue with switching to play mode when debugging (<a href="https://youtrack.jetbrains.com/issue/RIDER-26857">RIDER-26857</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1202">#1202</a>)</li>
-  <li>Rider: Fix Code Vision flickering when typing inside method (<a href="https://github.com/JetBrains/resharper-unity/pull/1203">#1203</a>)
-  <li>Rider: Ignore "unityhub" Ubuntu process in debug dialog (<a href="https://github.com/JetBrains/resharper-unity/pull/1210">#1210</a>)
+  <li>Exclude `Boo` and `UnityScript` namespaces from import completion (<a href="https://github.com/JetBrains/resharper-unity/issues/574">#574</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1252">#1252</a>)</li>
 </ul>
 </p>
-<p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/191/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
+<p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/192/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
 ]]>
   </change-notes>
 </idea-plugin>


### PR DESCRIPTION
Adds `Boo.Lang.*` and `UnityScript.*` as namespaces to be excluded from auto-import.

Note that this means excluded from import completion lists, the auto-import popup and any other quick fixes. The only way to use types from these namespaces is to manually add the `using` statement.

Note that the current implementation might have to change before 192 is completed. The auto import settings added to the in memory solution settings layer currently completely override any in the global settings. This will hopefully be fixed before RTM - see [RIDER-30397](https://youtrack.jetbrains.com/issue/RIDER-30397)

Fixes #574