### PR TITLE
Improve presentation of Player projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 - Rider: Show serializable Code Vision for more fields ([#1624](https://github.com/JetBrains/resharper-unity/pull/1624))
 - Rider: Improve presentation for asset Find Usages results ([#1624](https://github.com/JetBrains/resharper-unity/pull/1624))
+- Rider: Improve presentation of Player projects in Unity Explorer ([#1634](https://github.com/JetBrains/resharper-unity/pull/1634))
 - Unity Editor: Reduce frequency of refreshing Unity on save to explicit calls to Save All ([RIDER-37420](https://youtrack.jetbrains.com/issue/RIDER-37420), [#1629](https://github.com/JetBrains/resharper-unity/pull/1629))
 
 ### Fixed

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerNode.kt
@@ -140,7 +140,7 @@ open class UnityExplorerNode(project: Project,
     protected fun addProjects(presentation: PresentationData) {
         val projectNames = nodes   // One node for each project that this directory is part of
                 .mapNotNull { containingProjectNode(it) }
-                .map { it.name.removePrefix(UnityExplorer.DefaultProjectPrefix + "-").removePrefix(UnityExplorer.DefaultProjectPrefix) }
+                .map(::stripDefaultProjectPrefix)
                 .filter { it.isNotEmpty() }
                 .sortedWith(String.CASE_INSENSITIVE_ORDER)
         if (projectNames.any()) {
@@ -154,6 +154,13 @@ open class UnityExplorerNode(project: Project,
             }
             presentation.addText(" ($description)", SimpleTextAttributes.GRAYED_ATTRIBUTES)
         }
+    }
+
+    private fun stripDefaultProjectPrefix(it: ProjectModelNode): String {
+        // Assembly-CSharp => ""
+        // Assembly-CSharp-Editor => Editor
+        // Assembly-CSharp.Player => Player
+        return it.name.removePrefix(UnityExplorer.DefaultProjectPrefix).removePrefix("-").removePrefix(".")
     }
 
     private fun containingProjectNode(node: IProjectModelNode): ProjectModelNode? {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -290,6 +290,7 @@
 <ul>
   <li>Rider: Show serializable Code Vision for more fields (<a href="https://github.com/JetBrains/resharper-unity/pull/1624">#1624</a>)</li>
   <li>Rider: Improve presentation for asset Find Usages results (<a href="https://github.com/JetBrains/resharper-unity/pull/1624">#1624</a>)</li>
+  <li>Rider: Improve presentation of Player projects in Unity Explorer (<a href="https://github.com/JetBrains/resharper-unity/pull/1634"</a>)</li>
   <li>Unity Editor: Reduce frequency of refreshing Unity on save to explicit calls to Save All (<a href="https://youtrack.jetbrains.com/issue/RIDER-37420">RIDER-37420</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1629">#1629</a>)</li>
 </ul>
 </p>


### PR DESCRIPTION
`Assembly-CSharp.Player` was being shown as `.Player` in the Unity Explorer. Now shown as just `Player`. A player project that is not the default will show the full name, e.g. `Unity.Collections.Player`.