### PR TITLE
Add Unity specific Live Templates page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 - Rider: Add support for play mode tests ([#1293](https://github.com/JetBrains/resharper-unity/issues/1293), [RIDER-19513](https://youtrack.jetbrains.com/issue/RIDER-19513))
 - Rider: Show prompt to set Rider as default external editor when Unity is started by Rider ([#1127](https://github.com/JetBrains/resharper-unity/issues/1127), [#1270](https://github.com/JetBrains/resharper-unity/pull/1270))
+- Rider: Add Unity specific Live Templates settings page ([#1351](https://github.com/JetBrains/resharper-unity/pull/1351))
 
 ### Changed
 

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Rider/UnityLiveTemplatesOptionsPage.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Rider/UnityLiveTemplatesOptionsPage.cs
@@ -1,0 +1,31 @@
+using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.Application.UI.Options;
+using JetBrains.Application.UI.Options.OptionsDialog;
+using JetBrains.IDE.UI;
+using JetBrains.Lifetimes;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Settings;
+using JetBrains.ReSharper.LiveTemplates.UI;
+using JetBrains.ReSharper.Plugins.Unity.Resources;
+using JetBrains.Rider.Model;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplates.Rider
+{
+    [ZoneMarker(typeof(IRiderModelZone))]
+    [OptionsPage("RiderUnityLiveTemplatesSettings", "Unity", typeof(LogoThemedIcons.UnityLogo))]
+    public class UnityLiveTemplatesOptionsPage : RiderLiveTemplatesOptionPageBase
+    {
+        public UnityLiveTemplatesOptionsPage(Lifetime lifetime,
+                                             UnityScopeCategoryUIProvider uiProvider,
+                                             OptionsPageContext optionsPageContext,
+                                             OptionsSettingsSmartContext optionsSettingsSmartContext,
+                                             StoredTemplatesProvider storedTemplatesProvider,
+                                             ScopeCategoryManager scopeCategoryManager,
+                                             IDialogHost dialogHost,
+                                             TemplatesUIFactory uiFactory, IconHostBase iconHostBase)
+            : base(lifetime, uiProvider, optionsPageContext, optionsSettingsSmartContext, storedTemplatesProvider, scopeCategoryManager,
+                uiFactory, iconHostBase, dialogHost, "CSHARP")
+        {
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/settings/templates/UnityTemplatesOptionPage.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/settings/templates/UnityTemplatesOptionPage.kt
@@ -8,3 +8,9 @@ class UnityFileTemplatesOptionPage: SimpleOptionsPage("Unity", "RiderUnityFileTe
         return "RiderUnityFileTemplatesSettings"
     }
 }
+
+class UnityLiveTemplatesOptionPage: SimpleOptionsPage("Unity", "RiderUnityLiveTemplatesSettings"), Configurable.NoScroll {
+    override fun getId(): String {
+        return "RiderUnityLiveTemplatesSettings"
+    }
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.UnityPluginOptionsPage" id="preferences.build.unityPlugin" />
 
     <projectConfigurable parentId="FileTemplatesSettingsId" instance="com.jetbrains.rider.settings.templates.UnityFileTemplatesOptionPage" groupWeight="-120" />
+    <projectConfigurable parentId="LiveTemplatesSettingsId" instance="com.jetbrains.rider.settings.templates.UnityLiveTemplatesOptionPage" groupWeight="-120" />
 
     <!-- This has to be first, as the default Rider handler returns an empty list instead of null, and IJ considers that handled -->
     <lang.documentationProvider language="C#" implementationClass="com.jetbrains.rider.plugins.unity.quickDoc.UnityDocumentationProvider"

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -252,6 +252,7 @@
 <ul>
   <li>Rider: Add support for play mode tests (<a href="https://github.com/JetBrains/resharper-unity/issues/1293">#1293</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-19513">RIDER-19513</a>)</li>
   <li>Rider: Show prompt to set Rider as default external editor when Unity is started by Rider (<a href="https://github.com/JetBrains/resharper-unity/issues/1127">#1127<a/>), <a href="https://github.com/JetBrains/resharper-unity/pull/1270">#1270</a>)</li>
+  <li>Rider: Add Unity specific Live Templates settings page (<a href="https://github.com/JetBrains/resharper-unity/pull/1351">#1351</a>)</li>
 </ul>
 <em>Changed:</em>
 <ul>


### PR DESCRIPTION
This PR adds a "Unity" Live Templates page to match the existing File Templates page. All of the Unity specific Live Templates are already shown in the C# page, but it's hard to find them because the options pages don't list categories (all Unity templates have the "unity" category). A separate page can list them all.