### PR TITLE
Avoid creating meta files outside Assets and Packages

### DIFF
--- a/resharper/resharper-unity/src/ProjectExtensions.cs
+++ b/resharper/resharper-unity/src/ProjectExtensions.cs
@@ -8,6 +8,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
     public static class ProjectExtensions
     {
         public const string AssetsFolder = "Assets";
+        public const string PackagesFolder = "Packages";
         public const string ProjectSettingsFolder = "ProjectSettings";
 
         public static bool HasUnityReference([NotNull] this ISolution solution)

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -149,7 +149,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                     return true;
                 if (string.Compare(rootFolder.Name, ProjectExtensions.PackagesFolder, StringComparison.OrdinalIgnoreCase) == 0)
                     return true;
-                return rootFolder.Location.Combine($"{rootFolder.Name}.asmdef").ExistsFile; // for file: based packages
+                var project = change.ProjectItem.GetProject();
+                return project != null && project.HasSubItems(rootFolder.Name);
             }
 
             private static IProjectFolder GetRootFolder(IProjectItem item)

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -147,7 +147,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                     return false;
                 if (string.Compare(rootFolder.Name, ProjectExtensions.AssetsFolder, StringComparison.OrdinalIgnoreCase) == 0)
                     return true;
-                return string.Compare(rootFolder.Name, ProjectExtensions.PackagesFolder, StringComparison.OrdinalIgnoreCase) == 0;
+                if (string.Compare(rootFolder.Name, ProjectExtensions.PackagesFolder, StringComparison.OrdinalIgnoreCase) == 0)
+                    return true;
+                return rootFolder.Location.Combine($"{rootFolder.Name}.asmdef").ExistsFile; // for file: based packages
             }
 
             private static IProjectFolder GetRootFolder(IProjectItem item)

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -137,7 +137,24 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool ShouldHandleChange(ProjectItemChange change)
             {
                 // String comparisons, treat as expensive if we're doing this very frequently
-                return !IsItemMetaFile(change);
+                return IsAssetOrPackage(change) && !IsItemMetaFile(change);
+            }
+
+            private static bool IsAssetOrPackage(ProjectItemChange change)
+            {
+                var rootFolder = GetRootFolder(change.OldParentFolder);
+                if (rootFolder == null)
+                    return false;
+                if (string.Compare(rootFolder.Name, ProjectExtensions.AssetsFolder, StringComparison.OrdinalIgnoreCase) == 0)
+                    return true;
+                return string.Compare(rootFolder.Name, ProjectExtensions.PackagesFolder, StringComparison.OrdinalIgnoreCase) == 0;
+            }
+
+            private static IProjectFolder GetRootFolder(IProjectItem item)
+            {
+                while (item?.ParentFolder != null && item.ParentFolder.Kind != ProjectItemKind.PROJECT)
+                    item = item.ParentFolder;
+                return item as IProjectFolder;
             }
 
             private static bool IsItemMetaFile(ProjectItemChange change)


### PR DESCRIPTION
fix https://github.com/JetBrains/resharper-unity/issues/1481

Repro:
1. Open Unity project in Rider
2. In SolutionExplorer show all files
3. Include any file outside Assets/Packages to project
Meta file was generated previously, not it would not.