### PR TITLE
Fix Mono notification logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 ### Changed
 * Use platform native line endings in generated `.meta` files. Works better with Perforce ([#1323](https://github.com/JetBrains/resharper-unity/pull/1323))
 
+### Fixed
+* Fix issues with completion of Unity event functions ([RIDER-33167](https://youtrack.jetbrains.com/issue/RIDER-33167), [#1326](https://github.com/JetBrains/resharper-unity/pull/1326))
+* Rider: Fix missing "Install Mono" notification ([#1329](https://github.com/JetBrains/resharper-unity/pull/1329))
+
 
 
 ## 2019.2.2

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -34,11 +34,10 @@
 - And much more!
 </description>
 <releaseNotes>
-Changed:
-- Suppress warning when using CollisionFlags in a bitwise operation (RIDER-28661, #1289)
+New in 2019.2.3:
 
 Fixed:
-- Fix exception when pasting code (RIDER-31338, #1280)
+- Fix issues with completion of Unity event functions (RIDER-33167, #1326)
 
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -250,6 +250,11 @@
 <ul>
   <li>Use platform native line endings in generated <tt>.meta</tt> files. Works better with Perforce (<a href="https://github.com/JetBrains/resharper-unity/pull/1323">#1323</a>)</li>
 </ul>
+<em>Fixed:</em>
+<ul>
+  <li>Fix issues with completion of Unity event functions (<a href="https://youtrack.jetbrains.com/issue/RIDER-33167">RIDER-33167</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1326">#1326</a>)</li>
+  <li>Rider: Fix missing "Install Mono" notification (<a href="https://github.com/JetBrains/resharper-unity/pull/1329">#1329</a>)</li>
+</ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/192/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
 ]]>


### PR DESCRIPTION
Fixes bug that meant that "Install Mono" notification wasn't shown on Mac for modern Unity projects and a modern Mono install does not exist.