### PR TITLE
Provide help message on failed PlayMode tests with old Unity

### DIFF
--- a/resharper/resharper-unity/src/Rider/Packages/PackageValidator.cs
+++ b/resharper/resharper-unity/src/Rider/Packages/PackageValidator.cs
@@ -93,7 +93,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Packages
             if (myUnityVersion.GetActualVersionForSolution() >= new Version("2019.2"))
                 return true;
 
-            message = $"PlayMode tests are supported for Unity 2019.2 and above. {HelpLink}";
+            message = $"Unity 2019.2 or later is required to run play-mode tests. {HelpLink}";
             return false;
         }
     }

--- a/resharper/resharper-unity/src/Rider/Packages/PackageValidator.cs
+++ b/resharper/resharper-unity/src/Rider/Packages/PackageValidator.cs
@@ -18,14 +18,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Packages
             mySolution = solution;
             myUnityVersion = unityVersion;
         }
-        
+
         public bool HasNonCompatiblePackagesCombination(bool isCoverage, out string message)
         {
             message = string.Empty;
-            
+
             if (myUnityVersion.GetActualVersionForSolution() < new Version("2019.2"))
                 return false;
-            
+
             var manifestJsonFile = mySolution.SolutionDirectory.Combine("Packages/manifest.json");
             if (manifestJsonFile.ExistsFile)
             {
@@ -36,20 +36,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Packages
                 var riderPackageId = "com.unity.ide.rider";
                 var testFrameworkMarketingName = "Test Framework";
                 var riderMarketingName = "Rider Editor";
-                
-                if (PackageIsMissing(ref message, packages, testFrameworkPackageId, testFrameworkMarketingName)) return true;
+
+                if (PackageIsMissing(ref message, packages, testFrameworkPackageId, testFrameworkMarketingName))
+                    return true;
                 if (PackageIsMissing(ref message, packages, riderPackageId, riderMarketingName)) return true;
 
                 var riderPackageVersion = packages[riderPackageId];
                 var testFrameworkVersion = packages[testFrameworkPackageId];
                 if (IsOldPackage(ref message, riderPackageVersion, riderMarketingName, "1.1.1")) return true;
                 if (IsOldPackage(ref message, testFrameworkVersion, testFrameworkMarketingName, "1.1.1")) return true;
-                
+
                 if (isCoverage && packages.ContainsKey(riderPackageId) && packages.ContainsKey(testFrameworkPackageId))
                 {
                     // https://youtrack.jetbrains.com/issue/RIDER-35880
-                    if (riderPackageVersion != null && riderPackageVersion < new Version("1.2.0") 
-                                                    && testFrameworkVersion!=null && testFrameworkVersion >= new Version("1.1.5"))
+                    if (riderPackageVersion != null && riderPackageVersion < new Version("1.2.0")
+                                                    && testFrameworkVersion != null &&
+                                                    testFrameworkVersion >= new Version("1.1.5"))
                     {
                         message = $"Update {riderMarketingName} package to v.1.2.0 or later in Unity Package Manager. {HelpLink}";
                         return true;
@@ -73,7 +75,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Packages
 
             return false;
         }
-        
+
         private static bool IsOldPackage(ref string message, Version packageVersion, string packageMarketingName, string targetVersion)
         {
             if (packageVersion != null && packageVersion < new Version(targetVersion))
@@ -82,6 +84,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Packages
                 return true;
             }
 
+            return false;
+        }
+
+        public bool CanRunPlayModeTests(out string message)
+        {
+            message = string.Empty;
+            if (myUnityVersion.GetActualVersionForSolution() >= new Version("2019.2"))
+                return true;
+
+            message = $"PlayMode tests are supported for Unity 2019.2 and above. {HelpLink}";
             return false;
         }
     }

--- a/resharper/resharper-unity/src/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
+++ b/resharper/resharper-unity/src/Rider/UnitTesting/RunViaUnityEditorStrategy.cs
@@ -77,7 +77,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
             ILogger logger,
             Lifetime lifetime,
             PackageValidator packageValidator
-            )
+        )
         {
             mySolution = solution;
             myUnitTestResultManager = unitTestResultManager;
@@ -295,6 +295,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
                                         
                                         if (myPackageValidator.HasNonCompatiblePackagesCombination(isCoverage, out var message))
                                             defaultMessage = $"{defaultMessage} {message}";
+
+                                        if (myEditorProtocol.UnityModel.Value.UnitTestLaunch.Value.TestMode == TestMode.Play)
+                                        {
+                                            if (!myPackageValidator.CanRunPlayModeTests(out var playMessage))
+                                                defaultMessage = $"{defaultMessage} {playMessage}";
+                                        }
+
                                         tcs.TrySetException(new Exception(defaultMessage));
                                     }
                                 });


### PR DESCRIPTION
fix for 
RIDER-36598 PlayMode tests for Unity 2019.1 are inconclusive and do not provide any help in the output