### PR TITLE
Minor fixes for the Unity Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net201-rtm-2020.1.0...net201)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/37?closed=1)
 
+### Changed
+
+- Rider: Show serializable Code Vision for more fields ([#1624](https://github.com/JetBrains/resharper-unity/pull/1624))
+- Rider: Improve presentation for asset Find Usages results ([#1624](https://github.com/JetBrains/resharper-unity/pull/1624))
+- Unity Editor: Reduce frequency of refreshing Unity on save to explicit calls to Save All ([RIDER-37420](https://youtrack.jetbrains.com/issue/RIDER-37420), [#1629](https://github.com/JetBrains/resharper-unity/pull/1629))
+
 ### Fixed
 
+- Rider: Fix solution hang on "constructing components" due to excessive `FileSystemWatcher` initialisation ([RIDER-41812](https://youtrack.jetbrains.com/issue/RIDER-41812), [#1631](https://github.com/JetBrains/resharper-unity/pull/1631))
 - Rider: Fix exception finding file icon causing explorer view to be blank ([RIDER-43038](https://youtrack.jetbrains.com/issue/RIDER-43038), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
 - Rider: Fix handling of file system folders in `Packages` with the same name as a package ([#1626](https://github.com/JetBrains/resharper-unity/issues/1626), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
 - Rider: Fix size of tooltip for packages with many projects ([#1628](https://github.com/JetBrains/resharper-unity/issues/1628), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+- Unity Editor: Fix list of folders to search for .NET Framework references ([RIDER-42873](https://youtrack.jetbrains.com/issue/RIDER-42873), [#1630](https://github.com/JetBrains/resharper-unity/pull/1630))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0). 
 
 This plugin has functionality that is common to both ReSharper and Rider. It also contains a plugin for the Unity editor that is used to communicate with Rider. Changes marked with a "Rider:" prefix are specific to Rider, while changes for the Unity editor plugin are marked with a "Unity editor:" prefix. No prefix means that the change is common to both Rider and ReSharper.
 
+## 2020.1.1
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net201-rtm-2020.1.0...net201)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/37?closed=1)
+
+### Fixed
+
+- Rider: Fix exception finding file icon causing explorer view to be blank ([RIDER-43038](https://youtrack.jetbrains.com/issue/RIDER-43038), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+- Rider: Fix handling of file system folders in `Packages` with the same name as a package ([#1626](https://github.com/JetBrains/resharper-unity/issues/1626), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+- Rider: Fix size of tooltip for packages with many projects ([#1628](https://github.com/JetBrains/resharper-unity/issues/1628), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+
+
+
 ## 2020.1
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net193...net201)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net193...net201-rtm-2020.1.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/32?closed=1)
 
 ### Added

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/AssetsRoot.kt
@@ -15,7 +15,7 @@ import com.jetbrains.rider.projectView.views.ISolutionModelNodeOwner
 import com.jetbrains.rider.projectView.views.addAdditionalText
 
 class AssetsRoot(project: Project, virtualFile: VirtualFile)
-    : UnityExplorerNode(project, virtualFile, listOf(), true) {
+    : UnityExplorerNode(project, virtualFile, listOf(), AncestorNodeType.Assets) {
 
     private val referenceRoot = ReferenceRoot(project)
     private val solutionNode = ProjectModelViewHost.getInstance(project).solutionNode
@@ -125,7 +125,7 @@ class ReferenceRoot(project: Project) : AbstractTreeNode<Any>(project, key) {
     }
 }
 
-class ReferenceItem(project: Project, private val referenceName: String, val keys: ArrayList<ProjectModelNodeKey>)
+class ReferenceItem(project: Project, private val referenceName: String, private val keys: ArrayList<ProjectModelNodeKey>)
     : AbstractTreeNode<String>(project, referenceName), ISolutionModelNodeOwner, IProjectModeNodesOwner {
 
     override fun getChildren(): MutableCollection<out AbstractTreeNode<Any>> = arrayListOf()

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -47,7 +47,7 @@ import icons.UnityIcons
 // b) Right click on a referenced package to convert to embedded - simply copy into the project's Packages folder
 
 class PackagesRoot(project: Project, private val packageManager: PackageManager)
-    : UnityExplorerNode(project, packageManager.packagesFolder, listOf(), false) {
+    : UnityExplorerNode(project, packageManager.packagesFolder, listOf(), AncestorNodeType.FileSystem) {
 
     override fun update(presentation: PresentationData) {
         if (!virtualFile.isValid) return
@@ -96,7 +96,7 @@ class PackagesRoot(project: Project, private val packageManager: PackageManager)
 }
 
 class PackageNode(project: Project, private val packageManager: PackageManager, packageFolder: VirtualFile, private val packageData: PackageData)
-    : UnityExplorerNode(project, packageFolder, listOf(), false, !packageData.source.isEditable()), Comparable<AbstractTreeNode<*>> {
+    : UnityExplorerNode(project, packageFolder, listOf(), AncestorNodeType.fromPackageData(packageData)), Comparable<AbstractTreeNode<*>> {
 
     init {
         icon = when (packageData.source) {
@@ -290,7 +290,7 @@ class BuiltinPackagesRoot(project: Project, private val packageManager: PackageM
 // Note that a module can have dependencies. Perhaps we want to always show this as a folder, including the Dependencies
 // node?
 class BuiltinPackageNode(project: Project, private val packageData: PackageData)
-    : UnityExplorerNode(project, packageData.packageFolder!!, listOf(), false, true) {
+    : UnityExplorerNode(project, packageData.packageFolder!!, listOf(), AncestorNodeType.ReadOnlyPackage) {
 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
 
@@ -310,7 +310,7 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
     }
 
     override fun createNode(virtualFile: VirtualFile, nestedFiles: List<VirtualFile>): FileSystemNodeBase {
-        return UnityExplorerNode(project!!, virtualFile, nestedFiles, isUnderAssets = false, isReadOnlyPackageFile = true)
+        return UnityExplorerNode(project!!, virtualFile, nestedFiles, descendentOf)
     }
 
     override fun canNavigateToSource(): Boolean {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -147,7 +147,10 @@ open class UnityExplorerNode(project: Project,
             var description = projectNames.take(3).joinToString(", ")
             if (projectNames.count() > 3) {
                 description += ", …"
-                presentation.tooltip = "Contains files from multiple projects:<br/>" + projectNames.joinToString("<br/>")
+                presentation.tooltip = "Contains files from multiple projects:<br/>" + projectNames.take(10).joinToString("<br/>")
+                if (projectNames.count() > 10) {
+                    presentation.tooltip += "<br/>and ${projectNames.count() - 10} others"
+                }
             }
             presentation.addText(" ($description)", SimpleTextAttributes.GRAYED_ATTRIBUTES)
         }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.rider.plugins.unity.explorer
 
+import com.intellij.icons.AllIcons
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.scratch.ScratchProjectViewPane
@@ -256,7 +257,12 @@ open class UnityExplorerNode(project: Project,
             return UnityIcons.Explorer.UnloadedFolder
         }
 
-        return virtualFile.calculateFileSystemIcon(project!!)
+        return try {
+            // Make sure that errors fetching the icon can't kill the explorer - RIDER-43038
+            virtualFile.calculateFileSystemIcon(project!!)
+        } catch (ex: Throwable) {
+            AllIcons.FileTypes.Any_type
+        }
     }
 
     override fun createNode(virtualFile: VirtualFile, nestedFiles: List<VirtualFile>): FileSystemNodeBase {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
@@ -59,9 +59,9 @@ class PackageManager(private val project: Project) {
     private var editorManifestJson: EditorManifestJson? = null
 
     private var packagesByCanonicalName: Map<String, PackageData> = mutableMapOf()
-    private var packagesByFolderName: Map<String, PackageData> = mutableMapOf()
+    private var packagesByFolderPath: Map<String, PackageData> = mutableMapOf()
 
-    private data class Packages(val packagesByCanonicalName: Map<String, PackageData>, val packagesByFolderName: Map<String, PackageData>)
+    private data class Packages(val packagesByCanonicalName: Map<String, PackageData>, val packagesByFolderPath: Map<String, PackageData>)
 
     init {
         val listener = PackagesAsyncFileListener()
@@ -102,7 +102,7 @@ class PackageManager(private val project: Project) {
     }
 
     fun getPackageData(packageFolder: VirtualFile): PackageData? {
-        return packagesByFolderName[packageFolder.name]
+        return packagesByFolderPath[packageFolder.path]
     }
 
     fun getPackageData(canonicalName: String): PackageData? {
@@ -126,7 +126,7 @@ class PackageManager(private val project: Project) {
                 // Updated without locks. Each reference is updated atomically, and they are not used together, so there
                 // are no tearing issues
                 packagesByCanonicalName = it.packagesByCanonicalName
-                packagesByFolderName = it.packagesByFolderName
+                packagesByFolderPath = it.packagesByFolderPath
                 listeners.multicaster.onPackagesUpdated()
             }
             .submit(NonUrgentExecutor.getInstance())
@@ -139,9 +139,9 @@ class PackageManager(private val project: Project) {
         logger.debug("Refreshing packages manager")
 
         val byCanonicalName: MutableMap<String, PackageData> = mutableMapOf()
-        val byFolderName: MutableMap<String, PackageData> = mutableMapOf()
+        val byFolderPath: MutableMap<String, PackageData> = mutableMapOf()
 
-        val manifestJson = getManifestJsonFile() ?: return Packages(byCanonicalName, byFolderName)
+        val manifestJson = getManifestJsonFile() ?: return Packages(byCanonicalName, byFolderPath)
         val builtInPackagesFolder = UnityInstallationFinder.getInstance(project).getBuiltInPackagesRoot()
 
         val editorManifestPath = UnityInstallationFinder.getInstance(project).getPackageManagerDefaultManifest()
@@ -178,7 +178,7 @@ class PackageManager(private val project: Project) {
             val packageData = getPackageData(packagesFolder, name, version, registry, builtInPackagesFolder, lockDetails)
             byCanonicalName[name] = packageData
             if (packageData.packageFolder != null) {
-                byFolderName[packageData.packageFolder.name] = packageData
+                byFolderPath[packageData.packageFolder.path] = packageData
             }
         }
 
@@ -188,7 +188,7 @@ class PackageManager(private val project: Project) {
             val packageData = getPackageDataFromFolder(child.name, child, PackageSource.Embedded)
             if (packageData != null) {
                 byCanonicalName[packageData.details.canonicalName] = packageData
-                byFolderName[child.name] = packageData
+                byFolderPath[child.path] = packageData
             }
         }
 
@@ -203,11 +203,11 @@ class PackageManager(private val project: Project) {
             packagesToProcess = getPackagesFromDependencies(packagesFolder, registry, builtInPackagesFolder, resolvedPackages, packagesToProcess)
             for (newPackage in packagesToProcess) {
                 byCanonicalName[newPackage.details.canonicalName] = newPackage
-                newPackage.packageFolder?.let { byFolderName[it.name] = newPackage }
+                newPackage.packageFolder?.let { byFolderPath[it.path] = newPackage }
             }
         }
 
-        return Packages(byCanonicalName, byFolderName)
+        return Packages(byCanonicalName, byFolderPath)
     }
 
     private fun getManifestJsonFile(): VirtualFile? {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -283,60 +283,14 @@
   <change-notes>
 <![CDATA[
 <p>
-<strong>New in 2020.1</strong>
+<strong>New in 2020.1.1</strong>
 </p>
 <p>
-<em>Added:</em>
-<ul>
-  <li>Add performance inspection - prefer jagged array to multidimensional array access, with Quick Fix (<a href="https://youtrack.jetbrains.com/issue/RIDER-22812">RIDER-22812</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1459">#1459</a>)</li>
-  <li>Exclude <tt>Boo</tt> and <tt>UnityScript</tt> namespaces, as well as the <tt>System.Diagnostics.Debug</tt> type from import completion (<a href="https://github.com/JetBrains/resharper-unity/issues/574">#574</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1473">#1473</a>)</li>
-  <li>Add more attributes to external annotations. E.g. <tt>ShortcutAttribute</tt> will mark the method as in use (<a href="https://github.com/JetBrains/resharper-unity/issues/1546">#1546</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-40330">RIDER-40330</a> <a href="https://github.com/JetBrains/resharper-unity/pull/1548">#1548</a>)</li>
-  <li>Find Usages for serialised fields now includes asset usages (<a href="https://github.com/JetBrains/resharper-unity/pull/1530">#1530</a>)</li>
-  <li>Add context action to create Unity Assets menu item for a <tt>ScriptableObject</tt> (<a href="https://github.com/JetBrains/resharper-unity/pull/1567">#1567</a>)</li>
-  <li>Show serialised field values for scriptable objects (<a href="https://github.com/JetBrains/resharper-unity/pull/1567">#1567</a>)</li>
-  <li>Show usages of scriptable objects in assets (<a href="https://github.com/JetBrains/resharper-unity/pull/1567">#1567</a>)</li>
-  <li>Rider: Open corresponding <tt>.asmdef</tt> in Unity Inspector from <tt>.csproj</tt> editor notification (<a href="https://github.com/JetBrains/resharper-unity/pull/1574">#1574</a>)</li>
-  <li>Rider: Treat <tt>.inputactions</tt> as a JSON file (<a href="https://youtrack.jetbrains.com/issue/RIDER-38538">RIDER-38538</a>)</li>
-</ul>
-<em>Changed:</em>
-<ul>
-  <li>Indexing of assets deferred until after project loaded and will not interfere with existing code insight features (<a href="https://github.com/JetBrains/resharper-unity/pull/1530">#1530</a>)</li>
-  <li>Improved memory usage while parsing assets (<a href="https://github.com/JetBrains/resharper-unity/pull/1530">#1530</a>)</li>
-  <li>Improved support of nested and variant prefabs (<a href="https://github.com/JetBrains/resharper-unity/pull/1530">#1530</a>)</li>
-  <li>Serialised field values Code Vision now includes values from FomerlySerialisedAs attribute (<a href="https://github.com/JetBrains/resharper-unity/pull/1530">#1530</a>)</li>
-  <li>Serialised field values Code Vision now includes derived classes (<a href="https://github.com/JetBrains/resharper-unity/pull/1550">#1550</a>)</li>
-  <li>Show performance critical highlights for known methods without requiring Solution Wide Analysis enabled (<a href="https://github.com/JetBrains/resharper-unity/pull/1459">#1459</a>)</li>
-  <li>Stop marking a method as expensive if it only contains a null check (<a href="https://github.com/JetBrains/resharper-unity/pull/1459">#1459</a>)</li>
-  <li>Move vector multiplication order inspection to performance critical context only (<a href="https://github.com/JetBrains/resharper-unity/pull/1459">#1459</a>)</li>
-  <li>Updated API information to 2020.1.0a25 (<a href="https://github.com/JetBrains/resharper-unity/pull/1553">#1553</a>)</li>
-  <li>Sort commonly used event functions higher in Generate dialog (<a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
-  <li>Generate event functions at location of context action, rather than at end of class (<a href="https://github.com/JetBrains/resharper-unity/issues/1542">#1542</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
-  <li>Remove messages that use obsolete parameter types (<a href="https://github.com/JetBrains/resharper-unity/issues/1545">#1545</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1553">#1553</a>)</li>
-  <li>Rider: Adding file to Unity Explorer will add to correct C# project (<a href="https://youtrack.jetbrains.com/issue/RIDER-23169">RIDER-23169</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1470">#1470</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1501">#1501</a>)</li>
-  <li>Rider: Show folders ending with <tt>~</tt> by default in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/issues/1444">#1444</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1506">#1506</a>)</li>
-  <li>Rider: Move Unity Explorer settings to main "gear" icon (<a href="https://github.com/JetBrains/resharper-unity/pull/1506">#1506</a>)</li>
-  <li>Rider: Interesting content in builtin packages is now visible by default (<a href="https://github.com/JetBrains/resharper-unity/pull/1556">#1556</a>)</li>
-  <li>Rider: Only show "Show in Unity" link for Unity generated files when connected to Unity (<a href="https://github.com/JetBrains/resharper-unity/pull/1574">#1574</a>)</li>
-  <li>Rider: Improve detection of Unity version, especially after upgrading project (<a href="https://github.com/JetBrains/resharper-unity/issues/1507">#1507</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1572">#1572</a>)</li>
-  <li>Unity Editor: Move caret to correct column when opening file (<a href="https://youtrack.jetbrains.com/issue/RIDER-27450">RIDER-27450</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1486">#1486</a>)</li>
-  <li>Unity Editor: Delete the old Rider plugin when opening a project in Unity 2019.2+ (<a href="https://github.com/JetBrains/resharper-unity/pull/1591">#1591</a>)</li>
-</ul>
 <em>Fixed:</em>
 <ul>
-  <li>Fix incorrect redundant <tt>SerializeField</tt> attribute warning for property backing field (<a href="https://github.com/JetBrains/resharper-unity/issues/1016">#1016</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1464">#1464</a>)</li>
-  <li>Fix overwriting <tt>IEnumerator</tt> when auto-completing an event function that can be a coroutine (<a href="https://github.com/JetBrains/resharper-unity/issues/1258">#1258</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
-  <li>Fix duplicate "Generate Unity event functions" context action when gutter icons are visible (<a href="https://github.com/JetBrains/resharper-unity/issues/1537">#1537</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1566">#1566</a>)</li>
-  <li>Fix completion of tag value adding extra closing quote (<a href="https://youtrack.jetbrains.com/issue/RIDER-33067">RIDER-33067</a>)</li>
-  <li>Fix exception with building shortcut cache (<a href="https://youtrack.jetbrains.com/issue/RIDER-41206">RIDER-41206</a>)</li>
-  <li>Rider: Fix Unity tests working with <tt>.slnf</tt> files (<a href="https://github.com/JetBrains/resharper-unity/issues/1571">#1571</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1577">#1577</a>)</li>
-  <li>Rider: Fix tooltip display for packages in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1506">#1506</a>)</li>
-  <li>Rider: Fix resolving git based packages in Unity 2019.3+ (<a href="https://github.com/JetBrains/resharper-unity/pull/1616">#1616</a>)</li>
-  <li>Rider: Fix settings search not finding Unity pages (<a href="https://github.com/JetBrains/resharper-unity/issues/1516">#1516</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1520">#1520</a>)</li>
-  <li>Rider: Fix discovery and running of all tests in a project (<a href="https://github.com/JetBrains/resharper-unity/issues/1509">#1509</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1500">#1500</a>)</li>
-  <li>Rider: Fix finding location of Unity based on custom Hub install location (<a href="https://youtrack.jetbrains.com/issue/RIDER-42118">RIDER-42118</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1604">#1604</a>)</li>
-  <li>Rider: Use correct process ID for profiling and coverage (<a href="https://youtrack.jetbrains.com/issue/DTRC-26621">DTRC-26621</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1612">#1612</a>)</li>
-  <li>Rider: Mark editor as disconnected if response is not timely (<a href="https://github.com/JetBrains/resharper-unity/pull/1610">#1610</a>)</li>
-  <li>Unity Editor: Fix jumping to default desktop when opening files on Mac (<a href="https://github.com/JetBrains/resharper-unity/pull/1611">#1611</a>)</li>
+  <li>Rider: Fix exception finding file icon causing explorer view to be blank (<a href="https://youtrack.jetbrains.com/issue/RIDER-43038">RIDER-43038</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1632">#1632</a>)</li>
+  <li>Rider: Fix handling of file system folders in <tt>Packages</tt> with the same name as a package (<a href="https://github.com/JetBrains/resharper-unity/issues/1626">#1626</a>, [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+  <li>Rider: Fix size of tooltip for packages with many projects (<a href="https://github.com/JetBrains/resharper-unity/issues/1628">#1628</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1632">#1632</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net201/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -286,11 +286,21 @@
 <strong>New in 2020.1.1</strong>
 </p>
 <p>
+<em>Changed:</em>
+<ul>
+  <li>Rider: Show serializable Code Vision for more fields (<a href="https://github.com/JetBrains/resharper-unity/pull/1624">#1624</a>)</li>
+  <li>Rider: Improve presentation for asset Find Usages results (<a href="https://github.com/JetBrains/resharper-unity/pull/1624">#1624</a>)</li>
+  <li>Unity Editor: Reduce frequency of refreshing Unity on save to explicit calls to Save All (<a href="https://youtrack.jetbrains.com/issue/RIDER-37420">RIDER-37420</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1629">#1629</a>)</li>
+</ul>
+</p>
+<p>
 <em>Fixed:</em>
 <ul>
+  <li>Rider: Fix solution hang on "constructing components" due to excessive <tt>FileSystemWatcher</tt> initialisation (<a href="https://youtrack.jetbrains.com/issue/RIDER-41812">RIDER-41812</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1631">#1631</a>)</li>
   <li>Rider: Fix exception finding file icon causing explorer view to be blank (<a href="https://youtrack.jetbrains.com/issue/RIDER-43038">RIDER-43038</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1632">#1632</a>)</li>
-  <li>Rider: Fix handling of file system folders in <tt>Packages</tt> with the same name as a package (<a href="https://github.com/JetBrains/resharper-unity/issues/1626">#1626</a>, [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
+  <li>Rider: Fix handling of file system folders in <tt>Packages</tt> with the same name as a package (<a href="https://github.com/JetBrains/resharper-unity/issues/1626">#1626</a>, [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))</li>
   <li>Rider: Fix size of tooltip for packages with many projects (<a href="https://github.com/JetBrains/resharper-unity/issues/1628">#1628</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1632">#1632</a>)</li>
+  <li>Unity Editor: Fix list of folders to search for .NET Framework references (<a href="https://youtrack.jetbrains.com/issue/RIDER-42873">RIDER-42873</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1630">#1630</a>)</li>
 </ul>
 </p>
 <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net201/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>


### PR DESCRIPTION
This PR fixes a few issues with the Unity Explorer:

- [x] Adds defensive code so that a failure to calculate the file system icon does not break the entire explorer view ([RIDER-43038](https://youtrack.jetbrains.com/issue/RIDER-43038))
- [x] If a top level folder in `/Packages` has the same name as a package, but isn't the package, treat it as a normal file system folder. This can happen if a package with the same name is added with `file:`. This also correctly handles special folder icons under this folder and displaying project names (if the `file:` package is a reference into a folder under the top level file system folder. Yes, this can happen)
- [x] Limit the size of a folder's tooltip, if it has too many projects under it. E.g. Entities has 42 projects, and the tooltip listing them all is too big to fit on the screen properly. Now limited to 10 projects.