### PR TITLE
Map range attribute to value range annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Added
 
+- Use `Range` attribute to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673))
 - Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor ([#1272](https://github.com/JetBrains/resharper-unity/issues/1272), [#1661](https://github.com/JetBrains/resharper-unity/pull/1661))
 - Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages ([#1667](https://github.com/JetBrains/resharper-unity/pull/1667))
 

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/RedundantAttributeOnTargetProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/RedundantAttributeOnTargetProblemAnalyzer.cs
@@ -20,7 +20,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
                 // UnityEngine
                 {KnownTypes.AddComponentMenu, AttributeTargets.Class},
                 {KnownTypes.ExecuteInEditMode, AttributeTargets.Class},
-                {KnownTypes.HideInInspector, AttributeTargets.Field},
+                {KnownTypes.HideInInspectorAttribute, AttributeTargets.Field},
                 // All but undocumented. Appears to have the same usage as ImageEffectOpaque
                 // The ImageEffect* attributes that are applied to methods are only useful
                 // when applied to OnRenderImage

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/RedundantHideInInspectorAttributeProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/RedundantHideInInspectorAttributeProblemAnalyzer.cs
@@ -20,7 +20,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
             if (!(attribute.TypeReference?.Resolve().DeclaredElement is ITypeElement attributeTypeElement))
                 return;
 
-            if (!Equals(attributeTypeElement.GetClrName(), KnownTypes.HideInInspector))
+            if (!Equals(attributeTypeElement.GetClrName(), KnownTypes.HideInInspectorAttribute))
                 return;
 
             var fields = attribute.GetFieldsByAttribute();

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddHeaderAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddHeaderAttributeAction.cs
@@ -21,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
         }
 
-        protected override IClrTypeName AttributeTypeName => KnownTypes.Header;
+        protected override IClrTypeName AttributeTypeName => KnownTypes.HeaderAttribute;
         protected override bool IsLayoutAttribute => true;
 
         protected override AttributeValue[] GetAttributeValues(IPsiModule module, IFieldDeclaration fieldDeclaration)

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddRangeAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddRangeAttributeAction.cs
@@ -21,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
         }
 
-        protected override IClrTypeName AttributeTypeName => KnownTypes.Range;
+        protected override IClrTypeName AttributeTypeName => KnownTypes.RangeAttribute;
         protected override bool IsLayoutAttribute => false;
 
         // It can make sense to apply Range to all of the fields in a multiple field declaration, but it's unintuitive,

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddSpaceAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddSpaceAttributeAction.cs
@@ -18,7 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
         }
 
-        protected override IClrTypeName AttributeTypeName => KnownTypes.Space;
+        protected override IClrTypeName AttributeTypeName => KnownTypes.SpaceAttribute;
         protected override bool IsLayoutAttribute => true;
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddTooltipAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddTooltipAttributeAction.cs
@@ -21,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
         }
 
-        protected override IClrTypeName AttributeTypeName => KnownTypes.Tooltip;
+        protected override IClrTypeName AttributeTypeName => KnownTypes.TooltipAttribute;
         protected override bool IsLayoutAttribute => false;
 
         // It makes no sense to apply Tooltip to each field in a multiple field declaration

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/CreateAssetMenuContextAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/CreateAssetMenuContextAction.cs
@@ -55,7 +55,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
             if (classLikeDeclaration == null)
                 return false;
             
-            var existingAttribute = classLikeDeclaration.GetAttribute(KnownTypes.CreateAssetMenu);
+            var existingAttribute = classLikeDeclaration.GetAttribute(KnownTypes.CreateAssetMenuAttribute);
             return existingAttribute == null && UnityApi.IsDescendantOfScriptableObject(classLikeDeclaration.DeclaredElement);
         }
 
@@ -81,7 +81,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                     new Pair<string, AttributeValue>("order", new AttributeValue(new ConstantValue(0, myModule))),
                 };
                 
-                var attribute = AttributeUtil.AddAttributeToSingleDeclaration(myClassLikeDeclaration, KnownTypes.CreateAssetMenu, EmptyArray<AttributeValue>.Instance, 
+                var attribute = AttributeUtil.AddAttributeToSingleDeclaration(myClassLikeDeclaration, KnownTypes.CreateAssetMenuAttribute, EmptyArray<AttributeValue>.Instance, 
                     values, myModule, myElementFactory);
                 
                 return attribute.CreateHotspotSession();

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/ToggleHideInInspectorAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/ToggleHideInInspectorAttributeAction.cs
@@ -20,7 +20,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
         }
 
-        protected override IClrTypeName AttributeTypeName => KnownTypes.HideInInspector;
+        protected override IClrTypeName AttributeTypeName => KnownTypes.HideInInspectorAttribute;
         protected override bool IsRemoveActionAvailable => true;
         protected override bool IsLayoutAttribute => false;
     }

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
@@ -10,7 +11,6 @@ using JetBrains.ReSharper.Psi.Impl.Reflection2.ExternalAnnotations;
 using JetBrains.ReSharper.Psi.Impl.Special;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.Util;
-using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
 {
@@ -22,19 +22,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
         private static readonly IClrTypeName ourMeansImplicitUseAttribute = new ClrTypeName(typeof(MeansImplicitUseAttribute).FullName);
         private static readonly IClrTypeName ourPublicAPIAttribute = new ClrTypeName(typeof(PublicAPIAttribute).FullName);
         private static readonly IClrTypeName ourUsedImplicitlyAttributeFullName = new ClrTypeName(typeof(UsedImplicitlyAttribute).FullName);
+        private static readonly IClrTypeName ourValueRangeAttributeFullName = new ClrTypeName(typeof(ValueRangeAttribute).FullName);
         private static readonly IClrTypeName ourImplicitUseTargetFlags = new ClrTypeName(typeof(ImplicitUseTargetFlags).FullName);
         // ReSharper restore AssignNullToNotNullAttribute
 
+        private readonly ExternalAnnotationsModuleFactory myExternalAnnotationsModuleFactory;
         private readonly IPredefinedTypeCache myPredefinedTypeCache;
         private readonly UnityApi myUnityApi;
-        private readonly IPsiModule myAnnotationsPsiModule;
 
         public CustomCodeAnnotationProvider(ExternalAnnotationsModuleFactory externalAnnotationsModuleFactory, IPredefinedTypeCache predefinedTypeCache, UnityApi unityApi)
         {
             myPredefinedTypeCache = predefinedTypeCache;
             myUnityApi = unityApi;
-            myAnnotationsPsiModule = externalAnnotationsModuleFactory
-                .GetPsiModule(TargetFrameworkId.Default);
+            myExternalAnnotationsModuleFactory = externalAnnotationsModuleFactory;
         }
 
         public CodeAnnotationNullableValue? GetNullableAttribute(IDeclaredElement element)
@@ -42,8 +42,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
             return null;
         }
 
-        public CodeAnnotationNullableValue? GetContainerElementNullableAttribute(
-            IDeclaredElement element)
+        public CodeAnnotationNullableValue? GetContainerElementNullableAttribute(IDeclaredElement element)
         {
             return null;
         }
@@ -52,6 +51,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
         {
             if (GetCoroutineMustUseReturnValueAttribute(element, out var collection)) return collection;
             if (GetPublicAPIImplicitlyUsedAttribute(element, out collection)) return collection;
+            if (GetValueRangeFromRangeAttribute(element, out collection)) return collection;
+
             return EmptyList<IAttributeInstance>.Instance;
         }
 
@@ -68,15 +69,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
             var predefinedType = myPredefinedTypeCache.GetOrCreatePredefinedType(element.Module);
             if (!Equals(returnType, predefinedType.IEnumerator)) return false;
 
+            // The ctorArguments lambda result is not cached, so let's allocate everything up front
+            var args = new[]
+            {
+                new AttributeValue(
+                    new ConstantValue("Coroutine will not continue if return value is ignored",
+                        predefinedType.String))
+            };
             collection = new[]
             {
-                new SpecialAttributeInstance(
-                    ourMustUseReturnValueAttributeFullName, myAnnotationsPsiModule, () => new[]
-                    {
-                        new AttributeValue(
-                            new ConstantValue("Coroutine will not continue if return value is ignored",
-                                predefinedType.String)),
-                    })
+                new SpecialAttributeInstance(ourMustUseReturnValueAttributeFullName, GetModule(element), () => args)
             };
             return true;
         }
@@ -86,7 +88,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
         // So if applied to a class, only the class is marked as in use, while the members aren't. This
         // provider will apply [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)] to any type that
         // has the old [PublicAPI] applied
-        private static bool GetPublicAPIImplicitlyUsedAttribute(IClrDeclaredElement element,
+        private bool GetPublicAPIImplicitlyUsedAttribute(IClrDeclaredElement element,
             out ICollection<IAttributeInstance> collection)
         {
             collection = EmptyList<IAttributeInstance>.InstanceList;
@@ -102,18 +104,72 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
                     .FirstOrDefault();
                 if (meansImplicitUse?.Constructor == null || !meansImplicitUse.Constructor.IsDefault) continue;
 
+                // The ctorArguments lambda result is not cached, so let's allocate everything up front
                 var flagsType = TypeFactory.CreateTypeByCLRName(ourImplicitUseTargetFlags, element.Module);
+                var args = new[] {new AttributeValue(new ConstantValue(3, flagsType))};
                 collection = new[]
                 {
-                    new SpecialAttributeInstance(
-                        ourUsedImplicitlyAttributeFullName, element.Module, () => new[]
-                            {new AttributeValue(new ConstantValue(3, flagsType))}
-                    )
+                    new SpecialAttributeInstance(ourUsedImplicitlyAttributeFullName, GetModule(element), () => args)
                 };
                 return true;
             }
 
             return false;
+        }
+
+        // Treat Unity's RangeAttribute as ReSharper's ValueRangeAttribute annotation
+        private bool GetValueRangeFromRangeAttribute(IClrDeclaredElement element,
+            out ICollection<IAttributeInstance> collection)
+        {
+            collection = EmptyList<IAttributeInstance>.InstanceList;
+
+            if (!(element is IField field) || !element.IsFromUnityProject()) return false;
+
+            // Integer value analysis only works on integers, but it will make use of annotations applied to values that
+            // are convertible to int, such as byte/sbyte and short/ushort. It doesn't currently use values applied to
+            // uint, or long/ulong, but it is planned, so we'll apply to all sizes of integer.
+            var predefinedType = myPredefinedTypeCache.GetOrCreatePredefinedType(element.Module);
+            if (!Equals(field.Type, predefinedType.Int) && !Equals(field.Type, predefinedType.Uint) &&
+                !Equals(field.Type, predefinedType.Long) && !Equals(field.Type, predefinedType.Ulong) &&
+                !Equals(field.Type, predefinedType.Short) && !Equals(field.Type, predefinedType.Ushort) &&
+                !Equals(field.Type, predefinedType.Byte) && !Equals(field.Type, predefinedType.Sbyte))
+            {
+                return false;
+            }
+
+            foreach (var attributeInstance in field.GetAttributeInstances(KnownTypes.RangeAttribute, false))
+            {
+                if (!myUnityApi.IsSerialisedField(field))
+                    continue;
+
+                // Values are floats, but applied to an integer field. Convert to integer values
+                var unityFrom = attributeInstance.PositionParameter(0);
+                var unityTo = attributeInstance.PositionParameter(1);
+
+                if (!unityFrom.IsConstant || !unityFrom.ConstantValue.IsFloat() ||
+                    !unityTo.IsConstant || !unityTo.ConstantValue.IsFloat())
+                {
+                    continue;
+                }
+
+                // The ctorArguments lambda result is not cached, so let's allocate everything up front
+                var from = new AttributeValue(new ConstantValue(Convert.ToInt64(unityFrom.ConstantValue.Value), predefinedType.Long));
+                var to = new AttributeValue(new ConstantValue(Convert.ToInt64(unityTo.ConstantValue.Value), predefinedType.Long));
+                var args = new[] {from, to};
+
+                collection = new[]
+                {
+                    new SpecialAttributeInstance(ourValueRangeAttributeFullName, GetModule(element), () => args)
+                };
+                return true;
+            }
+
+            return false;
+        }
+
+        private IPsiModule GetModule(IClrDeclaredElement element)
+        {
+            return myExternalAnnotationsModuleFactory.GetPsiModule(element.Module.TargetFrameworkId) ?? element.Module;
         }
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ProjectModel;
@@ -152,9 +153,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
                     continue;
                 }
 
+                // The check above means this is not null. We take the floor, because that's how Unity works.
+                // E.g. Unity's Inspector treats [Range(1.7f, 10.9f)] as between 1 and 10 inclusive
+                var f = Math.Floor((float) unityFrom.ConstantValue.Value.NotNull());
+                var t = Math.Floor((float) unityTo.ConstantValue.Value.NotNull());
+
                 // The ctorArguments lambda result is not cached, so let's allocate everything up front
-                var from = new AttributeValue(new ConstantValue(Convert.ToInt64(unityFrom.ConstantValue.Value), predefinedType.Long));
-                var to = new AttributeValue(new ConstantValue(Convert.ToInt64(unityTo.ConstantValue.Value), predefinedType.Long));
+                var from = new AttributeValue(new ConstantValue(Convert.ToInt64(Math.Floor(f)), predefinedType.Long));
+                var to = new AttributeValue(new ConstantValue(Convert.ToInt64(Math.Floor(t)), predefinedType.Long));
                 var args = new[] {from, to};
 
                 collection = new[]

--- a/resharper/resharper-unity/src/KnownTypes.cs
+++ b/resharper/resharper-unity/src/KnownTypes.cs
@@ -10,39 +10,36 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName Animator = new ClrTypeName("UnityEngine.Animator");
         public static readonly IClrTypeName Camera = new ClrTypeName("UnityEngine.Camera");
         public static readonly IClrTypeName Component = new ClrTypeName("UnityEngine.Component");
+        public static readonly IClrTypeName CreateAssetMenuAttribute = new ClrTypeName("UnityEngine.CreateAssetMenuAttribute");
+        public static readonly IClrTypeName Debug = new ClrTypeName("UnityEngine.Debug");
         public static readonly IClrTypeName ExecuteInEditMode = new ClrTypeName("UnityEngine.ExecuteInEditMode");
         public static readonly IClrTypeName GameObject = new ClrTypeName("UnityEngine.GameObject");
-        public static readonly IClrTypeName HideInInspector = new ClrTypeName("UnityEngine.HideInInspector");
-        public static readonly IClrTypeName Space = new ClrTypeName("UnityEngine.SpaceAttribute");
-        public static readonly IClrTypeName Header = new ClrTypeName("UnityEngine.HeaderAttribute");
-        public static readonly IClrTypeName Tooltip = new ClrTypeName("UnityEngine.TooltipAttribute");
-        public static readonly IClrTypeName RequireComponent = new ClrTypeName("UnityEngine.RequireComponent");
-        public static readonly IClrTypeName Range = new ClrTypeName("UnityEngine.RangeAttribute");
-        public static readonly IClrTypeName CreateAssetMenu = new ClrTypeName("UnityEngine.CreateAssetMenuAttribute");
+        public static readonly IClrTypeName HeaderAttribute = new ClrTypeName("UnityEngine.HeaderAttribute");
+        public static readonly IClrTypeName HideInInspectorAttribute = new ClrTypeName("UnityEngine.HideInInspector");
         public static readonly IClrTypeName ImageEffectAfterScale = new ClrTypeName("UnityEngine.ImageEffectAfterScale");
         public static readonly IClrTypeName ImageEffectAllowedInSceneView = new ClrTypeName("UnityEngine.ImageEffectAllowedInSceneView");
         public static readonly IClrTypeName ImageEffectOpaque = new ClrTypeName("UnityEngine.ImageEffectOpaque");
         public static readonly IClrTypeName ImageEffectTransformsToLDR = new ClrTypeName("UnityEngine.ImageEffectTransformsToLDR");
+        public static readonly IClrTypeName Input = new ClrTypeName("UnityEngine.Input");
+        public static readonly IClrTypeName LayerMask = new ClrTypeName("UnityEngine.LayerMask");
         public static readonly IClrTypeName Material = new ClrTypeName("UnityEngine.Material");
         public static readonly IClrTypeName MaterialPropertyBlock = new ClrTypeName("UnityEngine.MaterialPropertyBlock");
         public static readonly IClrTypeName MonoBehaviour = new ClrTypeName("UnityEngine.MonoBehaviour");
         public static readonly IClrTypeName Object = new ClrTypeName("UnityEngine.Object");
         public static readonly IClrTypeName Physics = new ClrTypeName("UnityEngine.Physics");
         public static readonly IClrTypeName Physics2D = new ClrTypeName("UnityEngine.Physics2D");
+        public static readonly IClrTypeName RangeAttribute = new ClrTypeName("UnityEngine.RangeAttribute");
+        public static readonly IClrTypeName RequireComponent = new ClrTypeName("UnityEngine.RequireComponent");
         public static readonly IClrTypeName Resources = new ClrTypeName("UnityEngine.Resources");
         public static readonly IClrTypeName RuntimeInitializeOnLoadMethodAttribute = new ClrTypeName("UnityEngine.RuntimeInitializeOnLoadMethodAttribute");
         public static readonly IClrTypeName ScriptableObject = new ClrTypeName("UnityEngine.ScriptableObject");
-        public static readonly IClrTypeName UnityEvent = new ClrTypeName("UnityEngine.Events.UnityEventBase");
         public static readonly IClrTypeName SerializeField = new ClrTypeName("UnityEngine.SerializeField");
         public static readonly IClrTypeName Shader = new ClrTypeName("UnityEngine.Shader");
+        public static readonly IClrTypeName SpaceAttribute = new ClrTypeName("UnityEngine.SpaceAttribute");
+        public static readonly IClrTypeName TooltipAttribute = new ClrTypeName("UnityEngine.TooltipAttribute");
         public static readonly IClrTypeName Transform = new ClrTypeName("UnityEngine.Transform");
-        public static readonly IClrTypeName Debug = new ClrTypeName("UnityEngine.Debug");
-        public static readonly IClrTypeName SceneManager = new ClrTypeName("UnityEngine.SceneManagement.SceneManager");
-        public static readonly IClrTypeName EditorSceneManager = new ClrTypeName("UnityEditor.SceneManagement.EditorSceneManager");
-        public static readonly IClrTypeName LayerMask = new ClrTypeName("UnityEngine.LayerMask");
-        public static readonly IClrTypeName Input = new ClrTypeName("UnityEngine.Input");
-        public static readonly IClrTypeName BurstCompile = new ClrTypeName("Unity.Burst.BurstCompileAttribute");
-        public static readonly IClrTypeName Job = new ClrTypeName("Unity.Jobs.IJob");
+
+        public static readonly IClrTypeName UnityEvent = new ClrTypeName("UnityEngine.Events.UnityEventBase");
 
         // UnityEngine.Networking
         public static readonly IClrTypeName NetworkBehaviour = new ClrTypeName("UnityEngine.Networking.NetworkBehaviour");
@@ -63,18 +60,24 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName InitializeOnLoadAttribute = new ClrTypeName("UnityEditor.InitializeOnLoadAttribute");
         public static readonly IClrTypeName InitializeOnLoadMethodAttribute = new ClrTypeName("UnityEditor.InitializeOnLoadMethodAttribute");
         public static readonly IClrTypeName PropertyDrawer = new ClrTypeName("UnityEditor.PropertyDrawer");
-        
         public static readonly IClrTypeName SettingsProvider = new ClrTypeName("UnityEditor.SettingsProvider");
         public static readonly IClrTypeName SettingsProviderAttribute = new ClrTypeName("UnityEditor.SettingsProviderAttribute");
 
+        // UnityEditor.Callbacks
         public static readonly IClrTypeName DidReloadScripts = new ClrTypeName("UnityEditor.Callbacks.DidReloadScripts");
         public static readonly IClrTypeName OnOpenAssetAttribute = new ClrTypeName("UnityEditor.Callbacks.OnOpenAssetAttribute");
         public static readonly IClrTypeName PostProcessBuildAttribute = new ClrTypeName("UnityEditor.Callbacks.PostProcessBuildAttribute");
         public static readonly IClrTypeName PostProcessSceneAttribute = new ClrTypeName("UnityEditor.Callbacks.PostProcessSceneAttribute");
-        
-        // ECS
+
+        // UnityEditor.SceneManagement
+        public static readonly IClrTypeName EditorSceneManager = new ClrTypeName("UnityEditor.SceneManagement.EditorSceneManager");
+        public static readonly IClrTypeName SceneManager = new ClrTypeName("UnityEngine.SceneManagement.SceneManager");
+
+        // ECS/DOTS
         public static readonly IClrTypeName JobComponentSystem = new ClrTypeName("Unity.Entities.JobComponentSystem");
         public static readonly IClrTypeName ComponentSystem = new ClrTypeName("Unity.Entities.ComponentSystem");
         public static readonly IClrTypeName InjectAttribute = new ClrTypeName("Unity.Entities.InjectAttribute");
+        public static readonly IClrTypeName BurstCompile = new ClrTypeName("Unity.Burst.BurstCompileAttribute");
+        public static readonly IClrTypeName Job = new ClrTypeName("Unity.Jobs.IJob");
     }
 }

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -36,7 +36,11 @@
 <releaseNotes>
 New in 2020.2
 
-### Changed
+Added:
+
+- Use Range attribute to provide hints to integer dataflow analysis (#1673)
+
+Changed:
 
 - All applicable quick fixes are now bulk actions, and can be applied over project scope (#1648, #1649)
 

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    [Range(1, 10)] public int intValue;
+    [Range(1, 10)] public uint uintValue;
+    [Range(1, 10)] public long longValue;
+    [Range(1, 10)] public ulong ulongValue;
+    [Range(1, 10)] public byte byteValue;
+    [Range(1, 10)] public sbyte sbyteValue;
+    [Range(1, 10)] public short shortValue;
+    [Range(1, 10)] public ushort ushortValue;
+
+    [Range(1, 10)] private int nonSerialisedField;
+
+    public void Update()
+    {
+        // Only the types that are implicitly converted into int will have
+        // integer value analysis warnings
+        if (intValue > 20) { }
+        if (uintValue > 20) { }
+        if (longValue > 20) { }
+        if (ulongValue > 20) { }
+        if (byteValue > 20) { }
+        if (sbyteValue > 20) { }
+        if (shortValue > 20) { }
+        if (ushortValue > 20) { }
+
+        if (nonSerialisedField > 20) { }
+    }
+
+    public void LateUpdate()
+    {
+        if (intValue > 5) { }
+        if (uintValue > 5) { }
+        if (longValue > 5) { }
+        if (ulongValue > 5) { }
+        if (byteValue > 5) { }
+        if (sbyteValue > 5) { }
+        if (shortValue > 5) { }
+        if (ushortValue > 5) { }
+    }
+}
+
+// We contribute a custom attribute instance when we see RangeAttribute on an
+// int field. In a production context, this attribute instance resolves with
+// JetBrains.Annotations loaded from the install directory by the external
+// annotations module. This doesn't happen in a test context, so we have to
+// provide the class here in the test, so there's something to resolve against.
+// Other annotation based tests can work because Unity.Engine includes an old
+// subset of JetBrains.Annotations
+//
+// ReSharper disable All
+namespace JetBrains.Annotations
+{
+  [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Delegate, AllowMultiple = true)]
+  [Conditional("JETBRAINS_ANNOTATIONS")]
+  public sealed class ValueRangeAttribute : Attribute
+  {
+    public object From { get; }
+
+    public object To { get; }
+
+    public ValueRangeAttribute(long from, long to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(ulong from, ulong to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(long value) => this.From = this.To = (object) value;
+
+    public ValueRangeAttribute(ulong value) => this.From = this.To = (object) value;
+  }
+}
+// ReSharper enable All
+

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics;
 using UnityEngine;
 
 public class MyMonoBehaviour : MonoBehaviour
@@ -10,6 +12,8 @@ public class MyMonoBehaviour : MonoBehaviour
     [Range(1, 10)] public sbyte sbyteValue;
     [Range(1, 10)] public short shortValue;
     [Range(1, 10)] public ushort ushortValue;
+
+    [Range(1.3f, 10.7f)] public int intWithFloatRange;
 
     [Range(1, 10)] private int nonSerialisedField;
 
@@ -27,6 +31,14 @@ public class MyMonoBehaviour : MonoBehaviour
         if (ushortValue > 20) { }
 
         if (nonSerialisedField > 20) { }
+
+        if (intWithFloatRange < 1) { }
+        if (intWithFloatRange == 0) { }
+        if (intWithFloatRange == 1) { }
+        if (intWithFloatRange == 2) { }
+        if (intWithFloatRange > 10) { }
+        if (intWithFloatRange == 10) { }
+        if (intWithFloatRange == 11) { }
     }
 
     public void LateUpdate()

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs.gold
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Diagnostics;
+using UnityEngine;
 
 public class MyMonoBehaviour : MonoBehaviour
 {
@@ -10,6 +12,8 @@ public class MyMonoBehaviour : MonoBehaviour
     [Range(1, 10)] public sbyte sbyteValue;
     [Range(1, 10)] public short shortValue;
     [Range(1, 10)] public ushort ushortValue;
+
+    [Range(1.3f, 10.7f)] public int intWithFloatRange;
 
     [Range(1, 10)] private int nonSerialisedField;
 
@@ -27,6 +31,14 @@ public class MyMonoBehaviour : MonoBehaviour
         if (|ushortValue > 20|(4)) { }
 
         if (nonSerialisedField > 20) { }
+
+        if (|intWithFloatRange < 1|(5)) { }
+        if (|intWithFloatRange == 0|(6)) { }
+        if (intWithFloatRange == 1) { }
+        if (intWithFloatRange == 2) { }
+        if (|intWithFloatRange > 10|(7)) { }
+        if (intWithFloatRange == 10) { }
+        if (|intWithFloatRange == 11|(8)) { }
     }
 
     public void LateUpdate()
@@ -87,3 +99,7 @@ namespace JetBrains.Annotations
 (2): ReSharper Warning: Expression is always false
 (3): ReSharper Warning: Expression is always false
 (4): ReSharper Warning: Expression is always false
+(5): ReSharper Warning: Expression is always false
+(6): ReSharper Warning: Expression is always false
+(7): ReSharper Warning: Expression is always false
+(8): ReSharper Warning: Expression is always false

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/RangeAttributeAsValueRangeAttribute.cs.gold
@@ -1,0 +1,89 @@
+﻿using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    [Range(1, 10)] public int intValue;
+    [Range(1, 10)] public uint uintValue;
+    [Range(1, 10)] public long longValue;
+    [Range(1, 10)] public ulong ulongValue;
+    [Range(1, 10)] public byte byteValue;
+    [Range(1, 10)] public sbyte sbyteValue;
+    [Range(1, 10)] public short shortValue;
+    [Range(1, 10)] public ushort ushortValue;
+
+    [Range(1, 10)] private int nonSerialisedField;
+
+    public void Update()
+    {
+        // Only the types that are implicitly converted into int will have
+        // integer value analysis warnings
+        if (|intValue > 20|(0)) { }
+        if (uintValue > 20) { }
+        if (longValue > 20) { }
+        if (ulongValue > 20) { }
+        if (|byteValue > 20|(1)) { }
+        if (|sbyteValue > 20|(2)) { }
+        if (|shortValue > 20|(3)) { }
+        if (|ushortValue > 20|(4)) { }
+
+        if (nonSerialisedField > 20) { }
+    }
+
+    public void LateUpdate()
+    {
+        if (intValue > 5) { }
+        if (uintValue > 5) { }
+        if (longValue > 5) { }
+        if (ulongValue > 5) { }
+        if (byteValue > 5) { }
+        if (sbyteValue > 5) { }
+        if (shortValue > 5) { }
+        if (ushortValue > 5) { }
+    }
+}
+
+// We contribute a custom attribute instance when we see RangeAttribute on an
+// int field. In a production context, this attribute instance resolves with
+// JetBrains.Annotations loaded from the install directory by the external
+// annotations module. This doesn't happen in a test context, so we have to
+// provide the class here in the test, so there's something to resolve against.
+// Other annotation based tests can work because Unity.Engine includes an old
+// subset of JetBrains.Annotations
+//
+// ReSharper disable All
+namespace JetBrains.Annotations
+{
+  [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Delegate, AllowMultiple = true)]
+  [Conditional("JETBRAINS_ANNOTATIONS")]
+  public sealed class ValueRangeAttribute : Attribute
+  {
+    public object From { get; }
+
+    public object To { get; }
+
+    public ValueRangeAttribute(long from, long to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(ulong from, ulong to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(long value) => this.From = this.To = (object) value;
+
+    public ValueRangeAttribute(ulong value) => this.From = this.To = (object) value;
+  }
+}
+// ReSharper enable All
+
+
+---------------------------------------------------------
+(0): ReSharper Warning: Expression is always false
+(1): ReSharper Warning: Expression is always false
+(2): ReSharper Warning: Expression is always false
+(3): ReSharper Warning: Expression is always false
+(4): ReSharper Warning: Expression is always false

--- a/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProviderTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProviderTest.cs
@@ -18,9 +18,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.CodeAnnotations
         protected override bool HighlightingPredicate(IHighlighting highlighting, IPsiSourceFile sourceFile,
             IContextBoundSettingsStore settingsStore)
         {
-            return highlighting is MustUseReturnValueWarning || highlighting is IteratorMethodResultIsIgnoredWarning;
+            return highlighting is MustUseReturnValueWarning || highlighting is IteratorMethodResultIsIgnoredWarning ||
+                   highlighting is ConditionIsAlwaysTrueOrFalseWarning;
         }
 
         [Test] public void TestUnusedCoroutineReturnValue() { DoNamedTest2(); }
+
+        // Note that this test includes a definition of the ValueRangeAttribute in the source. This is because the
+        // external annotations module cannot load JetBrains.Annotations in a test context. Other annotation based tests
+        // work because Unity.Engine includes a subset of our annotations, and it's enough to run the tests
+        [Test] public void TestRangeAttributeAsValueRangeAttribute() { DoNamedTest2(); }
     }
 }

--- a/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/FixCharacterControllerCollisionFlagAnnotationTests.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/FixCharacterControllerCollisionFlagAnnotationTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.CodeAnnotations
 {
+    // See RIDER-28661
     [TestUnity]
     public class FixCharacterControllerCollisionFlagAnnotationTests : CSharpHighlightingTestBase
     {

--- a/resharper/resharper-unity/test/src/TestEnvironment.cs
+++ b/resharper/resharper-unity/test/src/TestEnvironment.cs
@@ -43,6 +43,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests
             {
                 // SetupLogging();
                 SetJetTestPackagesDir();
+                HackTaskRunnerFramework.Install();
                 HackTestDataInNugets.ApplyPatches();
             }
             catch (Exception e)

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -293,6 +293,7 @@
 <p>
 <em>Added:</em>
 <ul>
+  <li>Use <tt>Range</tt> attribute to provide hints to integer dataflow analysis (<a href="https://github.com/JetBrains/resharper-unity/pull/1673">#1673</a>)</li>
   <li>Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor (<a href="https://github.com/JetBrains/resharper-unity/issues/1272">#1272</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1661">#1661</a>)</li>
   <li>Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages (<a href="https://github.com/JetBrains/resharper-unity/pull/1667">#1667</a>)</li>
 </ul>


### PR DESCRIPTION
ReSharper/Rider 2020.1 introduced integer value dataflow analysis, which can track the value of integers through a piece of code. The `ValueRange` attribute can provide a hint that an integer value is only between a min and max value.

![int-dataflow-blog@2x-1](https://user-images.githubusercontent.com/222659/83063441-0df5cc00-a058-11ea-9902-999e1f89a74e.png)

Unity's `Range` attribute can be applied to fields, and the Inspector will ensure that the value of the field is kept between the given min and max value.

This PR will map Unity's `Range` attribute to ReSharper's `ValueRange` annotation, using the `Range`'s min/max values as the hint to ReSharper's dataflow analysis. Note that ReSharper's analysis only works with integer values, so `Range` attributes on float values are ignored.