### PR TITLE
Add `Unity.Licensing.Client` to list of ignored processes

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityRunUtil.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityRunUtil.kt
@@ -26,6 +26,7 @@ object UnityRunUtil {
             !name.contains("Unity Hub") &&
             !name.contains("UnityCrashHandler") &&
             !name.contains("UnityPackageManager") &&
+            !name.contains("Unity.Licensing.Client") &&
             !name.contains("unityhub", true)
     }
 


### PR DESCRIPTION
fix https://github.com/JetBrains/resharper-unity/issues/1283