### PR TITLE
Fix building searchable options (net193)

### DIFF
--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -16,8 +16,6 @@ ext.repoRoot = project.file("..")
 ext.isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
 ext.bundledRiderSdkRoot = new File(projectDir, "dependencies")  // SDK from TC configuration/artifacts
 
-buildSearchableOptions.enabled = BuildConfiguration == "Release"
-
 repositories {
     maven { url "https://cache-redirector.jetbrains.com/intellij-repository/snapshots" }
     maven { url "https://cache-redirector.jetbrains.com/maven-central" }
@@ -39,14 +37,15 @@ wrapper {
 
 version "${productVersion}.0.$BuildCounter"
 
-logger.lifecycle("version=$version")
-logger.lifecycle("Configuration=$BuildConfiguration")
-
-
 ext.buildServer = BuildServerKt.initBuildServer(gradle)
 if (buildServer.automatedBuild) {
     BuildConfiguration = "Release"
 }
+
+buildSearchableOptions.enabled = BuildConfiguration == "Release"
+
+logger.lifecycle("version=$version")
+logger.lifecycle("BuildConfiguration=$BuildConfiguration")
 
 
 apply from: 'model.gradle'


### PR DESCRIPTION
Backport #1520 to `net193` in case there's another 2019.3 maintenance release