### PR TITLE
Fix null reference exception with file with no extension

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileExtensions.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/FileExtensions.kt
@@ -44,13 +44,8 @@ private fun getExtensions(): THashSet<String> {
     return extensions
 }
 
-fun isNonEditableUnityFile(file: VirtualFile): Boolean {
-    return isNonEditableUnityFileExtension(file.extension)
-}
-
-fun isNonEditableUnityFileExtension(extension: String?): Boolean {
-    return nonEditableExtensions.contains(extension)
-}
+fun isNonEditableUnityFile(file: VirtualFile) = isNonEditableUnityFileExtension(file.extension)
+fun isNonEditableUnityFileExtension(extension: String?) = extension != null && nonEditableExtensions.contains(extension)
 
 fun isGeneratedUnityFile(file: VirtualFile): Boolean {
     val fileTypeRegistry = FileTypeRegistry.getInstance()


### PR DESCRIPTION
When opening a file with no extension, e.g. `README`, an exception is thrown when checking to see if it's a known Unity file type. See [DEXP-497558](https://youtrack.jetbrains.com/issue/DEXP-497558). The exception is new to `net201` and doesn't reproduce in `net193`