### PR TITLE
Add initial USS file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 - Rider: Add support for play mode tests ([#1293](https://github.com/JetBrains/resharper-unity/issues/1293), [RIDER-19513](https://youtrack.jetbrains.com/issue/RIDER-19513))
 - Rider: Add syntax highlighting, schema generation and validation of UXML files ([#1399](https://github.com/JetBrains/resharper-unity/pull/1399))
+- Rider: Add syntax highlighting, validation and completion for USS files ([#957](https://github.com/JetBrains/resharper-unity/issues/957), [RIDER-20576](https://youtrack.jetbrains.com/issue/RIDER-20576), [#1402](https://github.com/JetBrains/resharper-unity/pull/1402))
 - Rider: Show prompt to set Rider as default external editor when Unity is started by Rider ([#1127](https://github.com/JetBrains/resharper-unity/issues/1127), [#1270](https://github.com/JetBrains/resharper-unity/pull/1270))
 - Rider: Show prompt for Linux users to install Mono 5.16+ ([#1375](https://github.com/JetBrains/resharper-unity/issues/1375), [#1383](https://github.com/JetBrains/resharper-unity/pull/1383))
 - Rider: Add Unity specific Live Templates settings page ([#1351](https://github.com/JetBrains/resharper-unity/pull/1351))

--- a/rider/.idea/jarRepositories.xml
+++ b/rider/.idea/jarRepositories.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/maven-central" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven5" />
+      <option name="name" value="maven5" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/plugins.jetbrains.com/maven" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/kotlin-eap" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven4" />
+      <option name="name" value="maven4" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/intellij-repository/snapshots" />
+    </remote-repository>
+  </component>
+</project>

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -62,7 +62,7 @@ intellij {
     downloadSources = false
     instrumentCode = false
 
-    plugins = [ 'rider-plugins-appender' ]
+    plugins = [ 'rider-plugins-appender', 'CSS' ]
     useProductionClassLoaderInTests = true
 }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssDocumentationProvider.kt
@@ -1,0 +1,78 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.css.util.CssPsiUtil
+import com.intellij.lang.documentation.DocumentationProvider
+import com.intellij.openapi.util.Couple
+import com.intellij.psi.PsiElement
+import com.intellij.psi.css.CssDescriptorOwner
+import com.intellij.psi.css.descriptor.CssElementDescriptor
+import com.intellij.psi.css.descriptor.CssValueOwnerDescriptor
+import com.intellij.psi.css.impl.util.CssDocumentationProvider
+import com.intellij.psi.css.impl.util.CssUtil
+import com.intellij.psi.css.impl.util.table.CssDescriptorsUtil
+import com.intellij.xml.util.documentation.MdnDocumentationUtil
+
+class UssDocumentationProvider : DocumentationProvider {
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
+        if (element?.containingFile?.language is UssLanguage) {
+            val docElement = findDocumentationElement(element)
+            if (docElement != null) {
+                return generateDoc(element.text, docElement, originalElement)
+            }
+        }
+        return null
+    }
+
+    override fun getUrlFor(element: PsiElement?, originalElement: PsiElement?): List<String>? {
+        if (element?.containingFile?.language is UssLanguage) {
+            // Returning an empty list overrides the default CSS documentation list, so we get the default docs
+            return emptyList()
+        }
+        return null
+    }
+
+    private fun findDocumentationElement(element: PsiElement): PsiElement? {
+        var docElement: PsiElement? = element
+        if (!CssUtil.isCssDeclaration(element) || CssPsiUtil.isInFunction(element)) {
+            docElement = CssDocumentationProvider.getDocumentationElement(element)
+        }
+        return docElement
+    }
+
+    private fun generateDoc(descriptorText: String?,
+                            documentationElement: PsiElement,
+                            context: PsiElement?): String? {
+        if (descriptorText == null) return null
+        if (documentationElement is CssDescriptorOwner) {
+            val descriptorProviderContext = context ?: documentationElement
+            val descriptors = getFilteredAndSortedDescriptors(documentationElement, descriptorProviderContext)
+            if (descriptors.isEmpty()) {
+                return null
+            }
+            val latestDescriptor = descriptors.iterator().next()
+            val presentableName = latestDescriptor.presentableName
+            val doc = latestDescriptor.description
+            if (latestDescriptor is CssValueOwnerDescriptor) {
+                val valueDesc = latestDescriptor.valuePresentableDescription
+                if (valueDesc != null) {
+                    return MdnDocumentationUtil.buildDoc(presentableName, doc, null, listOf(Couple.of("Values:", valueDesc)))
+                }
+            }
+            return if (doc.isNotEmpty()) {
+                MdnDocumentationUtil.buildDoc(presentableName, doc, null)
+            } else latestDescriptor.getDocumentationString(documentationElement)
+        }
+        val descriptorProvider = CssDescriptorsUtil.findDescriptorProvider(context)
+        return descriptorProvider?.generateDocForSelector(descriptorText, context)
+    }
+
+    private fun getFilteredAndSortedDescriptors(descriptorOwner: CssDescriptorOwner,
+                                                descriptorProviderContext: PsiElement): Collection<CssElementDescriptor> {
+        var descriptors: MutableCollection<CssElementDescriptor> = descriptorOwner.getDescriptors(descriptorProviderContext).toMutableList()
+        val filteredByContext = CssDescriptorsUtil.filterDescriptorsByContext(descriptors, descriptorProviderContext)
+        if (!filteredByContext.isEmpty()) {
+            descriptors = filteredByContext
+        }
+        return CssDescriptorsUtil.sortDescriptors(descriptors)
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFile.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFile.kt
@@ -1,0 +1,8 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.css.impl.CssFileImpl
+
+class UssFile(viewProvider: FileViewProvider) : CssFileImpl(viewProvider, UssLanguage) {
+    override fun toString() = "UssFile:$name"
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileBreadcrumbsProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileBreadcrumbsProvider.kt
@@ -1,0 +1,8 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.psi.css.impl.util.editor.CssBreadcrumbsInfoProvider
+
+// Allows enabling/disabling breadcrumbs for USS
+class UssFileBreadcrumbsProvider: CssBreadcrumbsInfoProvider() {
+    override fun getLanguages()= arrayOf(UssLanguage)
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileParserDefinition.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileParserDefinition.kt
@@ -1,0 +1,14 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.lang.css.CSSParserDefinition
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.tree.IFileElementType
+
+class UssFileParserDefinition: CSSParserDefinition() {
+    companion object {
+        val USS_FILE = IFileElementType("USS_FILE", UssLanguage)
+    }
+
+    override fun createFile(viewProvider: FileViewProvider) = UssFile(viewProvider)
+    override fun getFileNodeType() = USS_FILE
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileType.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssFileType.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.openapi.fileTypes.LanguageFileType
+import icons.UnityIcons
+
+object UssFileType: LanguageFileType(UssLanguage) {
+    override fun getIcon() = UnityIcons.FileTypes.Asset
+    override fun getName() = "USS"
+    override fun getDefaultExtension() = "uss"
+    override fun getDescription() = "UIElement Style Sheet File (Unity)"
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssLanguage.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssLanguage.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.lang.css.CSSLanguage
+
+object UssLanguage: CSSLanguage(INSTANCE, "USS")

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssSyntaxHighlighter.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/UssSyntaxHighlighter.kt
@@ -1,0 +1,14 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss
+
+import com.intellij.lexer.Lexer
+import com.intellij.psi.css.impl.util.CssHighlighter
+import com.intellij.psi.css.impl.util.CssHighlighterLexer
+import com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorFactory
+
+class UssSyntaxHighlighter: CssHighlighter() {
+
+    override fun getHighlightingLexer(): Lexer {
+        // Make sure our property values (enums) are highlighted as "Property Value" instead of plain old "identifier"
+        return CssHighlighterLexer(UssCssElementDescriptorFactory.getInstance().getValueIdentifiers())
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/UssCssElementDescriptorFactory.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/UssCssElementDescriptorFactory.kt
@@ -1,0 +1,62 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css
+
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.css.impl.descriptor.value.CssGroupValue
+import com.intellij.psi.css.impl.descriptor.value.CssNameValue
+import com.intellij.psi.css.impl.descriptor.value.CssTextValue
+import com.intellij.psi.css.impl.descriptor.value.CssValueDescriptorVisitorImpl
+import com.intellij.psi.css.impl.util.scheme.CssDescriptorsHolder
+import com.intellij.psi.css.impl.util.scheme.CssDescriptorsLoader
+import com.intellij.reference.SoftReference
+import java.lang.ref.Reference
+
+class UssCssElementDescriptorFactory {
+    companion object {
+        fun getInstance(): UssCssElementDescriptorFactory = ServiceManager.getService(UssCssElementDescriptorFactory::class.java)
+    }
+
+    private var cssDescriptorsHolderRef: Reference<CssDescriptorsHolder>? = null
+    private var valueIdentifiersRef: Reference<Set<String>>? = null
+
+    fun getDescriptors(): CssDescriptorsHolder {
+        var descriptors = SoftReference.dereference(cssDescriptorsHolderRef)
+        if (descriptors == null) {
+            val progressManager = ProgressManager.getInstance()
+            val loader = CssDescriptorsLoader(progressManager.progressIndicator)
+            loader.loadDescriptors(this::class.java.getResource("/uss/element-descriptors.xml"))
+            descriptors = loader.descriptors
+            cssDescriptorsHolderRef = SoftReference(descriptors)
+        }
+        return descriptors
+    }
+
+    // CssDescriptorsHolder#validIdentifiers is package private, so we have to calculate it ourselves
+    fun getValueIdentifiers(): Set<String> {
+        var identifiers = SoftReference.dereference(valueIdentifiersRef)
+        if (identifiers == null) {
+            identifiers = mutableSetOf()
+            getDescriptors().properties.values().forEach {
+                it.valueDescriptor.accept(CssValueNameCollector(identifiers))
+            }
+            valueIdentifiersRef = SoftReference(identifiers)
+        }
+        return identifiers
+    }
+
+    private class CssValueNameCollector(val identifiers: MutableSet<String>) : CssValueDescriptorVisitorImpl() {
+        override fun visitGroupValue(groupValue: CssGroupValue) {
+            groupValue.children.forEach {
+                it.accept(this)
+            }
+        }
+
+        override fun visitNameValue(nameValue: CssNameValue) {
+            nameValue.value?.let { identifiers.add(it) }
+        }
+
+        override fun visitTextValue(textValue: CssTextValue) {
+            identifiers.add(textValue.value)
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/UssCssElementDescriptorProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/UssCssElementDescriptorProvider.kt
@@ -1,0 +1,62 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css
+
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.css.CssElementDescriptorProvider
+import com.intellij.psi.css.CssPropertyDescriptor
+import com.intellij.psi.css.CssSimpleSelector
+import com.intellij.psi.css.descriptor.CssFunctionDescriptor
+import com.intellij.psi.css.descriptor.CssPseudoSelectorDescriptor
+import com.intellij.psi.css.descriptor.value.CssValueDescriptor
+import com.intellij.psi.css.impl.descriptor.value.CssValueValidatorImpl
+import com.intellij.psi.css.impl.util.table.CssDescriptorsUtil.filterDescriptorsByContext
+import com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssLanguage
+
+class UssCssElementDescriptorProvider : CssElementDescriptorProvider() {
+    private val factory
+        get() = UssCssElementDescriptorFactory.getInstance().getDescriptors()
+
+    override fun isMyContext(psiElement: PsiElement?) = psiElement?.containingFile?.language is UssLanguage
+
+    // Allow all type names as simple selectors for now (e.g. TextField { ... })
+    // Future: Implement getSimpleSelectors to list all possible type names and remove this
+    override fun isPossibleSelector(selector: String, context: PsiElement) = true
+
+    override fun getDeclarationsForSimpleSelector(selector: CssSimpleSelector): Array<PsiElement> {
+        return arrayOf(selector)
+    }
+
+    // Pseudo selectors, e.g. :hover
+    override fun findPseudoSelectorDescriptors(name: String, context: PsiElement?): MutableCollection<out CssPseudoSelectorDescriptor> {
+        return factory.pseudoSelectors.get(StringUtil.toLowerCase(name))
+    }
+
+    override fun getAllPseudoSelectorDescriptors(context: PsiElement?): MutableCollection<out CssPseudoSelectorDescriptor> {
+        return filterDescriptorsByContext(factory.pseudoSelectors.values(), context)
+    }
+
+    // Properties - e.g. border, padding-left, etc.
+    override fun findPropertyDescriptors(propertyName: String, context: PsiElement?): MutableCollection<out CssPropertyDescriptor> {
+        return factory.properties.get(StringUtil.toLowerCase(propertyName))
+    }
+
+    override fun getAllPropertyDescriptors(context: PsiElement?): MutableCollection<out CssPropertyDescriptor> {
+        return filterDescriptorsByContext(factory.properties.values(), context)
+    }
+
+    override fun findFunctionDescriptors(functionName: String, context: PsiElement?): MutableCollection<out CssFunctionDescriptor> {
+        return factory.functions.get(StringUtil.toLowerCase(functionName))
+    }
+
+    // Named values - define a type to reuse in the descriptors file
+    // E.g. define a type called "margin-width" and then define "margin-top" in terms of "<margin-width> | inherit"
+    override fun getNamedValueDescriptors(name: String, parent: CssValueDescriptor?): MutableCollection<out CssValueDescriptor> {
+        return factory.namedValues.get(StringUtil.toLowerCase(name))
+    }
+
+    // Validator for property values, especially enums
+    override fun getValueValidator() = CssValueValidatorImpl(this)
+
+    override fun shouldAskOtherProviders(context: PsiElement?) = false
+    override fun providesClassicCss() = false
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/inspections/UssCssInspectionFilter.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/inspections/UssCssInspectionFilter.kt
@@ -1,0 +1,18 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.inspections
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.css.inspections.CssApiBaseInspection
+import com.intellij.psi.css.inspections.CssInspectionFilter
+import com.intellij.psi.css.inspections.bugs.CssUnitlessNumberInspection
+
+class UssCssInspectionFilter: CssInspectionFilter() {
+    override fun isSupported(clazz: Class<out CssApiBaseInspection>, context: PsiElement): Boolean {
+        // The CssDescriptorsLoader class creates instances of CssPropertyDescriptorImplEx, which returns false to
+        // CssPropertyDescriptor.allowsIntegerWithoutSuffix, which means this inspection fires on <number> which is
+        // wrong. The standard CSS elements from CssElementDescriptorProviderImpl appear to be loaded twice. Once with
+        // CssDescriptorsLoader via (CssElementDescriptorFactory2) and once with CssElementDescriptorFactory. The
+        // CssPropertyDescriptorImpl instances returns an appropriate value for allowsIntegerWithoutSuffix, so the
+        // standard properties don't have this problem
+        return clazz != CssUnitlessNumberInspection::class.java
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/inspections/UssCssIntentionFilter.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/codeInsight/css/inspections/UssCssIntentionFilter.kt
@@ -1,0 +1,16 @@
+package com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.inspections
+
+import com.intellij.psi.css.actions.CssBaseElementAtCaretIntentionAction
+import com.intellij.psi.css.actions.CssIntentionFilter
+import com.intellij.psi.css.actions.colors.CssConvertToHslIntention
+import com.intellij.psi.css.actions.colors.CssConvertToHwbIntention
+import com.intellij.psi.css.actions.colors.CssReplaceWithColorNameIntention
+
+class UssCssIntentionFilter: CssIntentionFilter() {
+    override fun isSupported(clazz: Class<out CssBaseElementAtCaretIntentionAction>): Boolean {
+        // USS doesn't support these colour types
+        return clazz != CssConvertToHslIntention::class.java
+            && clazz != CssConvertToHwbIntention::class.java
+            && clazz != CssReplaceWithColorNameIntention::class.java
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/readme.md
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/readme.md
@@ -1,0 +1,188 @@
+# USS
+
+The valid properties are listed in the `src/main/resources/uss/element-descriptors.xml` file. This file is primarily
+compiled from the Unity reference source.
+
+When a `.uss` file is added to a Unity project, it is parsed and imported into an internal asset. This asset is then
+validated, and it is this validation that is used to create the `element-descriptors.xml` file.
+
+## Parsing and importing stylesheets
+
+When adding a `.uss` file, Unity will call a stylesheet importer (natively in 2017.1, as a
+[scripted imported](https://docs.unity3d.com/Manual/ScriptedImporters.html) in 2017.2 and above). This importer uses
+[ExCss](https://github.com/TylerBrinks/ExCSS) to parse the `.uss` files, purely as syntax - the properties aren't
+validated, so the file just has to be valid syntactically. The importer will then walk the parsed stylesheet object
+model and start to build the `StyleSheet` asset. The property values are mostly stored as primitive values. There is
+some conversion from e.g. identifiers to keywords (`inherit`) or to create an actual `Color` instance, or to recognise
+functions.
+ 
+All of this happens in the editor. At runtime, the UIElements module uses the `StyleSheet` asset as pre-parsed data to
+apply to the visual tree.
+ 
+
+The stylesheet importer:
+* Unity 2017.2 - [`StyleSheetImporter.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.2/Editor/Mono/StyleSheets/StyleSheetImporter.cs)
+
+## 2017.1
+
+* [`StyleSheetImporter.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/StyleSheets/CSSSpec.cs)
+* [`VisualElementStyles.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Runtime/UIElements/Managed/StyleSheets/VisualElementStyles.cs)
+
+In 2017.1, the properties are stored in a file called [`VisualElementStyles`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Runtime/UIElements/Managed/StyleSheets/VisualElementStyles.cs).
+This class has a number of fields all marked with the `[StyleProperty]` attribute. This attribute contains the property
+name and a property ID. The field is of type `Style<T>`, where `T` is the "resolved" type of the property - e.g. `int`
+instead of enum and `Texture2D` for images. When applying enums, the string property value has the `-` characters
+removed, and the enum value is parsed.
+
+* Only supports `resource()` function.
+* Does not support `rgb()` or `rgba()`.
+* Supports `inherit` and `unset` for all properties.
+
+## 2017.2
+
+* [`StyleSheetImporter.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.2/Editor/Mono/StyleSheets/StyleSheetImporter.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.2/Runtime/UIElements/Managed/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.2/Runtime/UIElements/Managed/StyleSheets/StyleSheetCache.cs)
+
+The list of properties is now kept in a dictionary in `StyleSheetCache.cs`. Other than that, no significant changes.
+
+* Add `border-*-width`
+
+## 2017.3
+
+* [`StyleSheetImporter.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.3/Editor/Mono/StyleSheets/StyleSheetImporter.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.3/Runtime/UIElements/Managed/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.3/Runtime/UIElements/Managed/StyleSheets/StyleSheetCache.cs)
+
+Minor property changes.
+
+* Add `border-*-radius` + change `border-radius` to shorthand property
+
+## 2017.4
+
+* [`StyleSheetImporter.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.4/Editor/Mono/StyleSheets/StyleSheetImporter.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.4/Runtime/UIElements/Managed/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2017.4/Runtime/UIElements/Managed/StyleSheets/StyleSheetCache.cs)
+
+## 2018.1
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.1/Editor/Mono/StyleSheets/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.1/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.1/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+
+Minor property changes.
+
+* Introduces `flex-basis`, `flex-grow` and `flex-shrink`
+* Introduces `cursor`
+
+## 2018.2
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.2/Editor/Mono/StyleSheets/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.2/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.2/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+
+Minor property changes. Using [Yoga](https://yogalayout.com) for layout.
+
+* Introduces `visibility`
+
+## 2018.3
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.3/Editor/Mono/StyleSheets/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.3/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.3/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+
+Adds support for the `url()` function. Accepts URL beginning with `project:`. If URL begins with `/` treat as `project:`
+URL, else try to create a C# `Uri` with an absolute path. If that fails, try to create relative to current `.uss` file.
+During parsing, declares a dependency on the source asset, loads it and stores the reference, ready to be serialised.
+
+Lots of renames and deprecated names. The deprecated names are silently remapped to the new names.
+
+* Introduces `url()` function
+* Introduces `color`
+* `flex-wrap` supports new value `wrap-reverse`
+* `overflow` is missing the `scroll` value
+* `background-image` support `url()` function
+* `flex` shorthand applies correctly to `flex-grow`, `flex-shrink` and `flex-basis`
+* `flex-basis` data type more complex
+* `border-left` et al replaced with `border-*-width`
+* `font` replaced with `-unity-font` (data type changed to add `url()`)
+* `font-style` replaced with `-unity-font-style`
+* Introduces `position`
+* `position-type` replaced with `-unity-position-type` (overlaps with `position`?)
+* `text-alignment` replaced with `-unity-text-align`
+* `text-clipping` replaced with `-unity-clipping`
+* `text-color` replaced with `color`
+* `word-wrap` replaced with `-unity-word-wrap`
+* `background-size` replacedd with `-unity-background-scale-mode`
+* Introduces `-unity-background-scale-mode`
+* `position-left` et al replaced with `left`, `top`, `right`, `bottom`
+* `slice-left` et al replaced with `-unity-slice-*`
+
+## 2018.4
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.4/Editor/Mono/StyleSheets/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.4/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2018.4/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+
+No changes
+
+## 2019.1
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Modules/StyleSheetsEditor/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+* [`StyleSheetApplicator`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Modules/UIElements/StyleSheets/StyleSheetApplicator.cs)
+
+Parsing now supports unknown functions. Previously, would throw an error if the function wasn't `resource()` (`url()` is
+handled natively by ExCss). Each argument to the function is parsed as a separate term, so added to the `StyleSheet`
+asset correctly. ExCss splits the arugments, presumably on comma.
+
+The way of applying the styles has changed, with `VisualElementStylesData.ApplyStyleProperty` delegating to an interface.
+That interface has two implementations. The one that pulls the data out of the `StyleSheet` asset is `StyleSheetApplicator`.
+
+Introduces `initial` support. It is handled as a global keyword in `VisualElementStylesData.ApplyRule`. It checks if the
+value is `initial` and then applies either initial values or the rule values.
+
+* Introduces `initial` keyword
+* Introduces `display` and `white-space` properties
+* Introduces `margin` and `padding` shorthand properties
+* Introduces `-unity-background-image-tint-color` property
+* `background-image` allows both `unset` and `none`
+* Shorthand properties are better supported, e.g. `border-radius`, `flex`
+
+## 2019.2
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.2/Modules/StyleSheetsEditor/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.2/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.2/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+* [`StyleSheetApplicator`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.2/Modules/UIElements/StyleSheets/StyleSheetApplicator.cs)
+
+Removes `unset`. Note that `initial` is handled by `VisualElementStylesData.ApplyStyleValue`. It checks for a value of
+`initial` first, and then applies the normal style if not set.
+
+* Introduces `padding` shorthand property
+
+
+## 2019.3 (beta)
+
+* [`StyleSheetImporterImpl.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Modules/StyleSheetsEditor/StyleSheetImporterImpl.cs)
+* [`VisualElementStylesData.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Modules/UIElements/StyleSheets/VisualElementStylesData.cs)
+* [`StyleSheetCache.cs`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Modules/UIElements/StyleSheets/StyleSheetCache.cs)
+* [`StyleSheetApplicator`](https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Modules/UIElements/StyleSheets/StyleSheetApplicator.cs)
+
+The implementation changes again. Now, in `StylePropertyCache`, there is a dictionary of property names to CSS style
+syntax, rather than property IDs. E.g. `<length> | <percentage> | auto`. The style sheet asset importer has also changed,
+and supports number, pixel and percentage. Number is treated as "float", while pixel and percentage is treated as
+"dimension". Properties beginning with `--` are treated as variables.
+ 
+It validates the `var()` function. First argument is the variable name - it must begin with `--`. Second argument is
+required and is the fallback value.
+
+* Introduces the `var()` function
+* Introduces the `border-*-color` properties
+* Introduces the `-unity-overflow-clip-box` property
+
+----
+
+Note that StyleSheetCache.cs sets up initial values, for 2019.1 at least
+2019.1 has inline styles. Is this the first version?

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uxml/readme.md
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uxml/readme.md
@@ -5,7 +5,7 @@ UIElements was introduced as experimental in 2017.1. The first proper version wa
 * 2017.1
   * First introduced, in the `UnityEngine.Experimental.UIElements` namespace, in `UnityEngine.dll`
   * Editor support in `UnityEditor.Experimental.UIElements` namespace, in `UnityEditor.dll`
-  * No support for UXML or USS
+  * No support for UXML, but does support USS
   * [Documentation for 2017.1](https://docs.unity3d.com/2017.1/Documentation/Manual/UIElements.html)
 * 2017.4
   * Types are still in `UnityEngine.Experimental.UIElements` namespace, but moved to `UnityEngine.UIElementsModule.dll`

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,7 @@
     <breadcrumbsInfoProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssFileBreadcrumbsProvider" />
     <css.elementDescriptorProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorProvider" order="first" />
     <applicationService serviceImplementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorFactory" />
+    <css.cssInspectionFilter language="USS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.inspections.UssCssInspectionFilter"/>
     <!-- Override the CSS documentation for USS files -->
     <lang.documentationProvider language="CSS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssDocumentationProvider" order="first"/>
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -85,6 +85,7 @@
     <css.elementDescriptorProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorProvider" order="first" />
     <applicationService serviceImplementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorFactory" />
     <css.cssInspectionFilter language="USS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.inspections.UssCssInspectionFilter"/>
+    <css.cssIntentionFilter language="USS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.inspections.UssCssIntentionFilter"/>
     <!-- Override the CSS documentation for USS files -->
     <lang.documentationProvider language="CSS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssDocumentationProvider" order="first"/>
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,8 @@
     <breadcrumbsInfoProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssFileBreadcrumbsProvider" />
     <css.elementDescriptorProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorProvider" order="first" />
     <applicationService serviceImplementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorFactory" />
+    <!-- Override the CSS documentation for USS files -->
+    <lang.documentationProvider language="CSS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssDocumentationProvider" order="first"/>
 
     <editorNotificationProvider implementation="com.jetbrains.rider.plugins.unity.ui.UxmlMissingSchemaEditorNotification" />
     <editorNotificationProvider implementation="com.jetbrains.rider.plugins.unity.ui.NonUserEditableEditorNotification" />

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
   <vendor url="https://www.jetbrains.com">JetBrains</vendor>
 
   <depends>com.intellij.modules.rider</depends>
+  <depends>com.intellij.css</depends>
   <depends optional="true" config-file="PluginYamlPluginPart.xml">org.jetbrains.plugins.yaml</depends>
   <depends optional="true" config-file="PluginAppenderPluginPart.xml">rider.intellij.plugin.appender</depends>
 
@@ -75,6 +76,14 @@
     <lang.parserDefinition language="UXML" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uxml.UxmlFileParserDefinition"/>
     <breadcrumbsInfoProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uxml.UxmlFileBreadcrumbsProvider" />
     <xml.schemaProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uxml.codeInsight.schema.UxmlSchemaProvider" />
+
+    <!-- USS support -->
+    <fileType name="USS" language="USS" fieldName="INSTANCE" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssFileType" extensions="uss" />
+    <lang.parserDefinition language="USS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssFileParserDefinition"/>
+    <lang.syntaxHighlighter language="USS" implementationClass="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssSyntaxHighlighter" />
+    <breadcrumbsInfoProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.UssFileBreadcrumbsProvider" />
+    <css.elementDescriptorProvider implementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorProvider" order="first" />
+    <applicationService serviceImplementation="com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.uss.codeInsight.css.UssCssElementDescriptorFactory" />
 
     <editorNotificationProvider implementation="com.jetbrains.rider.plugins.unity.ui.UxmlMissingSchemaEditorNotification" />
     <editorNotificationProvider implementation="com.jetbrains.rider.plugins.unity.ui.NonUserEditableEditorNotification" />

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -274,6 +274,7 @@
 <ul>
   <li>Rider: Add support for play mode tests (<a href="https://youtrack.jetbrains.com/issue/RIDER-19513">RIDER-19513</a>, <a href="https://github.com/JetBrains/resharper-unity/issues/1293">#1293</a>)</li>
   <li>Rider: Add syntax highlighting, schema generation and validation of UXML files (<a href="https://github.com/JetBrains/resharper-unity/pull/1399">#1399</a>)></li>
+  <li>Rider: Add syntax highlighting, validation and completion for USS files (<a href="https://github.com/JetBrains/resharper-unity/issues/957">#957</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-20576">RIDER-20576</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1402">#1402</a>)</li>
   <li>Rider: Show prompt to set Rider as default external editor when Unity is started by Rider (<a href="https://github.com/JetBrains/resharper-unity/issues/1127">#1127<a/>), <a href="https://github.com/JetBrains/resharper-unity/pull/1270">#1270</a>)</li>
   <li>Rider: Show prompt for Linux users to install Mono 5.16+ (<a href="https://github.com/JetBrains/resharper-unity/issues/1375">#1375</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1383">#1383</a>)</li>
   <li>Rider: Add Unity specific Live Templates settings page (<a href="https://github.com/JetBrains/resharper-unity/pull/1351">#1351</a>)</li>

--- a/rider/src/main/resources/uss/element-descriptors.xml
+++ b/rider/src/main/resources/uss/element-descriptors.xml
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="utf-8"?>
+<definitions xmlns="urn:schemas-jetbrains-com:css-xml">
+
+  <!-- See the readme.md in src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uss/readme.md -->
+
+  <!-- It would be nice to use declared-in and obsolete-in attributes, but these are CSS versions, and will return
+       UNKNOWN if not a valid CSS version -->
+
+  <!-- Notes:
+       * The code reads `inherit`, but it's not used or supported anywhere
+       * USS's <length> is not the same as CSS's <length. USS does not require a unit. When specified it has to be `px`
+       * USS will also treat a `px` <length> as a float, which means it can be applied to a property that should only
+         accept <number>. This implementation detail is ignored in this file
+       * Initial values in this file are for latest version, and have not been looked at in previous versions
+       * 2017.1-2019.1 had `unset` for all properties - enums, color, float, resource, etc. It was removed in 2019.2
+         2019.1 reduced the set of properties that could use `unset`
+       * 2019.1 introduced `initial` as a global keyword. It is processed before attempting to apply the property value
+       * Technically, the code is more lax in its validation than is expected.
+         * The code has the idea of "float" and "length"
+         * The code to read a "float" will just read a float value. This can be <number> or <length> - there is nothing
+           to indicate which it should be
+         * The code to read a "length" will read a keyword or a float value. Technically, this means the value could be
+           [ auto | none | initial | unset | <length> | <number ]. There is nothing to indicate what it should be
+         * The 2019.3 code introduces more exact syntax for validation, e.g. "<length> | <percentage>" or "<length> | <percentage> | auto"
+         * This means you can write USS that parses just fine, but is being used incorrectly, e.g. `auto` on `border-top-width`
+         * This file uses the stricter syntax
+       -->
+
+  <named-value id="global-keywords" declared-in="0">
+    <name value="initial" />
+  </named-value>
+  <named-value id="length" declared-in="0">
+    <group type="or">
+      <number/>
+      <length/>
+    </group>
+  </named-value>
+  <named-value id="dimension" declared-in="0">
+    <!-- 2017.3-2019.2 <length> -->
+    <!-- Note that the code will technically allow reading keywords here ( auto | none | unset ). They can be read, but
+         they are not correct -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <percentage/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </named-value>
+  <named-value id="dimension-auto" declared-in="0">
+    <!-- 2017.3-2018.4 <length>
+         2019.1-2019.2 <length> | auto -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <percentage />
+      <name value="auto" />
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </named-value>
+  <named-value id="dimension-none" declared-in="0">
+    <!-- 2017.3-2018.4 <length>
+         2019.1-2019.2 <length> | none -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <percentage />
+      <name value="none" />
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </named-value>
+  <named-value id="color" declared-in="0">
+    <group type="or">
+      <color />
+      <invoke id="rgb" />
+      <invoke id="rgba" />
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </named-value>
+  <named-value id="asset" declared-in="0">
+    <group type="or">
+      <uri/>
+      <invoke id="resource"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </named-value>
+  <named-value id="asset-none" declared-in="0">
+    <group type="or">
+      <uri/>
+      <invoke id="resource"/>
+      <name value="none"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </named-value>
+
+  <!-- In alphabetical ordering (see uss-properties.json) -->
+  <property id="align-content" declared-in="" initial="flex-start"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="flex-start"/>
+      <name value="flex-end"/>
+      <name value="center"/>
+      <name value="stretch"/>
+      <name value="auto"/>
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </property>
+  <property id="align-items" declared-in="0" initial="stretch"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="flex-start"/>
+      <name value="flex-end"/>
+      <name value="center"/>
+      <name value="stretch"/>
+      <name value="auto"/>
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </property>
+  <property id="align-self" declared-in="0" initial="auto"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="flex-start"/>
+      <name value="flex-end"/>
+      <name value="center"/>
+      <name value="stretch"/>
+      <name value="auto"/>
+      <inline id="global-keywords" inline="yes" />
+    </group>
+  </property>
+  <property id="background-color" declared-in="0" initial="clear"> <!-- 2017.1-2019.3 -->
+    <inline id="color" inline="yes" />
+  </property>
+  <property id="background-image" declared-in="0" initial="default"> <!-- 2017.1-2019.3 -->
+    <inline id="asset-none" inline="yes" />
+  </property>
+  <property id="border-bottom-color" declared-in="0" initial="clear"> <!-- 2019.3 -->
+    <inline id="color" inline="yes" />
+  </property>
+  <property id="border-bottom-left-radius" declared-in="0" initial="0"> <!-- 2017.3-2019.3 -->
+    <inline id="dimension" inline="yes" />
+  </property>
+  <property id="border-bottom-right-radius" declared-in="0" initial="0"> <!-- 2017.3-2019.3 -->
+    <inline id="dimension" inline="yes" />
+  </property>
+  <property id="border-bottom-width" declared-in="0" initial="0"> <!-- 2017.2-2019.3 -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="border-color" declared-in="0"> <!-- 2017.1-2019.3 -->
+    <!-- 2017.1-2019.2 <color>{1} -->
+    <inline id="color" inline="yes" max="4"/>
+  </property>
+  <property id="border-left-color" declared-in="0" initial="clear"> <!-- 2019.3 -->
+    <inline id="color" inline="yes"/>
+  </property>
+  <property id="border-left-width" declared-in="0" initial="0"> <!-- 2017.2-2019.3 -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="border-radius" declared-in="0"> <!-- 2017.1-2019.3 -->
+    <!-- 2017.1-2018.4 <length>{1} -->
+    <!-- 2019.1-2019.3 <length>{1,4} -->
+    <group type="or" max="4">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="border-right-color" declared-in="0" initial="clear"> <!-- 2019.3 -->
+    <inline id="color" inline="yes"/>
+  </property>
+  <property id="border-right-width" declared-in="0" initial="0"> <!-- 2017.2-2019.3 -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="border-top-color" declared-in="0" initial="clear"> <!-- 2019.3 -->
+    <inline id="color" inline="yes"/>
+  </property>
+  <property id="border-top-left-radius" declared-in="0" initial="0"> <!-- 2017.3-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="border-top-right-radius" declared-in="0" initial="0"> <!-- 2017.3-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="border-top-width" declared-in="0" initial="0"> <!-- 2017.2-2019.3 -->
+    <group type="or">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="border-width" declared-in="0" initial="0"> <!-- 2017.1. Removed in 2017.2-2017.4. 2019.1-2019.3 -->
+    <!-- 2017.1 <length> -->
+    <!-- 2019.1-2019.2 (<length> | <number>){4} (brought back as shorthand) -->
+    <group type="or" max="4">
+      <inline id="length" inline="yes"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="bottom" declared-in="0" initial="auto"> <!-- 2018.3-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+  <property id="color" declared-in="0" initial="#000000"> <!-- 2018.3-2019.3 -->
+    <inline id="color" inline="yes"/>
+  </property>
+  <property id="cursor" declared-in="0" initial="default"> <!-- 2018.1-2019.3 -->
+    <!-- [ <resource> | <url> ] [<number>? <number>?] | enum -->
+    <group type="or">
+      <group type="and">
+        <group type="or">
+          <invoke id="resource"/>
+          <uri/>
+        </group>
+        <group type="and">
+          <number/>
+          <number min="0"/>
+        </group>
+      </group>
+      <group type="or">
+        <name value="arrow"/>
+        <name value="text"/>
+        <name value="resize-vertical"/>
+        <name value="resize-horizontal"/>
+        <name value="link"/>
+        <name value="slide-arrow"/>
+        <name value="resize-up-right"/>
+        <name value="resize-up-left"/>
+        <name value="move-arrow"/>
+        <name value="rotate-arrow"/>
+        <name value="scale-arrow"/>
+        <name value="arrow-plus"/>
+        <name value="arrow-minus"/>
+        <name value="pan"/>
+        <name value="orbit"/>
+        <name value="zoom"/>
+        <name value="fps"/>
+        <name value="split-resize-up-down"/>
+        <name value="split-resize-left-right"/>
+      </group>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="display" declared-in="0" initial="flex"> <!-- 2019.1-2019.3 -->
+    <group type="or">
+      <name value="flex"/>
+      <name value="none"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="flex" declared-in="0"> <!-- 2017.1-2019.3 -->
+    <!-- 2017.1-2018.2 <length> -->
+    <!-- 2018.3-2018.4 unset | none | auto (<length> | <number>)? (<length> | <number>)?
+         Applies to flex-grow (float), flex-shrink (float), flex-basis (float | keyword) -->
+    <!-- Using <float> to mean <length> | <number> -->
+    <!-- 2019.1-2019.2 unset | none | [ auto (<float>) (<float>)? ] | <float> <float>? <float>? | <float> auto -->
+    <name value="whatever"/>
+    <group type="or">
+      <name value="none"/>
+      <group type="any">
+        <group>
+          <number/> <!-- flex-grow -->
+          <number min="0"/> <!-- flex-shrink? -->
+        </group>
+        <inline id="dimension-auto" inline="yes"/> <!-- flex-basis -->
+      </group>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="flex-basis" declared-in="0" initial="auto"> <!-- 2018.1-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+  <property id="flex-direction" declared-in="0" initial="column"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="column"/>
+      <name value="row"/>
+      <name value="column-reverse"/>
+      <name value="row-reverse"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="flex-grow" declared-in="0" initial="0"> <!-- 2018.1-2019.3 -->
+    <group type="or">
+      <number/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="flex-shrink" declared-in="0" initial="1"> <!-- 2018.1-2019.3 -->
+    <group type="or">
+      <number/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="flex-wrap" declared-in="0" initial="nowrap"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="nowrap"/>
+      <name value="wrap"/>
+      <name value="wrap-reverse"/> <!-- 2018.3+ -->
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="font-size" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="height" declared-in="0" initial="auto"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="justify-content" declared-in="0" initial="flex-start"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="flex-start"/>
+      <name value="flex-end"/>
+      <name value="center"/>
+      <name value="space-between"/>
+      <name value="space-around"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="left" declared-in="0" initial="auto"> <!-- 2018.3-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+  <property id="margin" declared-in="0"> <!-- 2019.1-2019.3 -->
+    <inline id="dimension-auto" max="4"/>
+  </property>
+  <property id="margin-bottom" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="margin-left" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="margin-right" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="margin-top" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="max-height" declared-in="0" initial="none"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-none"/>
+  </property>
+  <property id="max-width" declared-in="0" initial="none"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-none"/>
+  </property>
+  <property id="min-height" declared-in="0" initial="auto"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="min-width" declared-in="0" initial="auto"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto"/>
+  </property>
+  <property id="opacity" declared-in="0" initial="1"> <!-- 2017.1-2019.3 -->
+    <!-- Technically the code will read <length> here, but that is not correct -->
+    <group type="or">
+      <number/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="overflow" declared-in="0" initial="visible"> <!-- 2017.1-2019.3 -->
+    <group type="or">
+      <name value="visible"/>
+      <name value="hidden"/>
+      <name value="scroll"/> <!-- Not in 2018.3 -->
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-overflow-clip-box" declared-in="0" initial="padding-box"> <!-- 2019.3 -->
+    <group type="or">
+      <name value="padding-box"/>
+      <name value="content-box"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="padding" declared-in="0"> <!-- 2019.1-2019.3 -->
+    <inline id="dimension" inline="yes" max="4"/>
+  </property>
+  <property id="padding-bottom" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="padding-left" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="padding-right" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="padding-top" declared-in="0" initial="0"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension" inline="yes"/>
+  </property>
+  <property id="position" declared-in="0" initial="relative"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <name value="relative"/>
+      <name value="absolute"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="right" declared-in="0" initial="auto"> <!-- 2018.3-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+  <property id="top" declared-in="0" initial="auto"> <!-- 2018.3-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+  <property id="-unity-background-image-tint-color" declared-in="0" initial="#ffffff"> <!-- 2019.1-2019.3 -->
+    <inline id="color" inline="yes"/>
+  </property>
+  <property id="-unity-background-scale-mode" declared-in="0" initial="stretch-to-fill"> <!-- 2018.3-2019.3 -->
+    <!-- 2018.3-2018.4 <integer> -->
+    <group type="or">
+      <name value="stretch-to-fill"/>
+      <name value="scale-and-crop"/>
+      <name value="scale-to-fit"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-font" declared-in="0" initial="default"> <!-- 2018.3-2019.3 -->
+    <inline id="asset" inline="yes"/>
+  </property>
+  <property id="-unity-font-style" declared-in="0" initial="normal"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <name value="normal"/>
+      <name value="italic"/>
+      <name value="bold"/>
+      <name value="bold-and-italic"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-slice-bottom" declared-in="0" initial="0"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <integer/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-slice-left" declared-in="0" initial="0"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <integer/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-slice-right" declared-in="0" initial="0"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <integer/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-slice-top" declared-in="0" initial="0"> <!-- 2018.3-2019.3 -->
+    <group type="or">
+      <integer/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="-unity-text-align" declared-in="0" initial="upper-left"> <!-- 2018.3-2091.3 -->
+    <group type="or">
+      <name value="upper-left"/>
+      <name value="middle-left"/>
+      <name value="lower-left"/>
+      <name value="upper-center"/>
+      <name value="middle-center"/>
+      <name value="lower-center"/>
+      <name value="upper-right"/>
+      <name value="middle-right"/>
+      <name value="lower-right"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="visibility" declared-in="0" initial="visible"> <!-- 2018.2-2019.3 -->
+    <group type="or">
+      <name value="visible"/>
+      <name value="hidden"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="white-space" declared-in="0" initial="normal"> <!-- 2019.1-2091.3 -->
+    <group type="or">
+      <name value="normal"/>
+      <name value="nowrap"/>
+      <inline id="global-keywords" inline="yes"/>
+    </group>
+  </property>
+  <property id="width" declared-in="0" initial="auto"> <!-- 2017.1-2019.3 -->
+    <inline id="dimension-auto" inline="yes"/>
+  </property>
+
+  <!-- Functions -->
+  <function id="rgb" declared-in="0">
+    <group>
+      <separator>
+        <text value="," min="0"/>
+      </separator>
+      <group type="or" name="&lt;red&gt;" tooltip="red value of color">
+        <integer/>
+        <percentage/>
+      </group>
+      <group type="or" name="&lt;green&gt;" tooltip="green value of color">
+        <integer/>
+        <percentage/>
+      </group>
+      <group type="or" name="&lt;blue&gt;" tooltip="blue value of color">
+        <integer/>
+        <percentage/>
+      </group>
+    </group>
+  </function>
+  <function id="rgba" declared-in="0">
+    <group>
+      <separator>
+        <text value="," min="0"/>
+      </separator>
+      <group type="or" name="&lt;red&gt;" tooltip="red value of color">
+        <integer/>
+        <percentage/>
+      </group>
+      <group type="or" name="&lt;green&gt;" tooltip="green value of color">
+        <integer/>
+        <percentage/>
+      </group>
+      <group type="or" name="&lt;blue&gt;" tooltip="blue value of color">
+        <integer/>
+        <percentage/>
+      </group>
+      <group type="or" name="&lt;alpha&gt;" tooltip="alpha value of color">
+        <integer/>
+        <percentage/>
+      </group>
+    </group>
+  </function>
+  <function id="resource" declared-in="0">
+    <string/>
+  </function>
+
+  <!-- Deprecated properties. Unity will silently mapped these to their new names. No longer supported in 2019.3 -->
+  <!-- border-left 2017.1-2018.2 - <length>  -> border-left-width (2018.3) -->
+  <!-- border-top 2017.1-2018.2 - <length> -> border-top-width (2018.3) -->
+  <!-- border-right 2017.1-2018.2 - <length> -> border-right-width (2018.3) -->
+  <!-- border-bottom 2017.1-2018.2 - <length> -> border-bottom-width (2018.3) -->
+  <!-- font 2017.1-2018.2 - resource() -> -unity-font (2018.3) -->
+  <!-- font-style 2017.1-2018.2 -> -unity-font-style (2018.3) -->
+  <!-- position-type 2017.1-2018.2 - relative | absolute | manual -> -unity-position (2018.3) -->
+  <!-- -unity-position 2018.3 - relative | absolute | manual -->
+  <!-- position-top 2017.1-2018.2 - <length> -> top (2018.3) -->
+  <!-- position-bottom 2017.1-2018.3 - <length> -> bottom (2018.3) -->
+  <!-- position-left 2017.1-2018.3 - <length> -> left (2018.3) -->
+  <!-- position-right 2017.1-2018.3 - <length> -> right (2018.3) -->
+  <!-- text-alignment 2017.1-2018.2 -> -unity-text-align (2018.3) -->
+  <!-- text-clipping 2017.1-2018.2 - overflow | clip -> -unity-clipping (2018.3) -->
+  <!-- -unity-clipping 2018.3 - overflow | clip -->
+  <!-- text-color 2017.1-2018.2 - <color> (not rgb, unless ExCss handles it) -> color (2018.3) -->
+  <!-- word-wrap 2017.1-2018.2 - true | false -> -unity-word-wrap (2018.3) -->
+  <!-- -unity-word-wrap 2018.3 - true | false -->
+  <!-- background-size 2017.1-2018.2 - <integer> -->
+  <!-- slice-left 2017.1-2018.2 - <integer> -> -unity-slice-left (2018.3) -->
+  <!-- slice-top 2017.1-2018.2 - <integer> -> -unity-slice-top (2018.3) -->
+  <!-- slice-bottom 2017.1-2018.2 - <integer> -> -unity-slice-bottom (2018.3) -->
+  <!-- slice-right 2017.1-2018.2 - <integer> -> -unity-slice-right (2018.3) -->
+
+  <!-- Note that 2017.1 has custom properties.8A1y unknown property is added to dictionary. Doesn't appear to have a typ -->
+
+  <!-- Pseudo classes -->
+  <!-- https://docs.unity3d.com/Manual/UIE-USS-Selectors.html -->
+  <pseudo-class id="hover" declared-in="0" tooltip="The cursor is hovering over the visual element."/>
+  <pseudo-class id="active" declared-in="0" tooltip="The visual element is being interacted with." />
+  <pseudo-class id="inactive" declared-in="0" tooltip="The visual element is no longer being interacted with." />
+  <pseudo-class id="focus" declared-in="0" tooltip="The visual element has focus." />
+  <!-- The documentation also lists selected ("unused") -->
+  <pseudo-class id="disabled" declared-in="0" tooltip="The visual element is set to enabled == false." />
+  <pseudo-class id="enabled" declared-in="0" tooltip="The visual element is set to enabled == true." />
+  <pseudo-class id="checked" declared-in="0" tooltip="The visual element is a Toggle element and it is checked." />
+</definitions>

--- a/rider/src/main/resources/uss/element-descriptors.xml
+++ b/rider/src/main/resources/uss/element-descriptors.xml
@@ -90,7 +90,7 @@
   </named-value>
 
   <!-- In alphabetical ordering (see uss-properties.json) -->
-  <property id="align-content" declared-in="" initial="flex-start"> <!-- 2017.1-2019.3 -->
+  <property id="align-content" declared-in="0" initial="flex-start"> <!-- 2017.1-2019.3 -->
     <group type="or">
       <name value="flex-start"/>
       <name value="flex-end"/>
@@ -250,7 +250,6 @@
          Applies to flex-grow (float), flex-shrink (float), flex-basis (float | keyword) -->
     <!-- Using <float> to mean <length> | <number> -->
     <!-- 2019.1-2019.2 unset | none | [ auto (<float>) (<float>)? ] | <float> <float>? <float>? | <float> auto -->
-    <name value="whatever"/>
     <group type="or">
       <name value="none"/>
       <group type="any">


### PR DESCRIPTION
Adds initial support for USS files:

- [x] Treat USS files as a specialised CSS file - syntax highlighting, formatting, folding, etc.
- [x] Provide validation/code completion for USS syntax - property names + values
- [x] Disable some CSS inspections + intentions that don't make sense for USS (e.g. convert to named colour)