### PR TITLE
Workaround Unity bug sending log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Fix correctly keeping `.meta` files up to date in `Packages` folder ([#1231](https://github.com/JetBrains/resharper-unity/issues/1231), [#1389](https://github.com/JetBrains/resharper-unity/pull/1389))
 - Rider: Fix race condition preventing "Attach to Unity Process" dialog from always listing players ([RIDER-34039](https://youtrack.jetbrains.com/issue/RIDER-34039), [#1298](https://github.com/JetBrains/resharper-unity/pull/1298))
 - Rider: Prevent "Attach to Unity Process" attempting to attach to the same process multiple times ([#1129](https://github.com/JetBrains/resharper-unity/issues/1129), [#1298](https://github.com/JetBrains/resharper-unity/pull/1298))
-- Rider: Fix auto-scroll of Unity log view ([#1393](https://github.com/JetBrains/resharper-unity/issues/1393), [#1394](https://github.com/JetBrains/resharper-unity/pull/1394))
+- Rider: Work around Unity bug failing to send log events after leaving play mode ([#1414](https://github.com/JetBrains/resharper-unity/pull/1414))
 - Unity Editor: Stop suggesting C# 8 features when using a new msbuild from Mono ([#1379](https://github.com/JetBrains/resharper-unity/issues/1379), [#1380](https://github.com/JetBrains/resharper-unity/pull/1380))
 - Unity Editor: Avoid all initialisation when started in batch mode ([#1396](https://github.com/JetBrains/resharper-unity/pull/1396))
 - Unity Editor: Fix exception calling `EditorApplication.isPlaying` on wrong thread ([#1308](https://github.com/JetBrains/resharper-unity/pull/1308))
@@ -59,15 +59,12 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/31?closed=1)
 
 ### Changed
-* Use platform native line endings in generated `.meta` files. Works better with Perforce ([#1323](https://github.com/JetBrains/resharper-unity/pull/1323))
+- Use platform native line endings in generated `.meta` files. Works better with Perforce ([#1323](https://github.com/JetBrains/resharper-unity/pull/1323))
 
 ### Fixed
-* Fix issues with completion of Unity event functions ([RIDER-33167](https://youtrack.jetbrains.com/issue/RIDER-33167), [#1326](https://github.com/JetBrains/resharper-unity/pull/1326))
+- Fix issues with completion of Unity event functions ([RIDER-33167](https://youtrack.jetbrains.com/issue/RIDER-33167), [#1326](https://github.com/JetBrains/resharper-unity/pull/1326))
 - Fix exception building caches ([DEXP-481931](https://youtrack.jetbrains.com/issue/DEXP-481931), [#1355](https://github.com/JetBrains/resharper-unity/pull/1355))
-* Rider: Fix missing "Install Mono" notification ([#1329](https://github.com/JetBrains/resharper-unity/pull/1329))
-
-- Rider: Fix Clear on Play in Rider's Unity log viewer ([#1281](https://github.com/JetBrains/resharper-unity/issues/1281), [#1294](https://github.com/JetBrains/resharper-unity/pull/1294))
-- Unity window should get focus, when Rider is showing usages in it ([#1344](https://github.com/JetBrains/resharper-unity/pull/1344)
+- Rider: Fix missing "Install Mono" notification ([#1329](https://github.com/JetBrains/resharper-unity/pull/1329))
 
 
 ## 2019.2.2

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -307,7 +307,7 @@
   <li>Fix correctly keeping <tt>.meta</tt> files up to date in <tt>Packages</tt> folder (<a href="https://github.com/JetBrains/resharper-unity/issues/1231">#1231</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1389">#1389</a>)</li>
   <li>Rider: Fix race condition preventing "Attach to Unity Process" dialog from always listing players (<a href="https://youtrack.jetbrains.com/issue/RIDER-34039">RIDER-34039</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1298">#1298</a>)</li>
   <li>Rider: Prevent "Attach to Unity Process" attempting to attach to the same process multiple times (<a href="https://github.com/JetBrains/resharper-unity/issues/1129">#1129</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1298">#1298</a>)</li>
-  <li>Rider: Fix auto-scroll of Unity log view (<a href="https://github.com/JetBrains/resharper-unity/issues/1393">#1393</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1394">#1394</a>)</li>
+  <li>Rider: Work around Unity bug failing to send log events after leaving play mode (<a href="https://github.com/JetBrains/resharper-unity/pull/1414">#1414</a>)</li>
   <li>Unity Editor: Stop suggesting C# 8 features when using a new msbuild from Mono (<a href="https://github.com/JetBrains/resharper-unity/issues/1379">#1379</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1380">#1380</a>)</li>
   <li>Unity Editor: Avoid all initialisation when started in batch mode (<a href="https://github.com/JetBrains/resharper-unity/pull/1396">#1396</a>)</li>
   <li>Unity Editor: Fix exception calling <tt>EditorApplication.isPlaying</tt> on wrong thread (<a href="https://github.com/JetBrains/resharper-unity/pull/1308">#1308</a>)</li>

--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -50,7 +50,7 @@ namespace JetBrains.Rider.Unity.Editor
       if (IsLoadedFromAssets()) // old mechanism, when EditorPlugin was copied to Assets folder
       {
         ourTestModeEnabled = Environment.GetCommandLineArgs().Contains("-riderTests");
-        
+
         var riderPath = ourRiderPathProvider.GetActualRider(EditorPrefsWrapper.ExternalScriptEditor,
           RiderPathLocator.GetAllFoundPaths(ourPluginSettings.OperatingSystemFamilyRider));
         if (!string.IsNullOrEmpty(riderPath))
@@ -449,13 +449,12 @@ namespace JetBrains.Rider.Unity.Editor
         {
           var isPlaying = EditorApplication.isPlayingOrWillChangePlaymode && EditorApplication.isPlaying;
 
-          if (isPlaying)
-            model.ClearOnPlay(DateTime.UtcNow.Ticks);
-
           if (!model.Play.HasValue() || model.Play.HasValue() && model.Play.Value != isPlaying)
           {
             ourLogger.Verbose("Reporting play mode change to model: {0}", isPlaying);
             model.Play.SetValue(isPlaying);
+            if (isPlaying)
+              model.ClearOnPlay(DateTime.UtcNow.Ticks);
           }
 
           var isPaused = EditorApplication.isPaused;


### PR DESCRIPTION
This PR works around a bug in Unity since at least 2017.1 that stops sending log events to subscribers when Unity leaves play mode. See [1102950](https://issuetracker.unity3d.com/issues/general-unityengine-dot-application-dot-logmessagereceived-is-not-being-raised-after-exiting-play-mode) on Unity's issue tracker. 

This bug affects 2017.1 and above (I didn't test 5.x), even though the bug report states 2017.4. The bug is closed as "by design" because changing it could break existing work arounds.

This PR also fixes an issue where the Unity log tool window was cleared when the pause state changed, rather than simply when entering play mode.