### PR TITLE
Correctly generate static constructor without body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Fixed
 
 - Fix incorrect base type required warning for `ExecuteAlways` attribute ([#1642](https://github.com/JetBrains/resharper-unity/pull/1642))
+- Fix generation of static constructor for redundant `[InitializeOnLoad]` when member generator set to "default return value" ([#1644](https://github.com/JetBrains/resharper-unity/pull/1644))
 - Rider: Fix solution hang on "constructing components" due to excessive `FileSystemWatcher` initialisation ([RIDER-41812](https://youtrack.jetbrains.com/issue/RIDER-41812), [#1631](https://github.com/JetBrains/resharper-unity/pull/1631))
 - Rider: Fix exception finding file icon causing explorer view to be blank ([RIDER-43038](https://youtrack.jetbrains.com/issue/RIDER-43038), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))
 - Rider: Fix handling of file system folders in `Packages` with the same name as a package ([#1626](https://github.com/JetBrains/resharper-unity/issues/1626), [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/CreateStaticConstructorFromUsageAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/CreateStaticConstructorFromUsageAction.cs
@@ -1,5 +1,5 @@
-﻿using JetBrains.DocumentModel;
-using JetBrains.ReSharper.Feature.Services.CSharp.Intentions.DataProviders;
+﻿using JetBrains.ReSharper.Feature.Services.CSharp.Intentions.DataProviders;
+using JetBrains.ReSharper.Feature.Services.Generate;
 using JetBrains.ReSharper.Feature.Services.Intentions;
 using JetBrains.ReSharper.Feature.Services.Intentions.CreateDeclaration;
 using JetBrains.ReSharper.Feature.Services.Intentions.DataProviders;
@@ -9,7 +9,6 @@ using JetBrains.ReSharper.Intentions.CreateFromUsage;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Resolve;
-using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util;
 
@@ -67,8 +66,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
             var intention = ConstructorDeclarationBuilder.Create(context);
             var constructor = (IConstructorDeclaration) intention.ResultDeclaration;
             constructor.SetStatic(true);
-            var statements = constructor.Body.Statements;
-            var selection = statements.Count > 0 ? statements[0].GetDocumentRange() : DocumentRange.InvalidRange;
+            var selection = MemberBodyUtil.GetBodyTextRange(constructor);
             return new IntentionResult(EmptyList<ITemplateFieldHolder>.Instance, constructor, selection);
         }
     }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/CreateStaticConstructorFromUsageAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/CreateStaticConstructorFromUsageAction.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.ReSharper.Feature.Services.CSharp.Intentions.DataProviders;
+﻿using JetBrains.DocumentModel;
+using JetBrains.ReSharper.Feature.Services.CSharp.Intentions.DataProviders;
 using JetBrains.ReSharper.Feature.Services.Intentions;
 using JetBrains.ReSharper.Feature.Services.Intentions.CreateDeclaration;
 using JetBrains.ReSharper.Feature.Services.Intentions.DataProviders;
@@ -66,7 +67,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
             var intention = ConstructorDeclarationBuilder.Create(context);
             var constructor = (IConstructorDeclaration) intention.ResultDeclaration;
             constructor.SetStatic(true);
-            return new IntentionResult(EmptyList<ITemplateFieldHolder>.Instance, constructor, constructor.Body.Statements[0].GetDocumentRange());
+            var statements = constructor.Body.Statements;
+            var selection = statements.Count > 0 ? statements[0].GetDocumentRange() : DocumentRange.InvalidRange;
+            return new IntentionResult(EmptyList<ITemplateFieldHolder>.Instance, constructor, selection);
         }
     }
 }

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -38,6 +38,7 @@ New in 2020.1.2
 
 Fixed:
 - Fix incorrect base type required warning for ExecuteAlways attribute (#1642)
+- Fix generation of static constructor for redundant [InitializeOnLoad] when member generator set to "default return value" (#1644)
 
 See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details and history.
 </releaseNotes>

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs
@@ -1,0 +1,7 @@
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOn{caret}Load]
+public class MissingConstructor()
+{
+}

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs.gold
@@ -1,10 +1,10 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-[InitializeOn{caret}Load]
+[InitializeOnLoad]
 public class MissingConstructor()
 {
   static MissingConstructor()
-  {
+  {{caret}
   }
 }

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttribute/Test05.cs.gold
@@ -1,0 +1,10 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+[InitializeOn{caret}Load]
+public class MissingConstructor()
+{
+  static MissingConstructor()
+  {
+  }
+}

--- a/resharper/resharper-unity/test/src/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttributeQuickFixTests.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttributeQuickFixTests.cs
@@ -1,6 +1,5 @@
 ﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes;
-using JetBrains.ReSharper.Psi.CSharp.CodeStyle.Settings;
 using JetBrains.ReSharper.Psi.GenerateMemberBody;
 using JetBrains.ReSharper.TestFramework;
 using NUnit.Framework;

--- a/resharper/resharper-unity/test/src/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttributeQuickFixTests.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Intentions/QuickFixes/RedundantInitializeOnLoadAttributeQuickFixTests.cs
@@ -1,5 +1,8 @@
 ﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi.CSharp.CodeStyle.Settings;
+using JetBrains.ReSharper.Psi.GenerateMemberBody;
+using JetBrains.ReSharper.TestFramework;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
@@ -23,11 +26,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Intentions.QuickFixes
     }
 
     [TestUnity]
+    [TestSetting(typeof(GenerateMemberBodySettings), nameof(GenerateMemberBodySettings.MethodImplementationKind), MethodImplementationKind.ThrowNotImplemented)]
     public class RedundantInitializeOnLoadAttributeQuickFixCreateTests : CSharpQuickFixTestBase<CreateFromUsageFix>
     {
         protected override string RelativeTestDataPath=> @"CSharp\Intentions\QuickFixes\RedundantInitializeOnLoadAttribute";
 
         [Test] public void Test03() { DoNamedTest(); }
         [Test] public void Test04() { DoNamedTest(); }
+
+        [Test, TestSetting(typeof(GenerateMemberBodySettings), nameof(GenerateMemberBodySettings.MethodImplementationKind), MethodImplementationKind.ReturnDefaultValue)]
+        public void Test05() { DoNamedTest(); }
     }
 }

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -298,6 +298,7 @@
 <em>Fixed:</em>
 <ul>
   <li>Fix incorrect base type required warning for <tt>ExecuteAlways</tt> attribute (<a href="https://github.com/JetBrains/resharper-unity/pull/1642">#1642</a>)</li>
+  <li>Fix generation of static constructor for redundant <tt>[InitializeOnLoad]</tt> when member generator set to "default return value" (<a href="https://github.com/JetBrains/resharper-unity/pull/1644">#1644</a>)</li>
   <li>Rider: Fix solution hang on "constructing components" due to excessive <tt>FileSystemWatcher</tt> initialisation (<a href="https://youtrack.jetbrains.com/issue/RIDER-41812">RIDER-41812</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1631">#1631</a>)</li>
   <li>Rider: Fix exception finding file icon causing explorer view to be blank (<a href="https://youtrack.jetbrains.com/issue/RIDER-43038">RIDER-43038</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1632">#1632</a>)</li>
   <li>Rider: Fix handling of file system folders in <tt>Packages</tt> with the same name as a package (<a href="https://github.com/JetBrains/resharper-unity/issues/1626">#1626</a>, [#1632](https://github.com/JetBrains/resharper-unity/pull/1632))</li>


### PR DESCRIPTION
Fixes an issue where the "redundant `[InitializeOnLoad]`" quick fix would fail to generate a static constructor if member generation settings were set to "default return value".