### PR TITLE
Migrate to async VFS file listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0). 
 
 This plugin has functionality that is common to both ReSharper and Rider. It also contains a plugin for the Unity editor that is used to communicate with Rider. Changes marked with a "Rider:" prefix are specific to Rider, while changes for the Unity editor plugin are marked with a "Unity editor:" prefix. No prefix means that the change is common to both Rider and ReSharper.
 
+## 2019.3
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/192...net193)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/29?closed=1)
+
+### Added
+
+- Rider: Show prompt to set Rider as default external editor when Unity is started by Rider ([#1127](https://github.com/JetBrains/resharper-unity/issues/1127), [#1270](https://github.com/JetBrains/resharper-unity/pull/1270))
+
+### Changed
+
+- Unity Editor: Use new 2019.2 API to open Rider at correct column as well as line (requires Rider package 1.1.0+) ([#888](https://github.com/JetBrains/resharper-unity/issues/888))
+
+### Fixed
+
+- Rider: Fix Clear on Play in Rider's Unity log viewer ([#1281](https://github.com/JetBrains/resharper-unity/issues/1281), [#1294](https://github.com/JetBrains/resharper-unity/pull/1294))
+
+
+
 ## 2019.2.2
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap8-rtm-2019.2.1...192)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/30?closed=1)

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -34,11 +34,6 @@
 - And much more!
 </description>
 <releaseNotes>
-Changed:
-- Suppress warning when using CollisionFlags in a bitwise operation (RIDER-28661, #1289)
-
-Fixed:
-- Fix exception when pasting code (RIDER-31338, #1280)
 
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -117,7 +117,7 @@ class PackageNode(project: Project, private val packageManager: PackageManager, 
         presentation.addNonIndexedMark(myProject, virtualFile)
 
         // Note that this might also set the tooltip if we have too many projects underneath
-        if (UnityExplorer.getInstance(myProject).myShowProjectNames)
+        if (UnityExplorer.getInstance(myProject).showProjectNames)
             addProjects(presentation)
 
         val existingTooltip = presentation.tooltip ?: ""
@@ -159,7 +159,7 @@ class PackageNode(project: Project, private val packageManager: PackageManager, 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
         val children = super.calculateChildren()
 
-        if (!packageData.details.dependencies.isEmpty()) {
+        if (packageData.details.dependencies.isNotEmpty()) {
             children.add(0, DependenciesRoot(project!!, packageManager, packageData))
         }
 
@@ -305,7 +305,7 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
 
-        if (!UnityExplorer.getInstance(project!!).myShowHiddenItems) {
+        if (!UnityExplorer.getInstance(project!!).showHiddenItems) {
             return arrayListOf()
         }
         return super.calculateChildren()
@@ -316,14 +316,14 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
     }
 
     override fun canNavigateToSource(): Boolean {
-        if (UnityExplorer.getInstance(project!!).myShowHiddenItems) {
+        if (UnityExplorer.getInstance(project!!).showHiddenItems) {
             return super.canNavigateToSource()
         }
         return true
     }
 
     override fun navigate(requestFocus: Boolean) {
-        if (UnityExplorer.getInstance(project!!).myShowHiddenItems) {
+        if (UnityExplorer.getInstance(project!!).showHiddenItems) {
             return super.navigate(requestFocus)
         }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
@@ -39,8 +39,24 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
         }
     }
 
-    var myShowHiddenItems = false
-    var myShowProjectNames = true
+    var showHiddenItems = false
+        private set(value) { field = value }
+
+    var showProjectNames = true
+        private set(value) { field = value }
+
+    fun hasPackagesRoot(): Boolean {
+        // The tree's model is cached, while this.model.root.children isn't. This is important in that it reflects the
+        // current state of the model before it's had a chance to be invalidated
+        val root = tree.model.root
+        val count = tree.model.getChildCount(root)
+        for (i in 0..count) {
+            if (tree.model.getChild(root, i) is PackagesRoot) {
+                return true
+            }
+        }
+        return false
+    }
 
     override fun isInitiallyVisible() = project.isUnityProject()
 
@@ -57,16 +73,16 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
-        JDOMExternalizerUtil.writeField(element, ShowHiddenItemsOption, myShowHiddenItems.toString())
-        JDOMExternalizerUtil.writeField(element, ShowProjectNamesOption, myShowProjectNames.toString())
+        JDOMExternalizerUtil.writeField(element, ShowHiddenItemsOption, showHiddenItems.toString())
+        JDOMExternalizerUtil.writeField(element, ShowProjectNamesOption, showProjectNames.toString())
     }
 
     override fun readExternal(element: Element) {
         super.readExternal(element)
         var option = JDOMExternalizerUtil.readField(element, ShowHiddenItemsOption)
-        myShowHiddenItems = option != null && java.lang.Boolean.parseBoolean(option)
+        showHiddenItems = option != null && java.lang.Boolean.parseBoolean(option)
         option = JDOMExternalizerUtil.readField(element, ShowProjectNamesOption)
-        myShowProjectNames = option == null || java.lang.Boolean.parseBoolean(option)
+        showProjectNames = option == null || java.lang.Boolean.parseBoolean(option)
     }
 
     override fun getTitle() = Title
@@ -100,12 +116,12 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
         : ToggleAction("Show Hidden Files", "Show all files, including .meta files", AllIcons.Actions.ShowHiddens), DumbAware {
 
         override fun isSelected(event: AnActionEvent): Boolean {
-            return myShowHiddenItems
+            return showHiddenItems
         }
 
         override fun setSelected(event: AnActionEvent, flag: Boolean) {
-            if (myShowHiddenItems != flag) {
-                myShowHiddenItems = flag
+            if (showHiddenItems != flag) {
+                showHiddenItems = flag
                 updateFromRoot(false)
             }
         }
@@ -120,12 +136,12 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, UnityExplo
         : ToggleAction("Show Project Names", "Show names of owning projects next to folders", AllIcons.Actions.ListFiles), DumbAware {
 
         override fun isSelected(event: AnActionEvent): Boolean {
-            return myShowProjectNames
+            return showProjectNames
         }
 
         override fun setSelected(event: AnActionEvent, flag: Boolean) {
-            if (myShowProjectNames != flag) {
-                myShowProjectNames = flag
+            if (showProjectNames != flag) {
+                showProjectNames = flag
                 updateFromRoot(false)
             }
         }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -94,7 +94,7 @@ open class UnityExplorerNode(project: Project,
         presentation.setIcon(calculateIcon())
 
         // Add additional info for directories
-        if (!virtualFile.isDirectory || !UnityExplorer.getInstance(myProject).myShowProjectNames) return
+        if (!virtualFile.isDirectory || !UnityExplorer.getInstance(myProject).showProjectNames) return
         addProjects(presentation)
     }
 
@@ -237,7 +237,7 @@ open class UnityExplorerNode(project: Project,
     }
 
     private fun filterNode(file: VirtualFile): Boolean {
-        if (UnityExplorer.getInstance(myProject).myShowHiddenItems) {
+        if (UnityExplorer.getInstance(myProject).showHiddenItems) {
             return true
         }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/UnityAutoSaveConfigureNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/notifications/UnityAutoSaveConfigureNotification.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.rd.createNestedDisposable
 import com.intellij.openapi.util.Key
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.LightColors
@@ -65,17 +66,13 @@ class UnityAutoSaveConfigureNotification(project: Project, private val unityProj
                     }
                 }
 
-                eventMulticaster.addDocumentListener(documentListener)
-                lifetimeDefinition.lifetime.onTermination {
-                    eventMulticaster.removeDocumentListener(documentListener)
-                }
+                eventMulticaster.addDocumentListener(documentListener, it.createNestedDisposable())
             }
         }
     }
 
     fun showNotification(lifetime: Lifetime, editor: Editor) {
         application.assertIsDispatchThread()
-
 
         if (!lifetime.isAlive) return
         val project = editor.project ?: return

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/UnityStatusBarIcon.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/UnityStatusBarIcon.kt
@@ -26,10 +26,10 @@ class UnityStatusBarIcon(private val host: UnityHost): StatusBarWidget, StatusBa
     private var myStatusBar: StatusBar? = null
 
     override fun ID(): String {
-        return "UnityStatusIcon"
+        return StatusBarIconId
     }
 
-    override fun getPresentation(type: StatusBarWidget.PlatformType): StatusBarWidget.WidgetPresentation? {
+    override fun getPresentation(): StatusBarWidget.WidgetPresentation? {
         return this
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileUtils.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileUtils.kt
@@ -6,8 +6,11 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.jetbrains.rider.projectDir
 import java.nio.file.Paths
 
-fun Project.refreshAndFindFile(relativeFile: String): VirtualFile?
-{
+fun Project.refreshAndFindFile(relativeFile: String): VirtualFile? {
     val path = Paths.get(this.projectDir.path, relativeFile)
     return VfsUtil.findFile(path, true)
+}
+
+fun Project.findFile(relativeFile: String): VirtualFile? {
+    return this.projectDir.findFileByRelativePath(relativeFile)
 }

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -246,22 +246,18 @@
   <change-notes>
 <![CDATA[
 <p>
-<strong>New in 2019.2.2</strong>
+<strong>New in 2019.3</strong>
 <em>Added:</em>
 <ul>
-  <li>Rider: Suggest files and folders to be ignored by version control (<a href="https://youtrack.jetbrains.com/issue/RIDER-31206">#1206</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1276">#1276</a>)</li>
+  <li>Rider: Show prompt to set Rider as default external editor when Unity is started by Rider (<a href="https://github.com/JetBrains/resharper-unity/issues/1127">#1127<a/>), <a href="https://github.com/JetBrains/resharper-unity/pull/1270">#1270</a>)</li>
 </ul>
 <em>Changed:</em>
 <ul>
-  <li>Suppress warning when using <tt>CollisionFlags</tt> in a bitwise operation (<a href="https://youtrack.jetbrains.com/issue/RIDER-28661">RIDER-28661</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1289">#1289</a>)</li>
-  <li>Rider: Show notification that Unity isn't running when clicking Code Vision to find Unity usages (<a href="https://github.com/JetBrains/resharper-unity/pull/1275">#1275</a>)</li>
-  <li>Rider: Ignore Unity.Licensing.Client in list of Unity processes to debug (<a href="https://github.com/JetBrains/resharper-unity/issues/1283">#1283</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1284">#1284</a>)</li>
-  <li>Rider: Files in read only packages no longer shown as "ignored" in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1288">#1288</a>)</li>
+  <li>Unity Editor: Use new 2019.2 API to open Rider at correct column as well as line (requires Rider package 1.1.0+) (<a href="https://github.com/JetBrains/resharper-unity/issues/888">#888<a/>)</li>
 </ul>
 <em>Fixed:</em>
 <ul>
-  <li>Fix exception when pasting code (<a href="https://youtrack.jetbrains.com/issue/RIDER-31338">RIDER-31338</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1280">#1280</a>)</li>
-  <li>Unity Editor: Fix exception running tests with older test framework packages (<a href="https://github.com/JetBrains/resharper-unity/pull/1273">#1273</a>)</li>
+  <li>Rider: Fix Clear on Play in Rider's Unity log viewer (<a href="https://github.com/JetBrains/resharper-unity/issues/1281">#1281</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1294">#1294</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/192/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>


### PR DESCRIPTION
This PR will:

- [x] Fix deprecated API usage warnings
- [x] Migrate to new async VFS file listeners
- [x] Reduce the number of unnecessary updates of the cached package list
- [x] Reduce the number of unnecessary updates of the Unity Explorer tree
- [x] Reduce the number of unnecessary updates of the content model to remove top level folders from the index
- [x] Update changelog for 2019.3
