### PR TITLE
Add Pure annotations for profiler struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,20 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 ### Changed
 
+- Rider: Improve rendering of Unity log event counts ([#1296](https://github.com/JetBrains/resharper-unity/issues/1296), [#1301](https://github.com/JetBrains/resharper-unity/pull/1301))
+- Rider: Display pause state in connection status icon ([#1227](https://github.com/JetBrains/resharper-unity/issues/1227), [#1301](https://github.com/JetBrains/resharper-unity/pull/1301))
 - Unity Editor: Use new 2019.2 API to open Rider at correct column as well as line (requires Rider package 1.1.0+) ([#888](https://github.com/JetBrains/resharper-unity/issues/888))
 
 ### Fixed
 
 - Rider: Fix Clear on Play in Rider's Unity log viewer ([#1281](https://github.com/JetBrains/resharper-unity/issues/1281), [#1294](https://github.com/JetBrains/resharper-unity/pull/1294))
+- Rider: Fix exception checking process list on UI thread ([RIDER-28743](https://youtrack.jetbrains.com/issue/RIDER-28743), [#1311](https://github.com/JetBrains/resharper-unity/pull/1311))
+- Unity Editor: Fix exceptions calling `isPlaying` on incorrect thread ([#1308](https://github.com/JetBrains/resharper-unity/pull/1308))
 
 
 
 ## 2019.2.2
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap8-rtm-2019.2.1...192)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap8-rtm-2019.2.1...192-eap9-rtm-2019.2.2)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/30?closed=1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 ### Added
 
+- Prevent "possibly impure struct method" warnings with `ProfilerMarker` ([#1319](https://github.com/JetBrains/resharper-unity/pull/1319))
 - Rider: Show prompt to set Rider as default external editor when Unity is started by Rider ([#1127](https://github.com/JetBrains/resharper-unity/issues/1127), [#1270](https://github.com/JetBrains/resharper-unity/pull/1270))
 
 ### Changed

--- a/resharper/resharper-unity/src/annotations/UnityEngine.CoreModule.xml
+++ b/resharper/resharper-unity/src/annotations/UnityEngine.CoreModule.xml
@@ -426,4 +426,16 @@
       <argument>UnityEngine.MonoBehaviour</argument>
     </attribute>
   </member>
+
+  <!-- Profiling -->
+  <!-- Prevents "Possibly impure struct method called on readonly variable" -->
+  <member name="M:Unity.Profiling.ProfilerMarker.Begin">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
+  <member name="M:Unity.Profiling.ProfilerMarker.End">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
+  <member name="M:Unity.Profiling.ProfilerMarker.Auto">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
 </assembly>

--- a/resharper/resharper-unity/src/annotations/UnityEngine.xml
+++ b/resharper/resharper-unity/src/annotations/UnityEngine.xml
@@ -442,4 +442,16 @@
   <member name="T:AOT.MonoPInvokeCallbackAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
+
+  <!-- Profiling -->
+  <!-- Prevents "Possibly impure struct method called on readonly variable" -->
+  <member name="M:Unity.Profiling.ProfilerMarker.Begin">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
+  <member name="M:Unity.Profiling.ProfilerMarker.End">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
+  <member name="M:Unity.Profiling.ProfilerMarker.Auto">
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
 </assembly>

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -34,6 +34,8 @@
 - And much more!
 </description>
 <releaseNotes>
+Added:
+- Prevent "possibly impure struct method" warnings with ProfilerMarker (#1319)
 
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachPresentationGroup.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityAttachPresentationGroup.kt
@@ -12,7 +12,4 @@ object UnityAttachPresentationGroup : XAttachProcessPresentationGroup {
     override fun getItemIcon(project: Project, process: ProcessInfo, userData: UserDataHolder) = UnityIcons.Icons.UnityLogo
     override fun getItemDisplayText(project: Project, process: ProcessInfo, userData: UserDataHolder) = process.executableDisplayName
     override fun compare(p1: ProcessInfo, p2: ProcessInfo) = p1.pid.compareTo(p2.pid)
-
-    override fun getProcessDisplayText(p0: Project, p1: ProcessInfo, p2: UserDataHolder) = throw UnsupportedOperationException("Should not use this method")
-    override fun getProcessIcon(p0: Project, p1: ProcessInfo, p2: UserDataHolder) = throw UnsupportedOperationException("Should not use this method")
 }

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -254,11 +254,15 @@
 </ul>
 <em>Changed:</em>
 <ul>
+  <li>Rider: Improve rendering of Unity log event counts (<a href="https://github.com/JetBrains/resharper-unity/issues/1296">#1296</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1301">#1301</a>)</li>
+  <li>Rider: Display pause state in connection status icon (<a href="https://github.com/JetBrains/resharper-unity/issues/1227">#1227</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1301">#1301</a>)</li>
   <li>Unity Editor: Use new 2019.2 API to open Rider at correct column as well as line (requires Rider package 1.1.0+) (<a href="https://github.com/JetBrains/resharper-unity/issues/888">#888<a/>)</li>
 </ul>
 <em>Fixed:</em>
 <ul>
   <li>Rider: Fix Clear on Play in Rider's Unity log viewer (<a href="https://github.com/JetBrains/resharper-unity/issues/1281">#1281</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1294">#1294</a>)</li>
+  <li>Rider: Fix exception checking process list on UI thread (<a href="https://youtrack.jetbrains.com/issue/RIDER-28743">RIDER-28743</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1311">#1311</a>)</li>
+  <li>Unity Editor: Fix exceptions calling <tt>isPlaying</tt> on incorrect thread (<a href="https://github.com/JetBrains/resharper-unity/pull/1308">#1308</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/192/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -249,6 +249,7 @@
 <strong>New in 2019.3</strong>
 <em>Added:</em>
 <ul>
+  <li>Prevent "possibly impure struct method" warnings with <tt>ProfilerMarker</tt> (<a href="https://github.com/JetBrains/resharper-unity/pull/1319">#1319</a>)</li>
   <li>Rider: Show prompt to set Rider as default external editor when Unity is started by Rider (<a href="https://github.com/JetBrains/resharper-unity/issues/1127">#1127<a/>), <a href="https://github.com/JetBrains/resharper-unity/pull/1270">#1270</a>)</li>
 </ul>
 <em>Changed:</em>


### PR DESCRIPTION
Prevents "Possibly impure struct method called on readonly variable" warnings