### PR TITLE
Fix resolving event based handlers for Unity 2018.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 ### Added
 
-- Added proper file icons for `*.uxml` and `*.uss` ([RIDER-34788](https://youtrack.jetbrains.com/issue/RIDER-34788), [#1443](https://github.com/JetBrains/resharper-unity/pull/1443))
+- Rider: Added proper file icons for `*.uxml` and `*.uss` ([RIDER-34788](https://youtrack.jetbrains.com/issue/RIDER-34788), [#1443](https://github.com/JetBrains/resharper-unity/pull/1443))
 
 ### Changed
 
-- Entire plugin is no longer disabled if the CSS plugin is disabled ([RIDER-36523](https://youtrack.jetbrains.com/issue/RIDER-36523), [#1443](https://github.com/JetBrains/resharper-unity/pull/1443))
+- Rider: Entire plugin is no longer disabled if the CSS plugin is disabled ([RIDER-36523](https://youtrack.jetbrains.com/issue/RIDER-36523), [#1443](https://github.com/JetBrains/resharper-unity/pull/1443))
 
+### Fixed
+
+- Fix usage count for custom event based event handlers in Unity 2018.4+ ([#1448](https://github.com/JetBrains/resharper-unity/issues/1448), [#1449](https://github.com/JetBrains/resharper-unity/pull/1449))
 
 
 ## 2019.3

--- a/resharper/resharper-unity/src/Yaml/Psi/Resolve/EventHandlerSymbolFilter.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Resolve/EventHandlerSymbolFilter.cs
@@ -7,6 +7,12 @@ using JetBrains.Util.dataStructures;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
 {
+    // This filter is the equivalent of UnityEventBase.FindMethod
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/2018.4/Runtime/Export/UnityEvent.cs#L721
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Runtime/Export/UnityEvent/UnityEvent.cs#L721
+    //
+    // Essentially, find a public or non-public instance method, anywhere in the hierarchy, with parameters that match
+    // the requested arguments
     public class EventHandlerSymbolFilter : SimpleSymbolFilter
     {
         private readonly EventHandlerArgumentMode myMode;
@@ -17,67 +23,64 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
             myTypes = new FrugalLocalList<IType>();
 
             myMode = mode;
-            if (mode == EventHandlerArgumentMode.UnityObject && type != null)
+            var predefinedTypes = psiModule.GetPredefinedType();
+            switch (mode)
             {
-                myTypes.Add(TypeFactory.CreateTypeByCLRName(type, psiModule));
-            }
-            else if (mode == EventHandlerArgumentMode.EventDefined && type != null)
-            {
-                var eventType = TypeFactory.CreateTypeByCLRName(type, psiModule);
-                var unityEventType = GetUnityEventType(eventType);
-                var unityEventTypeElement = unityEventType?.GetTypeElement();
-                if (unityEventType != null && unityEventTypeElement != null)
-                {
-                    var (_, substitution) = unityEventType.Resolve();
-                    var typeParameters = unityEventTypeElement.TypeParameters;
-                    foreach (var t in typeParameters)
+                case EventHandlerArgumentMode.EventDefined:
+                    if (type != null)
                     {
-                        myTypes.Add(substitution.Apply(t));
+                        // Find the UnityEvent base type, and use the type parameters as the required arguments
+                        // This only works for scenes serialised in Unity 2018.3 and below. The field was removed in 2018.4
+                        var eventType = TypeFactory.CreateTypeByCLRName(type, psiModule);
+                        var unityEventType = GetUnityEventType(eventType);
+                        var unityEventTypeElement = unityEventType?.GetTypeElement();
+                        if (unityEventType != null && unityEventTypeElement != null)
+                        {
+                            var (_, substitution) = unityEventType.Resolve();
+                            var typeParameters = unityEventTypeElement.TypeParameters;
+                            foreach (var t in typeParameters)
+                                myTypes.Add(substitution.Apply(t));
+                        }
                     }
-                }
-            }
-            else if (mode != EventHandlerArgumentMode.Void)
-            {
-                var predefinedTypes = psiModule.GetPredefinedType();
-                switch (mode)
-                {
-                    case EventHandlerArgumentMode.Int:
-                        myTypes.Add(predefinedTypes.Int);
-                        break;
-                    case EventHandlerArgumentMode.Float:
-                        myTypes.Add(predefinedTypes.Float);
-                        break;
-                    case EventHandlerArgumentMode.String:
-                        myTypes.Add(predefinedTypes.String);
-                        break;
-                    case EventHandlerArgumentMode.Bool:
-                        myTypes.Add(predefinedTypes.Bool);
-                        break;
-                }
-            }
-        }
+                    break;
 
-        [CanBeNull]
-        private static IDeclaredType GetUnityEventType(IDeclaredType eventType)
-        {
-            foreach (var superType in eventType.GetAllSuperTypes())
-            {
-                if (superType.GetClrName().ShortName == "UnityEvent")
-                    return superType;
-            }
+                case EventHandlerArgumentMode.UnityObject:
+                    myTypes.Add(type == null
+                        ? TypeFactory.CreateTypeByCLRName(KnownTypes.Object, NullableAnnotation.Unknown, psiModule)
+                        : TypeFactory.CreateTypeByCLRName(type, psiModule));
+                    break;
 
-            return null;
+                case EventHandlerArgumentMode.Int:
+                    myTypes.Add(predefinedTypes.Int);
+                    break;
+
+                case EventHandlerArgumentMode.Float:
+                    myTypes.Add(predefinedTypes.Float);
+                    break;
+
+                case EventHandlerArgumentMode.String:
+                    myTypes.Add(predefinedTypes.String);
+                    break;
+
+                case EventHandlerArgumentMode.Bool:
+                    myTypes.Add(predefinedTypes.Bool);
+                    break;
+            }
         }
 
         public override ResolveErrorType ErrorType => ResolveErrorType.ARGUMENTS_MISMATCH;
 
         public override bool Accepts(IDeclaredElement declaredElement, ISubstitution substitution)
         {
-            if (myMode != EventHandlerArgumentMode.Void && myTypes.Count == 0)
+            if (myMode != EventHandlerArgumentMode.Void && myMode != EventHandlerArgumentMode.EventDefined && myTypes.Count == 0)
                 return false;
 
             if (!(declaredElement is IMethod method))
                 return false;
+
+            // Since Unity 2018.4+ we don't know the type of the event
+            if (myMode == EventHandlerArgumentMode.EventDefined && myTypes.Count == 0)
+                return true;
 
             var parameters = method.Parameters;
             if (parameters.Count == myTypes.Count)
@@ -92,6 +95,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Resolve
             }
 
             return false;
+        }
+
+        [CanBeNull]
+        private static IDeclaredType GetUnityEventType(IDeclaredType eventType)
+        {
+            foreach (var superType in eventType.GetAllSuperTypes())
+            {
+                if (superType.GetClrName().ShortName == "UnityEvent")
+                    return superType;
+            }
+
+            return null;
         }
     }
 }

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -34,25 +34,10 @@
 - And much more!
 </description>
 <releaseNotes>
-Added:
-
-- Update API information to 2019.3.0b11 (#1412)
-- Methods with the [SettingsProvider] attribute are now marked as implicitly used (#1225, #1362)
-- Support Find Usages on UnityEvent based event handlers (#1142)
-- Add context action for creating method from unresolved string literal in StartCoroutine and StopCoroutine (RIDER-27707, #1416)
-
-Changed:
-
-- Improve performance parsing YAML scenes (#1408)
+New in 2019.3.1
 
 Fixed:
-- Fix overridden Update methods not acting as performance critical context (RIDER-33934, #1408)
-- Fix Quick Fix incorrectly converting LinecastAll to CapsuleCastNonAlloc instead of LinecastNonAlloc (#1324, RIDER-33442, #1408)
-- Fix finding usages of methods used as event handler from prefab (#1331, #1408)
-- Fix moving .meta file during "Move to Folder" refactoring (#1370, #1389)
-- Fix orphan .meta file during "Safe Delete" refactoring (#856, #1389)
-- Fix correctly keeping .meta files up to date in Packages folder (#1231, #1389)
-- Fix correctly adding second "RequireComponent" attribute (RIDER-34390, #1416)
+- Fix usage count for custom event based event handlers in Unity 2018.4+ (#1448, #1449)
     
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -271,6 +271,10 @@
 <ul>
   <li>Entire plugin is no longer disabled if the CSS plugin is disabled (<a href="https://youtrack.jetbrains.com/issue/RIDER-36523">RIDER-36523</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1443">#1443</a>)</li>
 </ul>
+<em>Fixed:</em>
+<ul>
+  <li>Fix usage count for custom event based event handlers in Unity 2018.4+ (<a href="https://github.com/JetBrains/resharper-unity/issues/1448">#1448</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1449">#1449</a>)</li>
+</ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/193/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
 ]]>


### PR DESCRIPTION
Unity 2018.4 removed the `m_TypeName` serialised field, so we no longer know the type of custom `UnityEvent` based events. This PR makes the event handler resolve, but it can't confirm the method signature.

If we wanted to get the correct signature, we'd have to walk up the YAML, resolving types and types of fields until we could find the event type. There's a deeper explanation in the comments in `UnityEventTargetReferenceFactory.cs`.

Fixes #1448 
