### PR TITLE
Fix resolving git packages for 2019.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Fix duplicate "Generate Unity event functions" context action when gutter icons are visible ([#1537](https://github.com/JetBrains/resharper-unity/issues/1537), [#1566](https://github.com/JetBrains/resharper-unity/pull/1566))
 - Rider: Fix Unity tests working with `.slnf` files ([#1571](https://github.com/JetBrains/resharper-unity/issues/1571), [#1577](https://github.com/JetBrains/resharper-unity/pull/1577))
 - Rider: Fix tooltip display for packages in Unity Explorer ([#1506](https://github.com/JetBrains/resharper-unity/pull/1506))
+- Rider: Fix resolving git based packages in Unity 2019.3+ ([#1616](https://github.com/JetBrains/resharper-unity/pull/1616))
 - Rider: Fix settings search not finding Unity pages (from 2019.3.3) ([#1516](https://github.com/JetBrains/resharper-unity/issues/1516), [#1520](https://github.com/JetBrains/resharper-unity/pull/1520))
 - Rider: Fix discovery and running of all tests in a project ([#1509](https://github.com/JetBrains/resharper-unity/issues/1509), [#1500](https://github.com/JetBrains/resharper-unity/pull/1500))
 - Rider: Fix finding location of Unity based on custom Hub install location ([RIDER-42118](https://youtrack.jetbrains.com/issue/RIDER-42118), [#1604](https://github.com/JetBrains/resharper-unity/pull/1604))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Show serialised field values for scriptable objects ([#1567](https://github.com/JetBrains/resharper-unity/pull/1567))
 - Show usages of scriptable objects in assets ([#1567](https://github.com/JetBrains/resharper-unity/pull/1567))
 - Rider: Open corresponding `.asmdef` in Unity Inspector from `.csproj` editor notification ([#1574](https://github.com/JetBrains/resharper-unity/pull/1574))
+- Rider: Treat `.inputactions` as a JSON file ([RIDER-38538](https://youtrack.jetbrains.com/issue/RIDER-38538))
 
 ### Changed
 
@@ -50,12 +51,17 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 - Avoid creating meta files outside of Asset or Packages folders (from 2019.3.2) ([#1481](https://github.com/JetBrains/resharper-unity/issues/1481), [#1491](https://github.com/JetBrains/resharper-unity/pull/1491), [#1489](https://github.com/JetBrains/resharper-unity/pull/1489))
 - Fix overwriting `IEnumerator` when auto-completing an event function that can be a coroutine ([#1258](https://github.com/JetBrains/resharper-unity/issues/1258), [#1566](https://github.com/JetBrains/resharper-unity/pull/1566))
 - Fix duplicate "Generate Unity event functions" context action when gutter icons are visible ([#1537](https://github.com/JetBrains/resharper-unity/issues/1537), [#1566](https://github.com/JetBrains/resharper-unity/pull/1566))
+- Fix completion of tag value adding extra closing quote ([RIDER-33067](https://youtrack.jetbrains.com/issue/RIDER-33067))
+- Fix exception with building shortcut cache ([RIDER-41206](https://youtrack.jetbrains.com/issue/RIDER-41206))
 - Rider: Fix Unity tests working with `.slnf` files ([#1571](https://github.com/JetBrains/resharper-unity/issues/1571), [#1577](https://github.com/JetBrains/resharper-unity/pull/1577))
 - Rider: Fix tooltip display for packages in Unity Explorer ([#1506](https://github.com/JetBrains/resharper-unity/pull/1506))
 - Rider: Fix resolving git based packages in Unity 2019.3+ ([#1616](https://github.com/JetBrains/resharper-unity/pull/1616))
 - Rider: Fix settings search not finding Unity pages (from 2019.3.3) ([#1516](https://github.com/JetBrains/resharper-unity/issues/1516), [#1520](https://github.com/JetBrains/resharper-unity/pull/1520))
 - Rider: Fix discovery and running of all tests in a project ([#1509](https://github.com/JetBrains/resharper-unity/issues/1509), [#1500](https://github.com/JetBrains/resharper-unity/pull/1500))
 - Rider: Fix finding location of Unity based on custom Hub install location ([RIDER-42118](https://youtrack.jetbrains.com/issue/RIDER-42118), [#1604](https://github.com/JetBrains/resharper-unity/pull/1604))
+- Rider: Use correct process ID for profiling and coverage ([DTRC-26621](https://youtrack.jetbrains.com/issue/DTRC-26621), [#1612](https://github.com/JetBrains/resharper-unity/pull/1612))
+- Rider: Mark editor as disconnected if response is not timely ([#1610](https://github.com/JetBrains/resharper-unity/pull/1610))
+- Unity Editor: Fix jumping to default desktop when opening files on Mac ([#1611](https://github.com/JetBrains/resharper-unity/pull/1611))
 
 
 

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -64,6 +64,8 @@ Fixed:
 - Avoid creating meta files outside of Asset or Packages folders (from 2019.3.2) (#1481, #1491, #1489)
 - Fix overwriting IEnumerator when auto-completing an event function that can be a coroutine (#1258, #1566)
 - Fix duplicate "Generate Unity event functions" context action when gutter icons are visible (#1537, #1566)
+- Fix completion of tag value adding extra closing quote (RIDER-33067)
+- Fix exception with building shortcut cache (RIDER-41206)
 
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
@@ -30,6 +30,7 @@ import com.jetbrains.rider.plugins.unity.util.UnityInstallationFinder
 import com.jetbrains.rider.plugins.unity.util.findFile
 import com.jetbrains.rider.projectDir
 import com.jetbrains.rider.projectView.solution
+import java.lang.Integer.min
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -309,7 +310,9 @@ class PackageManager(private val project: Project) {
 
         // If we have lockDetails, we know this is a git based package, so always return something
         return try {
+            // 2019.3 changed the format of the cached folder to only use the first 10 characters of the hash
             val packageFolder = project.findFile("Library/PackageCache/$name@${lockDetails.hash}")
+                ?: project.findFile("Library/PackageCache/$name@${lockDetails.hash.substring(0, min(lockDetails.hash.length, 10))}")
             getPackageDataFromFolder(name, packageFolder, PackageSource.Git, GitDetails(version, lockDetails.revision, lockDetails.hash))
         }
         catch (throwable: Throwable) {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -327,6 +327,7 @@
   <li>Fix duplicate "Generate Unity event functions" context action when gutter icons are visible (<a href="https://github.com/JetBrains/resharper-unity/issues/1537">#1537</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
   <li>Rider: Fix Unity tests working with <tt>.slnf</tt> files (<a href="https://github.com/JetBrains/resharper-unity/issues/1571">#1571</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1577">#1577</a>)</li>
   <li>Rider: Fix tooltip display for packages in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1506">#1506</a>)</li>
+  <li>Rider: Fix resolving git based packages in Unity 2019.3+ (<a href="https://github.com/JetBrains/resharper-unity/pull/1616">#1616</a>)</li>
   <li>Rider: Fix settings search not finding Unity pages (<a href="https://github.com/JetBrains/resharper-unity/issues/1516">#1516</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1520">#1520</a>)</li>
   <li>Rider: Fix discovery and running of all tests in a project (<a href="https://github.com/JetBrains/resharper-unity/issues/1509">#1509</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1500">#1500</a>)</li>
   <li>Rider: Fix finding location of Unity based on custom Hub install location (<a href="https://youtrack.jetbrains.com/issue/RIDER-42118">RIDER-42118</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1604">#1604</a>)</li>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -296,6 +296,7 @@
   <li>Show serialised field values for scriptable objects (<a href="https://github.com/JetBrains/resharper-unity/pull/1567">#1567</a>)</li>
   <li>Show usages of scriptable objects in assets (<a href="https://github.com/JetBrains/resharper-unity/pull/1567">#1567</a>)</li>
   <li>Rider: Open corresponding <tt>.asmdef</tt> in Unity Inspector from <tt>.csproj</tt> editor notification (<a href="https://github.com/JetBrains/resharper-unity/pull/1574">#1574</a>)</li>
+  <li>Rider: Treat <tt>.inputactions</tt> as a JSON file (<a href="https://youtrack.jetbrains.com/issue/RIDER-38538">RIDER-38538</a>)</li>
 </ul>
 <em>Changed:</em>
 <ul>
@@ -325,12 +326,17 @@
   <li>Fix incorrect redundant <tt>SerializeField</tt> attribute warning for property backing field (<a href="https://github.com/JetBrains/resharper-unity/issues/1016">#1016</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1464">#1464</a>)</li>
   <li>Fix overwriting <tt>IEnumerator</tt> when auto-completing an event function that can be a coroutine (<a href="https://github.com/JetBrains/resharper-unity/issues/1258">#1258</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
   <li>Fix duplicate "Generate Unity event functions" context action when gutter icons are visible (<a href="https://github.com/JetBrains/resharper-unity/issues/1537">#1537</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
+  <li>Fix completion of tag value adding extra closing quote (<a href="https://youtrack.jetbrains.com/issue/RIDER-33067">RIDER-33067</a>)</li>
+  <li>Fix exception with building shortcut cache (<a href="https://youtrack.jetbrains.com/issue/RIDER-41206">RIDER-41206</a>)</li>
   <li>Rider: Fix Unity tests working with <tt>.slnf</tt> files (<a href="https://github.com/JetBrains/resharper-unity/issues/1571">#1571</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1577">#1577</a>)</li>
   <li>Rider: Fix tooltip display for packages in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1506">#1506</a>)</li>
   <li>Rider: Fix resolving git based packages in Unity 2019.3+ (<a href="https://github.com/JetBrains/resharper-unity/pull/1616">#1616</a>)</li>
   <li>Rider: Fix settings search not finding Unity pages (<a href="https://github.com/JetBrains/resharper-unity/issues/1516">#1516</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1520">#1520</a>)</li>
   <li>Rider: Fix discovery and running of all tests in a project (<a href="https://github.com/JetBrains/resharper-unity/issues/1509">#1509</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1500">#1500</a>)</li>
   <li>Rider: Fix finding location of Unity based on custom Hub install location (<a href="https://youtrack.jetbrains.com/issue/RIDER-42118">RIDER-42118</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1604">#1604</a>)</li>
+  <li>Rider: Use correct process ID for profiling and coverage (<a href="https://youtrack.jetbrains.com/issue/DTRC-26621">DTRC-26621</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1612">#1612</a>)</li>
+  <li>Rider: Mark editor as disconnected if response is not timely (<a href="https://github.com/JetBrains/resharper-unity/pull/1610">#1610</a>)</li>
+  <li>Unity Editor: Fix jumping to default desktop when opening files on Mac (<a href="https://github.com/JetBrains/resharper-unity/pull/1611">#1611</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net201/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>


### PR DESCRIPTION
Git based packages are not resolving properly in Unity 2019.3+. The format of the name of the cached package folder has changed - in Unity 2019.2, it's `{name}@{hash}`, while in 2019.3+, it only uses the first 10 characters of the hash.