### PR TITLE
Stop trying to use MSBuild 15 without .NET Core SDK

### DIFF
--- a/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/tasks/MSBuildTask.kt
+++ b/rider/buildSrc/src/main/kotlin/com/jetbrains/rider/plugins/gradle/tasks/MSBuildTask.kt
@@ -63,7 +63,7 @@ open class MSBuildTask: DefaultTask() {
         val stdout = ByteArrayOutputStream()
         project.exec {
             executable = File(project.projectDir, "../tools/vswhere.exe").absolutePath
-            args = listOf("-all", "-version", "[15.0,)", "-products", "*", "-requires", "Microsoft.Component.MSBuild", "-property", "installationPath")
+            args = listOf("-all", "-version", "[15.0,)", "-products", "*", "-requires", "Microsoft.Component.MSBuild", "-requires", "Microsoft.NetCore.Component.SDK", "-property", "installationPath")
             standardOutput = stdout
         }
         val buildToolsDirs = stdout.toString().trim().split("\r\n", "\n")


### PR DESCRIPTION
By default, our build system will try to use any instance of MSBuild 15 if it's found.

I have VS2017 installed for native development, but had no .NET development tools installed. So it tried to use older MSBuild that has no support of SDK-style projects, and failed to build.

We could fix that by adding explicit requirement for .NET Core SDK support.