### PR TITLE
Marks providers fix

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/CallGraph/ExpensiveCodeCallGraphAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/CallGraph/ExpensiveCodeCallGraphAnalyzer.cs
@@ -25,6 +25,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
         
         public override LocalList<IDeclaredElement> GetMarkedFunctionsFrom(ITreeNode currentNode, IDeclaredElement containingFunction)
         {
+            if(containingFunction == null)
+                return new LocalList<IDeclaredElement>();
+            
             var result = new LocalList<IDeclaredElement>();
             switch (currentNode)
             {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/CallGraph/PerformanceCriticalCodeCallGraphMarksProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/CallGraph/PerformanceCriticalCodeCallGraphMarksProvider.cs
@@ -31,7 +31,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
         public override LocalList<IDeclaredElement> GetMarkedFunctionsFrom(ITreeNode currentNode, IDeclaredElement containingFunction)
         {
             var result = new LocalList<IDeclaredElement>();
-            if (PerformanceCriticalCodeStageUtil.IsPerformanceCriticalRootMethod(myUnityApi, currentNode))
+            if (containingFunction != null && PerformanceCriticalCodeStageUtil.IsPerformanceCriticalRootMethod(myUnityApi, currentNode))
             {
                 result.Add(containingFunction);
             }


### PR DESCRIPTION
Marks provider must work at any tree node regardless if containing function null or not because some marks can be added outside of any function. 