### PR TITLE
Treat Unity's compiled assemblies as user code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix meta file handling when references to Unity assemblies are invalid ([#1623](https://github.com/JetBrains/resharper-unity/pull/1623))
 - Public fields of type `Action` are no longer treated as serialised fields ([#1605](https://github.com/JetBrains/resharper-unity/issues/1605), [#1638](https://github.com/JetBrains/resharper-unity/pull/1638))
 - Fix incorrect method signature validation for methods marked with `OnOpenedAsset` ([#1053](https://github.com/JetBrains/resharper-unity/issues/1053), [#1679](https://github.com/JetBrains/resharper-unity/pull/1679))
+- Rider: Fix debugger sometimes treating user code as external code ([#1671](https://github.com/JetBrains/resharper-unity/issues/1671), [#1697](https://github.com/JetBrains/resharper-unity/pull/1697))
 - Rider: Fix grouping assets by directory in Find Usages results ([#1668](https://github.com/JetBrains/resharper-unity/pull/1668))
 - Rider: Fix exception trying to upgrade Unity editor plugin ([RIDER-42475](https://youtrack.jetbrains.com/issue/RIDER-42475), [#1658](https://github.com/JetBrains/resharper-unity/pull/1658))
 - Rider: Fix unit tests not running unless Rider has focus ([RIDER-37990](https://youtrack.jetbrains.com/issue/RIDER-37990), [#1672](https://github.com/JetBrains/resharper-unity/pull/1672))

--- a/debugger/src/debugger.csproj
+++ b/debugger/src/debugger.csproj
@@ -8,7 +8,5 @@
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
-    <ItemGroup>
-    </ItemGroup>
     <Import Project="$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props" Condition="Exists('$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props')" />
 </Project>

--- a/resharper/resharper-unity/src/Rider/Host/DebuggerOutputAssemblies/UnityDebuggerOutputAssembliesProviderHost.cs
+++ b/resharper/resharper-unity/src/Rider/Host/DebuggerOutputAssemblies/UnityDebuggerOutputAssembliesProviderHost.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Debugger.Common.OutputAssemblies;
+using JetBrains.Application.Infra;
+using JetBrains.Debugger.Host.DebuggerOutputAssemblies;
+using JetBrains.Lifetimes;
+using JetBrains.Metadata.Utils;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Host.Features.Debugger.Utils;
+using JetBrains.ReSharper.Resources.Shell;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.Host.DebuggerOutputAssemblies
+{
+    // Unity sets up the C# projects to build to Temp\Bin\Debug, but doesn't use these at runtime. It compiles its own
+    // versions to Library/ScriptAssemblies, optionally post-processing/IL rewriting, and loads them from here. This can
+    // affect the debugger's "user code" handling - it can mark user code as external code. The debugger reads metadata
+    // from assemblies in the project's output folder, and this is enough to recognise the assemblies that Unity
+    // compiles and loads from another location (based on assembly name, version, culture, etc.)
+    // But if the C# project has not been built, the debugger can't read the metadata and can only go by name. This
+    // isn't enough to match the Unity assemblies, and they are marked as external code, and can be hidden in the stack
+    // Note that this doesn't affect player debugging, as remote debugging doesn't seem to get the required assembly
+    // details
+    [SolutionComponent]
+    public class UnityDebuggerOutputAssembliesProviderHost : IDebuggerOutputAssembliesProvider
+    {
+        private readonly ISolution mySolution;
+        private readonly ILogger myLogger;
+
+        public UnityDebuggerOutputAssembliesProviderHost(ISolution solution, ILogger logger)
+        {
+            mySolution = solution;
+            myLogger = logger;
+        }
+
+        public Task<IReadOnlyList<DebuggerOutputAssemblyInfo>> GetOutputAssembliesInfoAsync(Lifetime lifetime)
+        {
+            return lifetime.StartBackgroundRead(() =>
+                (IReadOnlyList<DebuggerOutputAssemblyInfo>) GetOutputAssembliesInfoInternal()
+                    .ToList());
+        }
+
+        private IEnumerable<DebuggerOutputAssemblyInfo> GetOutputAssembliesInfoInternal()
+        {
+            var assemblyInfoDatabase = mySolution.GetComponent<AssemblyInfoDatabase>();
+            foreach (var project in mySolution.GetAllProjects().Where(x => x.IsProjectFromUserView()))
+            {
+                var configurations = project.ProjectProperties.ActiveConfigurations;
+                foreach (var targetFrameworkId in project.TargetFrameworkIds)
+                {
+                    var pathMap = configurations.TryGetPathMap(targetFrameworkId);
+                    var outputAssemblyName = project.GetOutputFilePath(targetFrameworkId).Name;
+                    var projectLocation = project.ProjectFileLocation.Parent;
+                    var unityOutputPath =
+                        projectLocation.Combine("Library/ScriptAssemblies").Combine(outputAssemblyName);
+                    if (!unityOutputPath.IsEmpty && unityOutputPath.IsAbsolute)
+                    {
+                        var assemblyNameInfo = assemblyInfoDatabase.GetAssemblyName(unityOutputPath);
+                        if (assemblyNameInfo.IsNullOrEmpty())
+                        {
+                            // The file should always exist - Unity will make sure it's there, as long as there are no
+                            // compile errors. And if there are compile errors (or the file doesn't exist for other
+                            // reasons), then debugging is unlikely to be successful, so there's nothing useful we can
+                            // do here
+                            myLogger.Warn("Cannot create assembly name for {0}", unityOutputPath);
+                            continue;
+                        }
+
+                        yield return new DebuggerOutputAssemblyInfo(assemblyNameInfo, projectLocation.FullPath,
+                            unityOutputPath.FullPath, in pathMap);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -333,6 +333,7 @@
   <li>Fix meta file handling when references to Unity assemblies are invalid (<a href="https://github.com/JetBrains/resharper-unity/pull/1623">#1623</a>)</li>
   <li>Public fields of type <tt>Action</tt> are no longer treated as serialised fields (<a href="https://github.com/JetBrains/resharper-unity/issues/1605">#1605</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1638">#1638</a>)</li>
   <li>Fix incorrect method signature validation for methods marked with <tt>OnOpenedAsset<tt> (<a href="https://github.com/JetBrains/resharper-unity/issues/1053">#1053</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1679">#1679</a>)</li>
+  <li>Rider: Fix debugger sometimes treating user code as external code (<a href="https://github.com/JetBrains/resharper-unity/issues/1671">#1671</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1697">#1697</a>)</li>
   <li>Rider: Fix grouping assets by directory in Find Usages results (<a href="https://github.com/JetBrains/resharper-unity/pull/1668">#1668</a>)</li>
   <li>Rider: Fix exception trying to upgrade Unity editor plugin (<a href="https://youtrack.jetbrains.com/issue/RIDER-42475">RIDER-42475</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1658">#1658</a>)</li>
   <li>Rider: Fix unit tests not running unless Rider has focus (<a href="https://youtrack.jetbrains.com/issue/RIDER-37990">RIDER-37990</a>, <a href="https://github.com/JetBrains/resharper-unity/pull/1672">#1672</a>)</li>


### PR DESCRIPTION
Unity doesn't use the assemblies compiled to the C# project output path of `Temp/Bin/Debug/`. It controls compilation and saves the assemblies (possibly with IL rewriting) in `Library/ScriptAssemblies`. If the C# project has not been built, all user code is treated as library code.

This PR treats any project output that also exists in `Library/ScriptAssemblies` as user code.

Fixes #1671