### PR TITLE
[WIP] Add caching to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.gradle/wrapper
-          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Cache Gradle dependencies
         id: cache-gradle
         uses: actions/cache@v2
@@ -29,13 +29,13 @@ jobs:
           path: |
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
       - name: Cache test packages
         id: cache-test-packages
         uses: actions/cache@v2
         with:
           path: ~/JetTestPackages
-          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
+          key: ${{ runner.os }}-jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build and Tests
         shell: powershell
         run: powershell -File .\build.ps1 -RunTests -Verbose
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.gradle/wrapper
-          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Cache Gradle dependencies
         id: cache-gradle
         uses: actions/cache@v2
@@ -62,7 +62,7 @@ jobs:
           path: |
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.gradle/wrapper
-          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Cache Gradle dependencies
         id: cache-gradle
         uses: actions/cache@v2
@@ -89,7 +89,7 @@ jobs:
           path: |
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-test1-${{ hashFiles('rider/**/*.gradle*') }}
       - name: Cache test packages
         id: cache-test-packages
         uses: actions/cache@v2
@@ -39,6 +39,8 @@ jobs:
       - name: Build and Tests
         shell: powershell
         run: powershell -File .\build.ps1 -RunTests -Verbose
+      - name: Stop gradle daemons
+        run: rider/gradlew.bat --stop
   linux:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,40 @@ name: CI
 
 on: [pull_request]
 
+env:
+  JET_TEST_PACKAGES_DIR: ~/JetTestPackages
+
 jobs:
   windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Build JVM
+        id: cache-gradle-jvm
+        uses: actions/cache@v2
+        with:
+          path: rider/build/gradle-jvm
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+      - name: Cache Gradle Wrapper
+        id: cache-gradle-wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Cache Gradle dependencies
+        id: cache-gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            !~/.gradle/caches/**/com.jetbrains.intellij.rider
+          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+      - name: Cache test packages
+        id: cache-test-packages
+        uses: actions/cache@v2
+        with:
+          path: ~/JetTestPackages
+          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build and Tests
         shell: powershell
         run: powershell -File .\build.ps1 -RunTests -Verbose
@@ -14,6 +43,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Build JVM
+        id: cache-gradle-jvm
+        uses: actions/cache@v2
+        with:
+          path: rider/build/gradle-jvm
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+      - name: Cache Gradle Wrapper
+        id: cache-gradle-wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Cache Gradle dependencies
+        id: cache-gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            !~/.gradle/caches/**/com.jetbrains.intellij.rider
+          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+      - name: Cache test packages
+        id: cache-test-packages
+        uses: actions/cache@v2
+        with:
+          path: ~/JetTestPackages
+          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace
@@ -21,6 +76,32 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Build JVM
+        id: cache-gradle-jvm
+        uses: actions/cache@v2
+        with:
+          path: rider/build/gradle-jvm
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+      - name: Cache Gradle Wrapper
+        id: cache-gradle-wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Cache Gradle dependencies
+        id: cache-gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            !~/.gradle/caches/**/com.jetbrains.intellij.rider
+          key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
+      - name: Cache test packages
+        id: cache-test-packages
+        uses: actions/cache@v2
+        with:
+          path: ~/JetTestPackages
+          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,6 @@ jobs:
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
           key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
-      - name: Cache test packages
-        id: cache-test-packages
-        uses: actions/cache@v2
-        with:
-          path: ~/JetTestPackages
-          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace
@@ -96,12 +90,6 @@ jobs:
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider
           key: gradle-${{ hashFiles('rider/**/*.gradle*') }}
-      - name: Cache test packages
-        id: cache-test-packages
-        uses: actions/cache@v2
-        with:
-          path: ~/JetTestPackages
-          key: jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
       - name: Build
         shell: bash
         run: ./build.sh --info --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request]
 
 env:
-  JET_TEST_PACKAGES_DIR: ~/JetTestPackages
+  JET_TEST_PACKAGES_DIR: ${{ github.workspace }}/JetTestPackages
 
 jobs:
   windows:
@@ -28,7 +28,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches
-            !~/.gradle/caches/**/com.jetbrains.intellij.rider
+            !~/.gradle/caches/**/com.jetbrains.intellij.rider/**/*
           key: ${{ runner.os }}-gradle-test1-${{ hashFiles('rider/**/*.gradle*') }}
       - name: Cache test packages
         id: cache-test-packages
@@ -36,6 +36,8 @@ jobs:
         with:
           path: ~/JetTestPackages
           key: ${{ runner.os }}-jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
+      - name: Dump Gradle
+        run: tree ${{ github.workspace }}/.gradle
       - name: Build and Tests
         shell: powershell
         run: powershell -File .\build.ps1 -RunTests -Verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: rider/build/gradle-jvm
-          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build.gradle') }}
       - name: Cache Gradle Wrapper
         id: cache-gradle-wrapper
         uses: actions/cache@v2
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: rider/build/gradle-jvm
-          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build.gradle') }}
       - name: Cache Gradle Wrapper
         id: cache-gradle-wrapper
         uses: actions/cache@v2
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: rider/build/gradle-jvm
-          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build/gradle-jvm/**/*') }}
+          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build.gradle') }}
       - name: Cache Gradle Wrapper
         id: cache-gradle-wrapper
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Debug Action
+        uses: hmarr/debug-action@v1.0.0
       - name: Cache Build JVM
         id: cache-gradle-jvm
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request]
 
 env:
-  JET_TEST_PACKAGES_DIR: ${{ github.workspace }}/JetTestPackages
+  JET_TEST_PACKAGES_DIR: ${{ env.HOME }}/JetTestPackages
 
 jobs:
   windows:
@@ -35,12 +35,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/JetTestPackages
-          key: ${{ runner.os }}-jet-test-packages-${{ hashFiles('~/JetTestPackages/*/*.nupkg') }}
+          key: ${{ runner.os }}-jet-test-packages-no-hash
       - name: Dump Gradle
-        run: tree ${{ github.workspace }}/.gradle
+        run: tree ${{ env.HOME }}/.gradle
       - name: Build and Tests
         shell: powershell
-        run: powershell -File .\build.ps1 -RunTests -Verbose
+        run: powershell -File .\build.ps1 -Verbose
       - name: Stop gradle daemons
         run: rider/gradlew.bat --stop
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on: [pull_request]
 
-env:
-  JET_TEST_PACKAGES_DIR: ${{ env.HOME }}/JetTestPackages
-
 jobs:
   windows:
     runs-on: windows-latest
@@ -29,71 +26,19 @@ jobs:
           path: |
             ~/.gradle/caches
             !~/.gradle/caches/**/com.jetbrains.intellij.rider/**/*
-          key: ${{ runner.os }}-gradle-test1-${{ hashFiles('rider/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-test1-${{ hashFiles('rider/**/?*.gradle*') }}
       - name: Cache test packages
         id: cache-test-packages
         uses: actions/cache@v2
         with:
           path: ~/JetTestPackages
-          key: ${{ runner.os }}-jet-test-packages-no-hash
+          key: ${{ runner.os }}-jet-test-packages-no-hash1
       - name: Dump Gradle
         run: tree ${{ env.HOME }}/.gradle
-      - name: Build and Tests
+      - name: Build and Run Tests
         shell: powershell
-        run: powershell -File .\build.ps1 -Verbose
+        run: powershell -File .\build.ps1 -RunTests -Verbose
+        env:
+          JET_TEST_PACKAGES_DIR: ${{ env.HOME }}/JetTestPackages
       - name: Stop gradle daemons
         run: rider/gradlew.bat --stop
-  linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache Build JVM
-        id: cache-gradle-jvm
-        uses: actions/cache@v2
-        with:
-          path: rider/build/gradle-jvm
-          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build.gradle') }}
-      - name: Cache Gradle Wrapper
-        id: cache-gradle-wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Cache Gradle dependencies
-        id: cache-gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
-      - name: Build
-        shell: bash
-        run: ./build.sh --info --stacktrace
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache Build JVM
-        id: cache-gradle-jvm
-        uses: actions/cache@v2
-        with:
-          path: rider/build/gradle-jvm
-          key: ${{ runner.os }}-gradle-jvm-${{ hashFiles('rider/build.gradle') }}
-      - name: Cache Gradle Wrapper
-        id: cache-gradle-wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('rider/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Cache Gradle dependencies
-        id: cache-gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            !~/.gradle/caches/**/com.jetbrains.intellij.rider
-          key: ${{ runner.os }}-gradle-${{ hashFiles('rider/**/*.gradle*') }}
-      - name: Build
-        shell: bash
-        run: ./build.sh --info --stacktrace


### PR DESCRIPTION
Adds caching to the GitHub workflows:

- [x] Cache build JVM, per OS + based on hash of all files
- [x] Cache Gradle wrapper, with hash of `rider/gradle/wrapper/gradle-wrapper.properties`
- [x] Cache Gradle dependencies, excluding `com.intellij.jetbrains.rider`, which is updated frequently. Hash is of `.gradle` and `.gradle.kts` files
- [x] Cache test nuget packages. Test packages folder is moved to `~/JetTestPackages`, and cached based on hash of `.nupkg` files
- [ ] Cache Rider SDK. `~/.gradle/caches/**/com.jetbrains.intellij.rider`. Cache separately as it changes frequently, but still useful to cache for multiple builds. This cache could get large quickly, and could possibly cause evictions in other caches.
- [ ] Cache nuget packages. Not done yet as `~/.nuget/packages` also contains the expanded packages from the frequently updated SDK gradle dependency