### PR TITLE
Hide .meta files from navigation bar

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -15,6 +15,7 @@ import com.jetbrains.rider.projectView.views.FileSystemNodeBase
 import com.jetbrains.rider.projectView.views.SolutionViewNode
 import com.jetbrains.rider.projectView.views.addNonIndexedMark
 import com.jetbrains.rider.projectView.views.navigateToSolutionView
+import com.jetbrains.rider.projectView.views.solutionExplorer.SolutionExplorerViewPane
 import icons.UnityIcons
 
 // Packages are included in a project by listing in the "dependencies" node of Packages/manifest.json. Packages can
@@ -294,7 +295,7 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
 
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
 
-        if (UnityExplorer.getInstance(project!!).showHiddenItems) {
+        if (SolutionExplorerViewPane.getInstance(myProject).myShowAllFiles) {
             return super.calculateChildren()
         }
 
@@ -314,14 +315,14 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
     }
 
     override fun canNavigateToSource(): Boolean {
-        if (UnityExplorer.getInstance(project!!).showHiddenItems) {
+        if (SolutionExplorerViewPane.getInstance(myProject).myShowAllFiles) {
             return super.canNavigateToSource()
         }
         return true
     }
 
     override fun navigate(requestFocus: Boolean) {
-        if (UnityExplorer.getInstance(project!!).showHiddenItems) {
+        if (SolutionExplorerViewPane.getInstance(myProject).myShowAllFiles) {
             return super.navigate(requestFocus)
         }
 
@@ -336,8 +337,9 @@ class BuiltinPackageNode(project: Project, private val packageData: PackageData)
     override fun update(presentation: PresentationData) {
         presentation.addText(name, SimpleTextAttributes.REGULAR_ATTRIBUTES)
         presentation.setIcon(UnityIcons.Explorer.BuiltInPackage)
-        if (UnityExplorer.getInstance(myProject).showHiddenItems)
+        if (SolutionExplorerViewPane.getInstance(myProject).myShowAllFiles) {
             presentation.addNonIndexedMark(myProject, virtualFile)
+        }
 
         val tooltip = getPackageTooltip(name, packageData)
         if (tooltip != name) {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ide/navigationToolbar/UnityNavBarModelExtension.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ide/navigationToolbar/UnityNavBarModelExtension.kt
@@ -1,0 +1,39 @@
+package com.jetbrains.rider.plugins.unity.ide.navigationToolbar
+
+import com.intellij.ide.navigationToolbar.AbstractNavBarModelExtension
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.jetbrains.rider.plugins.unity.ideaInterop.fileTypes.yaml.UnityYamlFileType
+import com.jetbrains.rider.projectView.views.solutionExplorer.SolutionExplorerViewPane
+
+// This class hides .meta files from the navigation bar, and they can be shown again using the "show all files" setting
+// in Solution Explorer or Unity Explorer.
+// We don't hide folders such as Library, obj and Temp because the navbar is a view of the filesystem, rather than a
+// view of the project model (in IntelliJ that's essentially the same thing). We could ignore these folders, but what
+// should happen to other files/folders in the project root? We hide `.meta` because there is one for each file and
+// folder, and they create a lot of noise.
+// The navbar only lists files and folders that are not already excluded by the File Types | Ignored Files and Folders
+// list. This means we don't see `.git`, but it also means `*~` is filtered, which impacts Unity's "hidden" folders,
+// such as `Documentation~` (named like this so the asset database doesn't import the files). We can't override this
+// setting (mainly because it's hardcoded, and a global setting, not per-project), so we will have some files shown in
+// the Unity Explorer, but not shown in the navbar.
+class UnityNavBarModelExtension : AbstractNavBarModelExtension() {
+    override fun getPresentableText(o: Any?): String? = null
+
+    override fun adjustElement(psiElement: PsiElement) =
+        if (shouldHide(psiElement)) null else super.adjustElement(psiElement)
+
+    private fun shouldHide(psiElement: PsiElement) = isMetaFile(psiElement) && !shouldShowMetaFiles(psiElement.project)
+
+    private fun shouldShowMetaFiles(project: Project): Boolean {
+        return SolutionExplorerViewPane.getInstance(project).myShowAllFiles
+    }
+
+    private fun isMetaFile(psiElement: PsiElement): Boolean {
+        if (psiElement is PsiFile) {
+            return psiElement.fileType == UnityYamlFileType && psiElement.name.endsWith(".meta", false)
+        }
+        return false
+    }
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,8 @@
     <standardResourceProvider implementation="com.jetbrains.rider.plugins.unity.settings.fileLayout.AdditionalFileLayoutStandardResourceProvider"/>
     <xml.schemaProvider implementation="com.jetbrains.rider.plugins.unity.settings.fileLayout.AdditionalFileLayoutSchemaProvider"/>
 
+    <navbar implementation="com.jetbrains.rider.plugins.unity.ide.navigationToolbar.UnityNavBarModelExtension"/>
+
     <projectService serviceImplementation="com.jetbrains.rider.plugins.unity.ui.UnityUIManager"/>
     <projectService serviceImplementation="com.jetbrains.rider.UnityProjectDiscoverer"/>
 


### PR DESCRIPTION
This PR will:

* Unify the "show all files" setting between Unity Explorer and Solution Explorer
* Filter out `.meta` files from the navigation bar, as they introduce too much noise. They can be shown again with the "show all files" setting.

Fixes [RIDER-28425](https://youtrack.jetbrains.com/issue/RIDER-28425)