### PR TITLE
Update OnOpenAssetHandler.cs

### DIFF
--- a/unity/EditorPlugin/OnOpenAssetHandler.cs
+++ b/unity/EditorPlugin/OnOpenAssetHandler.cs
@@ -120,7 +120,7 @@ namespace JetBrains.Rider.Unity.Editor
       if (myPluginSettings.OperatingSystemFamilyRider == OperatingSystemFamilyRider.MacOSX)
       {
         proc.StartInfo.FileName = "open";
-        proc.StartInfo.Arguments = string.Format("-n {0}{1}{0} --args {2}", "\"", defaultApp, args);
+        proc.StartInfo.Arguments = string.Format("-n -j {0}{1}{0} --args {2}", "\"", defaultApp, args);
         myLogger.Verbose("{0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
       }
       else


### PR DESCRIPTION
This solves the issue that when both Unity3D and Rider are in fullscreen mode (different workspaces) in MacOS, open script will jump back to desktop and then to Rider.