### PR TITLE
Validate gradle-wrapper.jar before running GH workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,17 @@ name: CI
 on: [pull_request]
 
 jobs:
+  # Make sure we only invoke known gradle-wrapper.jar files
+  gradleValidation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
   windows:
+    needs: gradleValidation
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -11,6 +21,7 @@ jobs:
         shell: powershell
         run: powershell -File .\build.ps1 -RunTests -Verbose
   linux:
+    needs: gradleValidation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +29,7 @@ jobs:
         shell: bash
         run: ./build.sh --info --stacktrace
   macos:
+    needs: gradleValidation
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Make sure we only use known `gradle-wrapper.jar` files before they get invoked as part of the build.