### PR TITLE
Avoid creating meta, when file doesn't belong to project

### DIFF
--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -131,7 +131,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool ShouldHandleChange(ProjectItemChange change)
             {
                 // String comparisons, treat as expensive if we're doing this very frequently
-                return !IsItemMetaFile(change);
+                return BelongsToProject(change) && !IsItemMetaFile(change);
+            }
+
+            private static bool BelongsToProject(ProjectModelChange change)
+            {
+                return change.ProjectModelElement is IProjectFile;
             }
 
             private static bool IsItemMetaFile(ProjectItemChange change)

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -131,12 +131,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool ShouldHandleChange(ProjectItemChange change)
             {
                 // String comparisons, treat as expensive if we're doing this very frequently
-                return BelongsToProject(change) && !IsItemMetaFile(change);
+                return BelongsToRealProject(change) && !IsItemMetaFile(change);
             }
 
-            private static bool BelongsToProject(ProjectModelChange change)
+            private static bool BelongsToRealProject(ProjectModelChange change)
             {
-                return change.ProjectModelElement is IProjectFile;
+                var projectFile = change.ProjectModelElement as IProjectFile;
+                var project = projectFile?.GetProject();
+                if (project == null)
+                    return false;
+                if (project.IsMiscFilesProject())
+                    return false;
+                return true;
             }
 
             private static bool IsItemMetaFile(ProjectItemChange change)


### PR DESCRIPTION
fix RIDER-35227 Failed to create Unity meta file /usr/share/dotnet/sdk/3.0.100/Microsoft.Common.CurrentVersion.targets.meta
and 
RIDER-35197 Opening json file from Library folder creates bogus meta file