### PR TITLE
Use native line endings in .meta files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0). 
 
 This plugin has functionality that is common to both ReSharper and Rider. It also contains a plugin for the Unity editor that is used to communicate with Rider. Changes marked with a "Rider:" prefix are specific to Rider, while changes for the Unity editor plugin are marked with a "Unity editor:" prefix. No prefix means that the change is common to both Rider and ReSharper.
 
+## 2019.2.3
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap9-rtm-2019.2.2...192)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/31?closed=1)
+
+### Changed
+* Use platform native line endings in generated `.meta` files. Works better with Perforce ([#1323](https://github.com/JetBrains/resharper-unity/pull/1323))
+
+
+
 ## 2019.2.2
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap8-rtm-2019.2.1...192)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/192-eap8-rtm-2019.2.1...192-eap9-rtm-2019.2.2)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/30?closed=1)
 
 ### Added

--- a/resharper/.idea/.idea.rider-unity/.idea/runConfigurations/runIde.xml
+++ b/resharper/.idea/.idea.rider-unity/.idea/runConfigurations/runIde.xml
@@ -14,7 +14,7 @@
     <option name="PROJECT_PATH" value="$PROJECT_DIR$/gradle-launcher/gradle-launcher.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
-    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
     <option name="PROJECT_TFM" value=".NETFramework,Version=v4.6.1" />
     <browser url="http://localhost:5000" />

--- a/resharper/.idea/.idea.rider-unity/.idea/runConfigurations/runIde__offline_.xml
+++ b/resharper/.idea/.idea.rider-unity/.idea/runConfigurations/runIde__offline_.xml
@@ -14,7 +14,7 @@
     <option name="PROJECT_PATH" value="$PROJECT_DIR$/gradle-launcher/gradle-launcher.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
-    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
     <option name="PROJECT_TFM" value=".NETFramework,Version=v4.6.1" />
     <browser url="http://localhost:5000" />

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -25,12 +25,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
         {
             mySolution = solution;
             myLogger = logger;
-            
+
             solutionLoadTasksScheduler.EnqueueTask(new SolutionLoadTask("AdviseForChanges", SolutionLoadTaskKinds.AfterDone,
                 () =>
                 {
                     changeManager.RegisterChangeProvider(lifetime, this);
-                    changeManager.AddDependency(lifetime, this, solution);        
+                    changeManager.AddDependency(lifetime, this, solution);
                 }));
         }
 
@@ -239,7 +239,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                 {
                     var guid = Guid.NewGuid();
                     var timestamp = (long)(DateTime.UtcNow - ourUnixTime).TotalSeconds;
-                    DoUnderTransaction("Unity::CreateMetaFile", () => path.WriteAllText($"fileFormatVersion: 2\r\nguid: {guid:N}\r\ntimeCreated: {timestamp}"));
+                    DoUnderTransaction("Unity::CreateMetaFile", () => path.WriteAllText($"fileFormatVersion: 2{Environment.NewLine}guid: {guid:N}{Environment.NewLine}timeCreated: {timestamp}"));
                     myLogger.Info("*** resharper-unity: Meta added {0}", path);
                 }
                 catch (Exception e)

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -245,24 +245,10 @@
   <change-notes>
 <![CDATA[
 <p>
-<strong>New in 2019.2.2</strong>
-<em>Added:</em>
-<ul>
-  <li>Rider: Suggest files and folders to be ignored by version control (<a href="https://youtrack.jetbrains.com/issue/RIDER-31206">#1206</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1276">#1276</a>)</li>
-</ul>
+<strong>New in 2019.2.3</strong>
 <em>Changed:</em>
 <ul>
-  <li>Suppress warning when using <tt>CollisionFlags</tt> in a bitwise operation (<a href="https://youtrack.jetbrains.com/issue/RIDER-28661">RIDER-28661</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1289">#1289</a>)</li>
-  <li>Rider: Show notification that Unity isn't running when clicking Code Vision to find Unity usages (<a href="https://github.com/JetBrains/resharper-unity/pull/1275">#1275</a>)</li>
-  <li>Rider: Ignore Unity.Licensing.Client in list of Unity processes to debug (<a href="https://github.com/JetBrains/resharper-unity/issues/1283">#1283</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1284">#1284</a>)</li>
-  <li>Rider: Files in read only packages no longer shown as "ignored" in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1288">#1288</a>)</li>
-  <li>Unity Editor: Improve performance on AppDomain reloads (<a href="https://github.com/JetBrains/resharper-unity/pull/1291">#1291</a>)</li>
-</ul>
-<em>Fixed:</em>
-<ul>
-  <li>Fix exception when pasting code (<a href="https://youtrack.jetbrains.com/issue/RIDER-31338">RIDER-31338</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1280">#1280</a>)</li>
-  <li>Rider: Fix fetching list of Unity editors and players on UI thread (<a href="https://youtrack.jetbrains.com/issue/RIDER-31585">RIDER-31585</a>)</li>
-  <li>Unity Editor: Fix exception running tests with older test framework packages (<a href="https://github.com/JetBrains/resharper-unity/pull/1273">#1273</a>)</li>
+  <li>Use platform native line endings in generated <tt>.meta</tt> files. Works better with Perforce (<a href="https://github.com/JetBrains/resharper-unity/pull/1323">#1323</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/192/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>


### PR DESCRIPTION
Was hardcoded to Windows line endings (`\r\n`), but this can cause problems with Perforce on Mac, which does a dumb line conversion and ends up with `\r\r\n`.