### PR TITLE
Exclude conflicting type names from import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net193...net201)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/32?closed=1)
 
+### Added
+
+- Exclude `Boo` and `UnityScript` namespaces, as well as the `System.Diagnostics.Debug` type from import completion ([#574](https://github.com/JetBrains/resharper-unity/issues/574), [#1473](https://github.com/JetBrains/resharper-unity/pull/1473))
+
 
 
 ## 2019.3.1

--- a/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
+++ b/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
@@ -1,18 +1,14 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Application.DataContext;
 using JetBrains.Application.Diagnostics;
 using JetBrains.Application.UI.Actions;
 using JetBrains.Application.UI.ActionsRevised.Menu;
-using JetBrains.Build.Running;
 using JetBrains.Collections;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
-using JetBrains.ReSharper.Psi.Modules;
-using JetBrains.RiderTutorials.Utils;
 using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Feature.Internal
@@ -47,7 +43,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Internal
                     var shortName = typeElement.ShortName + (typeParametersOwner.TypeParameters.Count > 0
                                         ? $"`{typeParametersOwner.TypeParameters.Count}"
                                         : string.Empty);
-                    types.Add(shortName, ((ITypeElement) typeElement).GetFullClrName());
+                    types.Add(shortName, ((ITypeElement) typeElement).GetClrName().FullName);
                 }
             }
 

--- a/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
+++ b/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
@@ -43,12 +43,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Internal
                 // Non-nested, public or protected types. Essentially what would appear in completion
                 if (typeElement.GetContainingType() == null && IsVisible(typeElement))
                 {
-                    var fullname = ((ITypeElement) typeElement).GetFullClrName();
-                    if (fullname.Contains("List"))
-                    {
-                        Console.WriteLine();
-                    }
-
                     var typeParametersOwner = (ITypeParametersOwner) typeElement;
                     var shortName = typeElement.ShortName + (typeParametersOwner.TypeParameters.Count > 0
                                         ? $"`{typeParametersOwner.TypeParameters.Count}"

--- a/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
+++ b/resharper/resharper-unity/src/Feature/Internal/DumpDuplicateTypeNamesAction.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Application.DataContext;
+using JetBrains.Application.Diagnostics;
+using JetBrains.Application.UI.Actions;
+using JetBrains.Application.UI.ActionsRevised.Menu;
+using JetBrains.Build.Running;
+using JetBrains.Collections;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.DataContext;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.RiderTutorials.Utils;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Internal
+{
+    // Simple internal action to dump any clashing APIs in the given project's references. Useful for finding extra
+    // candidates for values to add to AutoImportSolutionSettingsProvider
+    [Action("Unity_Internal_DumpDuplicateTypeNames", "Dump Duplicate Type Names")]
+    public class DumpDuplicateTypeNamesAction : IExecutableAction
+    {
+        public bool Update(IDataContext context, ActionPresentation presentation, DelegateUpdate nextUpdate)
+        {
+            // TODO: Make sure it's only visible/available in internal mode?
+            return true;
+        }
+
+        public void Execute(IDataContext context, DelegateExecute nextExecute)
+        {
+            var solution = context.GetData(ProjectModelDataConstants.SOLUTION);
+            if (solution == null)
+                return;
+
+            var symbolCache = solution.GetComponent<ISymbolCache>();
+
+            var types = new OneToSetMap<string, string>();
+            var symbolScope = symbolCache.GetSymbolScope(LibrarySymbolScope.FULL, true);
+            foreach (var typeElement in symbolScope.GetAllTypeElementsGroupedByName().OfType<ITypeMember>())
+            {
+                // Non-nested, public or protected types. Essentially what would appear in completion
+                if (typeElement.GetContainingType() == null && IsVisible(typeElement))
+                {
+                    var fullname = ((ITypeElement) typeElement).GetFullClrName();
+                    if (fullname.Contains("List"))
+                    {
+                        Console.WriteLine();
+                    }
+
+                    var typeParametersOwner = (ITypeParametersOwner) typeElement;
+                    var shortName = typeElement.ShortName + (typeParametersOwner.TypeParameters.Count > 0
+                                        ? $"`{typeParametersOwner.TypeParameters.Count}"
+                                        : string.Empty);
+                    types.Add(shortName, ((ITypeElement) typeElement).GetFullClrName());
+                }
+            }
+
+            Dumper.DumpToNotepad(writer =>
+            {
+                var toDump = (from pair in types
+                    where pair.Value.Count > 1 && pair.Value.Any(x => !x.StartsWith("System"))
+                    let skipped = IsSkipped(pair)
+                    select new {pair, skipped}).OrderBy(x => x.pair.Key).ToList();
+
+                writer.WriteLine($"Found {toDump.Count} items. Skipping {toDump.Count(x => x.skipped)}");
+                writer.WriteLine();
+
+                foreach (var (key, value) in toDump.Where(x => !x.skipped).Select(x => x.pair))
+                {
+                    writer.WriteLine("Short name: " + key);
+                    foreach (var fullName in value) writer.WriteLine($"  {fullName}");
+                    writer.WriteLine();
+                }
+
+                writer.WriteLine();
+                writer.WriteLine();
+                writer.WriteLine();
+                writer.WriteLine("Skipping:");
+                writer.WriteLine();
+
+                foreach (var (key, value) in toDump.Where(x => x.skipped).Select(x => x.pair))
+                {
+                    writer.WriteLine("Short name: " + key);
+                    foreach (var fullName in value) writer.WriteLine($"  {fullName}");
+                    writer.WriteLine();
+                }
+            });
+        }
+
+        private bool IsSkipped(KeyValuePair<string, ISet<string>> pair)
+        {
+            return pair.Value.Count(x => !IsSkipped(x)) < 2;
+        }
+
+        private bool IsSkipped(string fullName)
+        {
+            // Note that this replicates the settings in AutoImportSolutionSettingsProvider, and is just a means of
+            // making it easier to check the list of matching items
+            return fullName.StartsWith("Boo.Lang.") || fullName.StartsWith("UnityScript.") ||
+                   fullName.StartsWith("System.Diagnostics.Debug");
+        }
+
+        private static bool IsVisible(ITypeMember typeElement)
+        {
+            return typeElement.AccessibilityDomain.DomainType == AccessibilityDomain.AccessibilityDomainType.PUBLIC
+                   || typeElement.AccessibilityDomain.DomainType ==
+                   AccessibilityDomain.AccessibilityDomainType.PROTECTED;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Settings/AutoImportSolutionSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/AutoImportSolutionSettingsProvider.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using JetBrains.Application.Settings;
+using JetBrains.Application.Settings.Implementation;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.ImportType.BlackList;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Settings
+{
+    [SolutionComponent]
+    public class AutoImportSolutionSettingsProvider : IUnitySolutionSettingsProvider
+    {
+        private readonly ISettingsSchema mySettingsSchema;
+        private readonly ILogger myLogger;
+
+        public AutoImportSolutionSettingsProvider(ISettingsSchema settingsSchema, ILogger logger)
+        {
+            mySettingsSchema = settingsSchema;
+            myLogger = logger;
+        }
+
+        public void InitialiseSolutionSettings(ISettingsStorageMountPoint mountPoint)
+        {
+            // Remove items from auto completion. Anything in these namespaces, or matching the method name will not
+            // show in the auto import completion lists, and will not get the auto-import alt+enter tooltip popup.
+            // If you want to use a type that matches, you need to add the using statement manually.
+            // * Ignore Bool.Lang.* and UnityScript.* as they were deprecated in late 2017, and most of the code there
+            //   is not intended to be consumed by users, but the assemblies are still referenced. This prevents e.g.:
+            //   Boo.Lang.List`1 from appearing in the completion list above System.Collections.Generic.List`1
+            // * Also exclude System.Diagnostics.Debug() to prevent similar clashes with UnityEngine.Debug()
+
+            // See the internal DumpDuplicateTypeNamesAction to generate a list of types that can clash. There are about
+            // 80 types on this list. It's not worth ignoring all of them. But some candidates:
+            // * System.Numerics.Vector{2,3,4} + Quaternion + Plane
+            // * System.Random + UnityEngine.Random
+            AddAutoImportExclusions(mountPoint, "Boo.Lang.*", "UnityScript.*", "System.Diagnostics.Debug");
+        }
+
+        private void AddAutoImportExclusions(ISettingsStorageMountPoint mountPoint, params string[] settings)
+        {
+            var entry = mySettingsSchema.GetIndexedEntry((AutoImport2Settings s) => s.BlackLists);
+            var indexedKey = new Dictionary<SettingsKey, object>
+            {
+                {mySettingsSchema.GetKey<AutoImport2Settings>(), CSharpLanguage.Name}
+            };
+            foreach (var setting in settings)
+                ScalarSettingsStoreAccess.SetIndexedValue(mountPoint, entry, setting, indexedKey, true, null, myLogger);
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Settings/LangVersionProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/LangVersionProjectSettingsProvider.cs
@@ -16,7 +16,7 @@ using JetBrains.Util;
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
     [SolutionComponent]
-    public class LangVersionSetting : IUnityProjectSettingsProvider
+    public class LangVersionProjectSettingsProvider : IUnityProjectSettingsProvider
     {
         private readonly ISettingsSchema mySettingsSchema;
         private readonly ILogger myLogger;
@@ -24,9 +24,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
         private readonly ILanguageLevelProjectProperty<CSharpLanguageLevel, CSharpLanguageVersion> myLanguageLevelProjectProperty;
         private static readonly Version ourVersion46 = new Version(4, 6);
 
-        public LangVersionSetting(ISettingsSchema settingsSchema, ILogger logger,
-                                  UnityProjectFileCacheProvider unityProjectFileCache,
-                                  ILanguageLevelProjectProperty<CSharpLanguageLevel, CSharpLanguageVersion> languageLevelProjectProperty)
+        public LangVersionProjectSettingsProvider(ISettingsSchema settingsSchema, ILogger logger,
+                                                  UnityProjectFileCacheProvider unityProjectFileCache,
+                                                  ILanguageLevelProjectProperty<CSharpLanguageLevel, CSharpLanguageVersion> languageLevelProjectProperty)
         {
             mySettingsSchema = settingsSchema;
             myLogger = logger;
@@ -164,7 +164,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
             }
             return true;
         }
-        
+
         private bool IsLangVersionLatest(IProject project)
         {
             foreach (var configuration in project.ProjectProperties.ActiveConfigurations.Configurations)

--- a/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
@@ -12,12 +12,12 @@ using JetBrains.Util;
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
     [SolutionComponent]
-    public class NamespaceProviderSettings : IUnityProjectSettingsProvider
+    public class NamespaceProviderProjectSettingsProvider : IUnityProjectSettingsProvider
     {
         private readonly ISettingsSchema mySettingsSchema;
         private readonly ILogger myLogger;
 
-        public NamespaceProviderSettings(ISettingsSchema settingsSchema, ILogger logger)
+        public NamespaceProviderProjectSettingsProvider(ISettingsSchema settingsSchema, ILogger logger)
         {
             mySettingsSchema = settingsSchema;
             myLogger = logger;

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -36,6 +36,10 @@
 <releaseNotes>
 New in 2020.1
 
+Added:
+- Exclude Boo and UnityScript namespaces, as well as the System.Diagnostics.Debug type from import completion (#574, #1473)
+
+
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>
     <projectUrl>https://github.com/JetBrains/resharper-unity</projectUrl>

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/internal/DumpDuplicateTypeNamesAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/internal/DumpDuplicateTypeNamesAction.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.rider.plugins.unity.actions.internal
+
+import com.jetbrains.rider.actions.base.RiderAnAction
+
+class DumpDuplicateTypeNamesAction: RiderAnAction("Unity_Internal_DumpDuplicateTypeNames")

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -207,6 +207,15 @@
       <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="FindUsages"/>
       <add-to-group group-id="EditorPopupMenu1.FindRefactor" anchor="after" relative-to-action="FindUsages"/>
     </action>
+
+    <group id="RiderInternal.Unity" text="Unity Actions" popup="true" internal="true">
+      <add-to-group group-id="RiderInternal" anchor="last" />
+
+      <action id="Unity_Internal_DumpDuplicateTypeNames"
+              class="com.jetbrains.rider.plugins.unity.actions.internal.DumpDuplicateTypeNamesAction"
+              text="Dump Duplicate Type Names"
+              internal="true" />
+    </group>
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -276,12 +276,7 @@
 <p>
 <em>Added:</em>
 <ul>
-</ul>
-<em>Changed:</em>
-<ul>
-</ul>
-<em>Fixed:</em>
-<ul>
+  <li>Exclude <tt>Boo</tt> and <tt>UnityScript</tt> namespaces, as well as the <tt>System.Diagnostics.Debug</tt> type from import completion (<a href="https://github.com/JetBrains/resharper-unity/issues/574">#574</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1473">#1473</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net201/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>


### PR DESCRIPTION
Adds `Boo.Lang.*` and `UnityScript.*` as namespaces to be excluded from auto-import. Also adds `System.Diagnostics.Debug` as a method to be ignored. This means that these namespaces and types are not shown in import completion popup lists, the auto-import tooltip popup, and any other quick fix. The only way to use these types is to manually add the using statement.

This addresses the issue that trying to complete `List<T>` can match `Boo.Lang.List<T>`.

This PR also adds an internal action to Rider that will dump all duplicate type names in a given project. Useful to show candidates that could use further rules.

Fixes #574 