### PR TITLE
Disable namespace provider for Packages and subfolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Added
 
 - Use `Range` attribute to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673))
-- Remove `Packages` and any subfolder from namespace suggestions ([#1677](https://github.com/JetBrains/resharper-unity/pull/1677))
+- Improve namespace suggestions for packages ([#1161](https://github.com/JetBrains/resharper-unity/issues/1161), [RIDER-36546](https://youtrack.jetbrains.com/issue/RIDER-36546), [#1677](https://github.com/JetBrains/resharper-unity/pull/1677))
 - Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor ([#1272](https://github.com/JetBrains/resharper-unity/issues/1272), [#1661](https://github.com/JetBrains/resharper-unity/pull/1661))
 - Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages ([#1667](https://github.com/JetBrains/resharper-unity/pull/1667))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Added
 
 - Use `Range` attribute to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673))
+- Remove `Packages` and any subfolder from namespace suggestions ([#1677](https://github.com/JetBrains/resharper-unity/pull/1677))
 - Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor ([#1272](https://github.com/JetBrains/resharper-unity/issues/1272), [#1661](https://github.com/JetBrains/resharper-unity/pull/1661))
 - Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages ([#1667](https://github.com/JetBrains/resharper-unity/pull/1667))
 

--- a/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
@@ -30,32 +30,64 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
             ExcludeFolderFromNamespace(mountPoint, "Assets");
             ExcludeFolderFromNamespace(mountPoint, @"Assets\Scripts");
 
-            // Don't require Packages, or the immediate children of Packages in namespaces. The immediate children are
-            // package names, and shouldn't be considered part of the namespace.
-            // E.g. Given Packages/com.foo.package/package.json don't require Packages.com.foo.packages in the namespace
-            ExcludeFolderFromNamespace(mountPoint, "Packages");
-            ExcludeImmediateSubfoldersFromNamespace(mountPoint, project, "Packages");
-
-            ExcludeFolderFromNamespace(mountPoint, "Library");
-            ExcludeFolderFromNamespace(mountPoint, @"Library\PackageCache");
+            ExcludePackagesFoldersFromNamespace(mountPoint, project, "Packages");
             foreach (var projectFolder in project.GetSubFolders("Library"))
-                ExcludeImmediateSubfoldersFromNamespace(mountPoint, projectFolder, "PackageCache", @"Library\");
+            {
+                ExcludeFolderFromNamespace(mountPoint, "Library");
+                ExcludePackagesFoldersFromNamespace(mountPoint, projectFolder, "PackageCache", @"Library");
+            }
         }
 
         private void ExcludeFolderFromNamespace(ISettingsStorageMountPoint mountPoint, string path)
         {
-            var index = NamespaceFolderProvider.GetIndexFromOldIndex(FileSystemPath.Parse(path, FileSystemPathInternStrategy.TRY_GET_INTERNED_BUT_DO_NOT_INTERN));
+            var index = NamespaceFolderProvider.GetIndexFromOldIndex(FileSystemPath.Parse(path,
+                FileSystemPathInternStrategy.TRY_GET_INTERNED_BUT_DO_NOT_INTERN));
             SetIndexedValue(mountPoint, NamespaceProviderSettingsAccessor.NamespaceFoldersToSkip, index, true);
         }
 
-        private void ExcludeImmediateSubfoldersFromNamespace(ISettingsStorageMountPoint mountPoint, IProjectFolder root, string parent, string rootPath = "")
+        private void ExcludePackagesFoldersFromNamespace(ISettingsStorageMountPoint mountPoint,
+                                                         IProjectFolder packageHierarchyParentFolder,
+                                                         string packageHierarchyFolderName,
+                                                         string parentProjectRelativePath = "")
         {
-            foreach (var projectFolder in root.GetSubFolders(parent))
+            var packageHierarchyRootFolderPath = parentProjectRelativePath.Length == 0
+                ? packageHierarchyFolderName
+                : parentProjectRelativePath + @"\" + packageHierarchyFolderName;
+
+            foreach (var subFolder in packageHierarchyParentFolder.GetSubFolders(packageHierarchyFolderName))
             {
-                foreach (var subFolder in projectFolder.GetSubFolders())
+                // Exclude the root of the package hierarchy (Packages or PackageCache)
+                ExcludeFolderFromNamespace(mountPoint, packageHierarchyRootFolderPath);
+                ExcludePackageSubFoldersFromNamespace(mountPoint, subFolder, packageHierarchyRootFolderPath);
+            }
+        }
+
+        private void ExcludePackageSubFoldersFromNamespace(ISettingsStorageMountPoint mountPoint,
+                                                           IProjectFolder thisFolder, string thisPath)
+        {
+            // First time called, this excludes package name, e.g. `Packages/com.unity.mathematics` or
+            // `Library/PackageCache/com.unity.collections@0.0.9-preview.9`
+            // If that folder does not have a package.json recurse until we find one, and exclude everything along the
+            // way. This handles an edge case where e.g. a GitHub repo is checked out into Packages, but the root of the
+            // project isn't the package. Instead, the package is defined one or two levels down, and included into the
+            // project via file: in the manifest.
+            // E.g. myrepo/src/mypackage/{package.json}. We don't want `myrepo` or `src` appearing in the namespace
+            foreach (var subFolder in thisFolder.GetSubFolders())
+            {
+                var path = thisPath + @"\" + subFolder.Name;
+                ExcludeFolderFromNamespace(mountPoint, path);
+
+                // Is it a package folder? Exclude Scripts, Runtime, Scripts/Runtime and Runtime/Scripts
+                if (subFolder.Location.Combine("package.json").ExistsFile)
                 {
-                    ExcludeFolderFromNamespace(mountPoint, rootPath + projectFolder.Name + @"\" + subFolder.Name);
+                    ExcludeFolderFromNamespace(mountPoint, path + @"\Runtime");
+                    ExcludeFolderFromNamespace(mountPoint, path + @"\Scripts");
+                    ExcludeFolderFromNamespace(mountPoint, path + @"\Runtime\Scripts");
+                    ExcludeFolderFromNamespace(mountPoint, path + @"\Scripts\Runtime");
+                    return;
                 }
+
+                ExcludePackageSubFoldersFromNamespace(mountPoint, subFolder, path);
             }
         }
 

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -39,6 +39,7 @@ New in 2020.2
 Added:
 
 - Use Range attribute to provide hints to integer dataflow analysis (#1673)
+- Remove Packages and any subfolder from namespace suggestions (#1677)
 
 Changed:
 

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -39,7 +39,7 @@ New in 2020.2
 Added:
 
 - Use Range attribute to provide hints to integer dataflow analysis (#1673)
-- Remove Packages and any subfolder from namespace suggestions (#1677)
+- Improve namespace suggestions for packages (#1161, RIDER-36546, #1677)
 
 Changed:
 

--- a/resharper/resharper-unity/src/rider-unity.csproj
+++ b/resharper/resharper-unity/src/rider-unity.csproj
@@ -33,6 +33,7 @@
     <Compile Update="CSharp\Daemon\Errors\CSharpPerformanceErrors.generated.cs">
       <DependentUpon>CSharpPerformanceErrors.xml</DependentUpon>
     </Compile>
+    <Compile Remove="ShaderLab\Rider\Host\Features\Documents\ShaderLabBreadCrumbsProvider.cs" />
   </ItemGroup>
   <!-- ********** -->
   <ItemGroup Label="Cg">
@@ -129,6 +130,9 @@
     <Compile Remove="**\VisualStudio\**" />
     <EmbeddedResource Remove="**\VisualStudio\**" />
     <None Remove="**\VisualStudio\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ShaderLab\Rider\Host\Features\Documents" />
   </ItemGroup>
   <Import Project="$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props" Condition="Exists('$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props')" />
 </Project>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -294,7 +294,7 @@
 <em>Added:</em>
 <ul>
   <li>Use <tt>Range</tt> attribute to provide hints to integer dataflow analysis (<a href="https://github.com/JetBrains/resharper-unity/pull/1673">#1673</a>)</li>
-  <li>Remove <tt>Packages</tt> and any subfolder from namespace suggestions (<a href="https://github.com/JetBrains/resharper-unity/pull/1677">#1677</a>)</li>
+  <li>Improve namespace suggestions for packages (<a href="https://github.com/JetBrains/resharper-unity/issues/1161">#1161</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-36546">RIDER-36546</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1677">#1677</a>)</li>
   <li>Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor (<a href="https://github.com/JetBrains/resharper-unity/issues/1272">#1272</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1661">#1661</a>)</li>
   <li>Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages (<a href="https://github.com/JetBrains/resharper-unity/pull/1667">#1667</a>)</li>
 </ul>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -294,6 +294,7 @@
 <em>Added:</em>
 <ul>
   <li>Use <tt>Range</tt> attribute to provide hints to integer dataflow analysis (<a href="https://github.com/JetBrains/resharper-unity/pull/1673">#1673</a>)</li>
+  <li>Remove <tt>Packages</tt> and any subfolder from namespace suggestions (<a href="https://github.com/JetBrains/resharper-unity/pull/1677">#1677</a>)</li>
   <li>Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor (<a href="https://github.com/JetBrains/resharper-unity/issues/1272">#1272</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1661">#1661</a>)</li>
   <li>Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages (<a href="https://github.com/JetBrains/resharper-unity/pull/1667">#1667</a>)</li>
 </ul>


### PR DESCRIPTION
Add new rules to disable the "namespace provider" for the following folders. This will stop Rider/ReSharper from suggesting that folder as part of the namespace name. Once this PR is applied, the following folders will no longer be included in namespace name suggestions:

* `Assets`
* `Assets/Scripts`
* `Packages/<package-root>` - any top level folder under `Packages`
* `Packages/<package-root>/**` - any non-project folders. I.e. any folder under a package root that does not have `package.json`
* `Packages/<package-root>/**/Runtime`
* `Packages/<package-root>/**/Scripts`
* `Packages/<package-root>/**/Runtime/Scripts`
* `Packages/<package-root>/**/Scripts/Runtime`
* `Library/PackageCache/<package-root>`
* `Library/PackageCache/<package-root>/**` - any non-project folders. I.e. any folder under a package root that does not have `package.json`
* `Library/PackageCache/<package-root>/**/Runtime`
* `Library/PackageCache/<package-root>/**/Scripts`
* `Library/PackageCache/<package-root>/**/Runtime/Scripts`
* `Library/PackageCache/<package-root>/**/Scripts/Runtime`

This means that code in packages do not get the package name suggested, nor `Scripts`, `Runtime`, or a combination of the two. The patterns will also exclude any folder at the root of a package folder that does not contain `package.json`. This matches the use case of a git repo added to the `Packages` folder that does not have a package in the root folder of the repo (the package must be manually added via a `file:` reference in `Packages/manifest.json`)

The `Library/PackageCache` patterns stop ReSharper/Rider prompting if the user generates projects for referenced packages (which is arguably a bad idea, as these files should not be user editable, and are not in source control).

This does not fix all incorrect warnings for mismatched namespaces, as there are no widely accepted standards or conventions for namespaces or folder structure, but it does remove a number of poor suggestions. 

It is not currently possible to set a root namespace for packages (although this will be fixed in Unity 2020.2), so it is hard to get correct suggestions. The current recommendation is that the root folder of the assembly (not the package) has the same name as the root namespace. E.g. `Packages/com.unity.collections@0.0.9-preview.9/Unity.Collections/UnityCollections.asmdef` would have a root namespace of `Unity.Collections`. These changes support this scheme.

Fixes #1161 and addresses #1584 and [RIDER-36546](https://youtrack.jetbrains.com/issue/RIDER-36546)