### PR TITLE
Avoid calling Refresh on every save in the editor

### DIFF
--- a/resharper/resharper-unity/src/Rider/UnityRefreshTracker.cs
+++ b/resharper/resharper-unity/src/Rider/UnityRefreshTracker.cs
@@ -75,8 +75,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             if (!myBoundSettingsStore.GetValue((UnitySettings s) => s.AllowAutomaticRefreshInUnity) &&
                 refreshType == RefreshType.Normal)
                 return Task.CompletedTask;
-            
-            
 
             if (myRunningRefreshTask != null && !myRunningRefreshTask.IsCompleted)
             {
@@ -198,13 +196,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             unitySolutionTracker.IsUnityProject.AdviseOnce(lifetime, args =>
             {
                 if (!args) return;
-
-                var protocolSolution = solution.GetProtocolSolution();
-                protocolSolution.Editors.AfterDocumentInEditorSaved.Advise(lifetime, _ =>
-                {
-                    logger.Verbose("protocolSolution.Editors.AfterDocumentInEditorSaved");
-                    myGroupingEvent.FireIncoming();
-                });
                 
                 fileSystemTracker.RegisterPrioritySink(lifetime, FileSystemChange, HandlingPriority.Other);
             });


### PR DESCRIPTION
Saves in the editor might be very frequent.
And each refresh may break completion https://youtrack.jetbrains.com/issue/RIDER-37420

From user logs:
![image](https://user-images.githubusercontent.com/1482681/79852121-8a94eb00-83c6-11ea-852a-9f67f3eb199a.png)
