### PR TITLE
Handle namespace suggestions for external packages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 - Add Unity code cleanup patterns that do not reorder serialised fields ([#88](https://github.com/JetBrains/resharper-unity/issues/88), [#1676](https://github.com/JetBrains/resharper-unity/pull/1676))
 - Use `Range` attribute to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673))
-- Improve namespace suggestions for packages ([#1161](https://github.com/JetBrains/resharper-unity/issues/1161), [RIDER-36546](https://youtrack.jetbrains.com/issue/RIDER-36546), [#1677](https://github.com/JetBrains/resharper-unity/pull/1677))
+- Improve namespace suggestions for packages ([#1161](https://github.com/JetBrains/resharper-unity/issues/1161), [RIDER-36546](https://youtrack.jetbrains.com/issue/RIDER-36546), [#1677](https://github.com/JetBrains/resharper-unity/pull/1677), [#1689](https://github.com/JetBrains/resharper-unity/pull/1689))
 - Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor ([#1272](https://github.com/JetBrains/resharper-unity/issues/1272), [#1661](https://github.com/JetBrains/resharper-unity/pull/1661))
+- Rider: Automatically use UnityYamlMerge to merge asset files ([RIDER-33411](https://youtrack.jetbrains.com/issue/RIDER-33411), [#1682](https://github.com/JetBrains/resharper-unity/pull/1682))
 - Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages ([#1667](https://github.com/JetBrains/resharper-unity/pull/1667))
 
 ### Changed
@@ -28,6 +29,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Better support for prefab modifications in Find Usages and showing Inspector values ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Show method handlers for Unity events in the editor ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Disable "Start Unity" action when Unity is running ([RIDER-36108](https://youtrack.jetbrains.com/issue/RIDER-36108), [#1554](https://github.com/JetBrains/resharper-unity/pull/1554))
+- Rider: Unity Log view optionally scrolls to show new items ([RIDER-14377](https://youtrack.jetbrains.com/issue/RIDER-14377), [#1678](https://github.com/JetBrains/resharper-unity/pull/1678))
+- Rider: Play/pause/step buttons no longer disabled while Rider is indexing ([#1678](https://github.com/JetBrains/resharper-unity/pull/1678))
 
 ### Fixed
 

--- a/resharper/resharper-unity/src/CSharp/Psi/Util/ExternalPackageCustomNamespaceProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/Util/ExternalPackageCustomNamespaceProvider.cs
@@ -1,0 +1,142 @@
+using JetBrains.Annotations;
+using JetBrains.Diagnostics;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Properties;
+using JetBrains.ProjectModel.Properties.Managed;
+using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Util
+{
+    [SolutionComponent]
+    public class ExternalPackageCustomNamespaceProvider : ICustomDefaultNamespaceProvider
+    {
+        private static readonly Key<string> ourCalculatedDefaultNamespaceKey = new Key<string>("Unity::ExternalPackage::DefaultNamespace");
+
+        public ExpectedNamespaceAndNamespaceChecker CalculateCustomNamespace(IProjectItem projectItem, PsiLanguageType language)
+        {
+            var project = projectItem.GetProject().NotNull();
+            if (!ShouldProvideCustomNamespace(project, projectItem, language))
+                return new ExpectedNamespaceAndNamespaceChecker(null);
+
+            var namespaceFolderProperty = project.GetComponent<NamespaceFolderProperty>();
+            return new ExpectedNamespaceAndNamespaceChecker(CalculateNamespace(projectItem, language.LanguageService(),
+                namespaceFolderProperty));
+        }
+
+        private static bool ShouldProvideCustomNamespace(IProject project, IProjectItem projectItem, PsiLanguageType language)
+        {
+            if (!project.IsUnityProject() || !language.Is<CSharpLanguage>())
+                return false;
+
+            // If the project item lives under the solution location, we don't need to do anything. The default
+            // namespace handling, coupled with our namespace provider settings in NamespaceProviderProjectSettingsProvider
+            // means everything works
+            if (project.Location.IsPrefixOf(projectItem.Location))
+                return false;
+
+            // If the project has a default namespace, do nothing. When the project is based on an .asmdef file, the
+            // linked root folder is the location of the .asmdef file, and the namespaces we want are relative to the
+            // .asmdef file's default namespace
+            var buildSettings = project.ProjectProperties.BuildSettings as IManagedProjectBuildSettings;
+            var defaultNamespace = buildSettings?.DefaultNamespace;
+            if (!defaultNamespace.IsNullOrEmpty())
+                return false;
+
+            // Is the root folder a linked folder, pointing externally to the solution?
+            var rootFolder = GetRootFolder(projectItem);
+            return rootFolder?.IsLinked == true;
+        }
+
+        [CanBeNull]
+        private static IProjectFolder GetRootFolder(IProjectItem projectItem)
+        {
+            var projectFolder = projectItem.ParentFolder;
+            while (projectFolder != null)
+            {
+                if (projectFolder.ParentFolder is IProject)
+                    return projectFolder;
+
+                projectFolder = projectFolder.ParentFolder;
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private static string CalculateNamespace([NotNull] IProjectItem item, LanguageService languageService,
+                                                 NamespaceFolderProperty namespaceFolderProperty)
+        {
+            if (item.ParentFolder is IProject && item is IProjectFolder rootFolder)
+                return CalculateNamespaceForProjectFromRootFolder(item.GetProject(), rootFolder, languageService);
+
+            var parentFolder = item.ParentFolder;
+            if (parentFolder == null) return null;
+
+            var parentNamespace = CalculateNamespace(parentFolder, languageService, namespaceFolderProperty);
+            if (parentNamespace == null)
+                return null;
+
+            if (item is IProjectFolder folder)
+            {
+                var isNamespaceProvider = namespaceFolderProperty.GetNamespaceFolderProperty(folder);
+                if (!isNamespaceProvider)
+                    return parentNamespace;
+            }
+
+            if (item is IProjectFile)
+                return parentNamespace;
+
+            var suffix = NamespaceFolderUtil.MakeValidQualifiedName(item.Name, languageService);
+
+            if (parentNamespace.Length > 0)
+            {
+                if (string.IsNullOrEmpty(suffix)) return parentNamespace;
+                return $"{parentNamespace}.{suffix}";
+            }
+
+            return suffix;
+        }
+
+        [CanBeNull]
+        private static string CalculateNamespaceForProjectFromRootFolder(
+            [CanBeNull] IProject project, IProjectFolder rootFolder, LanguageService languageService)
+        {
+            if (project == null || !rootFolder.IsLinked || rootFolder.Path == null) return null;
+
+            var calculatedNamespace = project.GetData(ourCalculatedDefaultNamespaceKey);
+            if (calculatedNamespace != null)
+                return calculatedNamespace;
+
+            var location = rootFolder.Path.ReferencedFolderPath;
+            var packageJsonDirectory = FileSystemUtil.TryGetDirectoryNameOfFileAbove(location, "package.json");
+            if (packageJsonDirectory != null)
+            {
+                var path = location.MakeRelativeTo(packageJsonDirectory);
+
+                // MAKE SURE TO KEEP UP TO DATE WITH THE RULES IN NamespaceProviderProjectSettingsProvider
+                if (path.StartsWith("Runtime/Scripts"))
+                    path = path.RemovePrefix("Runtime/Scripts");
+                else if (path.StartsWith("Scripts/Runtime"))
+                    path = path.RemovePrefix("Scripts/Runtime");
+                else if (path.StartsWith("Runtime"))
+                    path = path.RemovePrefix("Runtime");
+                else if (path.StartsWith("Scripts"))
+                    path = path.RemovePrefix("Scripts");
+
+                foreach (var pathComponent in path.Components)
+                {
+                    var name = NamespaceFolderUtil.MakeValidQualifiedName(pathComponent.ToString(), languageService);
+                    calculatedNamespace = calculatedNamespace.IsNullOrEmpty() ? name : $"{calculatedNamespace}.{name}";
+                }
+            }
+
+            project.PutData(ourCalculatedDefaultNamespaceKey, calculatedNamespace);
+
+            return calculatedNamespace;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Settings/NamespaceProviderProjectSettingsProvider.cs
@@ -121,6 +121,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
                 // The folder will be linked if the project's files belong to a package that is external to the solution
                 // folder. With a linked folder, the namespace provider must be the actual path, relative to the parent
                 // folder, rather than the visible path in the Solution Explorer
+                //
+                // NOTE: KEEP UP TO DATE WITH ExternalPackageCustomNamespaceProvider!
                 if (folder.IsLinked && folder.ParentFolder != null)
                     path = folder.Location.ConvertToRelativePath(folder.ParentFolder.Location).FullPath;
                 ExcludeFolderFromNamespace(mountPoint, path + @"\Runtime");

--- a/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
+++ b/resharper/resharper-unity/src/resharper-unity.resharper.nuspec
@@ -40,7 +40,7 @@ Added:
 
 - Add Unity code cleanup patterns that do not reorder serialised fields (#88, #1676)
 - Use Range attribute to provide hints to integer dataflow analysis (#1673)
-- Improve namespace suggestions for packages (#1161, RIDER-36546, #1677)
+- Improve namespace suggestions for packages (#1161, RIDER-36546, #1677, #1689)
 
 Changed:
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -304,9 +304,12 @@
 <ul>
   <li>Add Unity code cleanup patterns that do not reorder serialised fields (<a href="https://github.com/JetBrains/resharper-unity/issues/88">#88</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1676">#1676</a>)</li>
   <li>Use <tt>Range</tt> attribute to provide hints to integer dataflow analysis (<a href="https://github.com/JetBrains/resharper-unity/pull/1673">#1673</a>)</li>
-  <li>Improve namespace suggestions for packages (<a href="https://github.com/JetBrains/resharper-unity/issues/1161">#1161</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-36546">RIDER-36546</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1677">#1677</a>)</li>
+  <li>Improve namespace suggestions for packages (<a href="https://github.com/JetBrains/resharper-unity/issues/1161">#1161</a>, <a href="https://youtrack.jetbrains.com/issue/RIDER-36546">RIDER-36546</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1677">#1677</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1689">#1689</a>)</li>
   <li>Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor (<a href="https://github.com/JetBrains/resharper-unity/issues/1272">#1272</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1661">#1661</a>)</li>
+  <li>Rider: Automatically use UnityYamlMerge to merge asset files (<a href="https://youtrack.jetbrains.com/issue/RIDER-33411">RIDER-33411</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1682">#1682</a>)</li>
   <li>Rider: Add sample text for "Unity", "ShaderLab" and "Cg/HLSL" Colour Scheme options pages (<a href="https://github.com/JetBrains/resharper-unity/pull/1667">#1667</a>)</li>
+  <li>Rider: Unity Log view optionally scrolls to show new items (<a href="https://youtrack.jetbrains.com/issue/RIDER-14377">RIDER-14377</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1678">#1678</a>)</li>
+  <li>Rider: Play/pause/step buttons no longer disabled while Rider is indexing (<a href="https://github.com/JetBrains/resharper-unity/pull/1678">#1678</a>)</li>
 </ul>
 </p>
 <p>
@@ -318,6 +321,8 @@
   <li>Rider: Better support for prefab modifications in Find Usages and showing Inspector values (<a href="https://github.com/JetBrains/resharper-unity/pull/1645">#1645</a>)</li>
   <li>Rider: Show method handlers for Unity events in the editor (<a href="https://github.com/JetBrains/resharper-unity/pull/1645">#1645</a>)</li>
   <li>Rider: Disable "Start Unity" action when Unity is running (<a href="https://youtrack.jetbrains.com/issue/RIDER-36108">RIDER-36108</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1554">#1554</a>)</li>
+  <li>Rider: Unity Log view optionally scrolls to show new items (<a href="https://youtrack.jetbrains.com/issue/RIDER-14377">RIDER-14377<a/>, <a href="https://github.com/JetBrains/resharper-unity/pull/1678">#1678</a>)</li>
+  <li>Rider: Play/pause/step buttons no longer disabled while Rider is indexing (<a href="https://github.com/JetBrains/resharper-unity/pull/1678">#1678</a>)</li>
 </ul>
 </p>
 <p>


### PR DESCRIPTION
This PR expands on #1677 to support correct namespace suggestions for packages that are outside of the normal Unity project structure and included via `file:` references in `Packages/manifest.json`. It handles projects that live under the normal Unity project folder location (but not under `Assets` or `Packages`) and also projects outside of the solution structure completely.

To recap, the idea is this:

* A package owner has no control over the location of a package, or the name of its root folder, so these things should not affect the namespace of the code. (E.g. a package can live in `Packages`, `Library/PackageCache` or anywhere else on disk, and when under `Library/PackageCache`, the name can contain ID and version, but won't have this name when cloned from GitHub)
* An assembly definition file is in a specific location with a package or `Assets`, and those folder names should affect the namespace. Moving a package will not affect this.
* Certain folder names should be ignored - `Scripts`, `Runtime`, `Scripts/Runtime` and `Runtime/Scripts`.