### PR TITLE
fix RIDER-38427 - opening script resizes Rider

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/UnityHost.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/UnityHost.kt
@@ -45,7 +45,8 @@ class UnityHost(project: Project, runManager: RunManager) : LifetimedProjectComp
             ProjectUtil.focusProjectWindow(project, true)
             val frame = WindowManager.getInstance().getFrame(project)
             if (frame != null) {
-                frame.setExtendedState(BitUtil.set(frame.extendedState, Frame.ICONIFIED, false))
+                if (BitUtil.isSet(frame.extendedState, Frame.ICONIFIED))
+                    frame.extendedState = BitUtil.set(frame.extendedState, Frame.ICONIFIED, false)
             }
         }
 


### PR DESCRIPTION
Was happening only with Windows Multitasking "Snap windows" setting is enabled