### PR TITLE
Show read only package files as unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 ### Changed
 - Rider: Show notification that Unity isn't running when clicking Code Vision to find Unity usages ([#1275](https://github.com/JetBrains/resharper-unity/pull/1275))
 - Rider: Ignore Unity.Licensing.Client in list of Unity processes to debug ([#1283](https://github.com/JetBrains/resharper-unity/issues/1283), [#1284](https://github.com/JetBrains/resharper-unity/pull/1284))
+- Rider: Files in read only packages no longer shown as "ignored" in Unity Explorer ([#1288](https://github.com/JetBrains/resharper-unity/pull/1288))
 
 ### Fixed
 - Fix exception when pasting code ([RIDER-31338](https://youtrack.jetbrains.com/issue/RIDER-31338), [#1280](https://github.com/JetBrains/resharper-unity/pull/1280))

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
@@ -234,6 +234,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
 
             var psiIconManager = context.BasicContext.LookupItemsOwner.Services.PsiIconManager;
 
+            // Note that because this is a text based lookup item, then it won't be included if the normal C# method
+            // filter is applied. We can't make it a method based lookup item because the DeclaredElement isn't valid in
+            // this situation - it's not a real method, and a DeclaredElementInfo would try to store a pointer to it,
+            // and be unable to recreate it when it's needed.
             var textualInfo = new TextualInfo(text, text) {Ranges = context.CompletionRanges};
 
             var lookupItem = LookupItemFactory.CreateLookupItem(textualInfo)
@@ -449,7 +453,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
         }
 
         // DeclaredElementMatcher can take a custom text to match against, but ReSharper applies the matching result to
-        // the display text, so it looks wrong. Interestingly, Rider gets it right. Don't know why they're difference.
+        // the display text, so it looks wrong. Interestingly, Rider gets it right. Don't know why they're different.
         // This class will shift the match result by a given value. It assumes that the custom text is the tail of the
         // display text and makes no other modifications to the matched offsets
         private class ShiftedDeclaredElementMatcher : TextualMatcher<TextualInfo>

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/AlphabeticalMonoBehaviour01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/AlphabeticalMonoBehaviour01.cs.gold
@@ -740,9 +740,9 @@ virtual
 void
 volatile
 ---- FULL EVALUATION ----
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string
 # AUTOMATIC #
 # 742 ITEMS #
 
@@ -1486,6 +1486,6 @@ virtual
 void
 volatile
 ---- FULL EVALUATION ----
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/DoNotListVirtualFunctions.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/DoNotListVirtualFunctions.cs.gold
@@ -12,7 +12,7 @@ CustomRenderTextureUpdateZoneSpace
 PhysicsUpdateBehaviour2D
 UISystemProfilerApi
 WaitForFixedUpdate
-protected override Update() { ... }
+protected override Update() { … }    void
 UpdatedEventHandler (in UnityEngine.RemoteSettings)
 UploadHandler (in UnityEngine.Networking)
 UploadHandlerRaw (in UnityEngine.Networking)
@@ -72,7 +72,7 @@ CustomRenderTextureUpdateZoneSpace
 PhysicsUpdateBehaviour2D
 UISystemProfilerApi
 WaitForFixedUpdate
-protected override Update() { ... }
+protected override Update() { … }    void
 UpdatedEventHandler (in UnityEngine.RemoteSettings)
 UploadHandler (in UnityEngine.Networking)
 UploadHandlerRaw (in UnityEngine.Networking)

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
@@ -987,9 +987,9 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string
 # AUTOMATIC #
 # 990 ITEMS #
 
@@ -1980,6 +1980,6 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/MonoBehaviour01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/MonoBehaviour01.cs.gold
@@ -739,9 +739,9 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string
 # AUTOMATIC #
 # 742 ITEMS #
 
@@ -1484,6 +1484,6 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/MonoBehaviour06.cs
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/MonoBehaviour06.cs
@@ -1,4 +1,3 @@
-// ${FILTERS:IntelliSense_FilterMethods}
 using UnityEngine;
 
 public class A : MonoBehaviour

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/NoCompletionFollowingSerializeFieldAttribute01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/NoCompletionFollowingSerializeFieldAttribute01.cs.gold
@@ -1,4 +1,4 @@
-﻿# 671 ITEMS #
+﻿# 674 ITEMS #
 
 + abstract
 async
@@ -671,8 +671,11 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string
 # AUTOMATIC #
-# 671 ITEMS #
+# 674 ITEMS #
 
 + abstract
 async
@@ -1345,3 +1348,6 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/UnityEditor01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/UnityEditor01.cs.gold
@@ -1041,9 +1041,9 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string
 # AUTOMATIC #
 # 1044 ITEMS #
 
@@ -2088,6 +2088,6 @@ UnityEditor
 UnityEditorInternal
 UnityEngine
 UnityEngineInternal
-public override Equals(object) { ... }
-public override GetHashCode() { ... }
-public override ToString() { ... }
+public override Equals(object) { … }    bool
+public override GetHashCode() { … }    int
+public override ToString() { … }    string

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -8,8 +8,8 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.SimpleTextAttributes
 import com.jetbrains.rider.plugins.unity.packageManager.PackageData
-import com.jetbrains.rider.plugins.unity.packageManager.PackageSource
 import com.jetbrains.rider.plugins.unity.packageManager.PackageManager
+import com.jetbrains.rider.plugins.unity.packageManager.PackageSource
 import com.jetbrains.rider.projectView.views.FileSystemNodeBase
 import com.jetbrains.rider.projectView.views.SolutionViewNode
 import com.jetbrains.rider.projectView.views.addNonIndexedMark
@@ -96,7 +96,7 @@ class PackagesRoot(project: Project, private val packageManager: PackageManager)
 }
 
 class PackageNode(project: Project, private val packageManager: PackageManager, packageFolder: VirtualFile, private val packageData: PackageData)
-    : UnityExplorerNode(project, packageFolder, listOf(), false), Comparable<AbstractTreeNode<*>> {
+    : UnityExplorerNode(project, packageFolder, listOf(), false, !packageData.source.isEditable()), Comparable<AbstractTreeNode<*>> {
 
     init {
         icon = when (packageData.source) {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -254,6 +254,7 @@
 <ul>
   <li>Rider: Show notification that Unity isn't running when clicking Code Vision to find Unity usages (<a href="https://github.com/JetBrains/resharper-unity/pull/1275">#1275</a>)</li>
   <li>Rider: Ignore Unity.Licensing.Client in list of Unity processes to debug (<a href="https://github.com/JetBrains/resharper-unity/issues/1283">#1283</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1284">#1284</a>)</li>
+  <li>Rider: Files in read only packages no longer shown as "ignored" in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1288">#1288</a>)</li>
 </ul>
 <em>Fixed:</em>
 <ul>


### PR DESCRIPTION
Currently, the contents of read only packages are highlighted as IGNORED in Unity Explorer, because they're cache in `Library`, which is usually ignored in VCS. Highlighting VCS status is irrelevant as they're read only.