### PR TITLE
Add missing highlighting types annotations.

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/AttributedMethodSignatureProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/AttributedMethodSignatureProblemAnalyzer.cs
@@ -14,7 +14,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
             typeof(InvalidStaticModifierWarning),
             typeof(InvalidReturnTypeWarning),
             typeof(InvalidTypeParametersWarning),
-            typeof(InvalidParametersWarning)
+            typeof(InvalidParametersWarning),
+            typeof(IncorrectSignatureWarning)
         })]
     public class AttributedMethodSignatureProblemAnalyzer : MethodSignatureProblemAnalyzerBase<IAttribute>
     {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/DrawGizmoAttributeProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/DrawGizmoAttributeProblemAnalyzer.cs
@@ -11,7 +11,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
         HighlightingTypes = new[]
         {
             typeof(InvalidStaticModifierWarning), typeof(InvalidReturnTypeWarning),
-            typeof(InvalidTypeParametersWarning), typeof(InvalidParametersWarning)
+            typeof(InvalidTypeParametersWarning), typeof(InvalidParametersWarning),
+            typeof(IncorrectSignatureWarning), typeof(ParameterNotDerivedFromComponentWarning)
         })]
     public class DrawGizmoAttributeProblemAnalyzer : MethodSignatureProblemAnalyzerBase<IAttribute>
     {


### PR DESCRIPTION
ReSharper is going to add an assertion that all highlighting types emitted by analyzer should be annotated. This PR adds missing highlighting types to not fail the build after introducing the assertion.