### PR TITLE
Use MinAttribute as ValueRange provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Added
 
 - Add Unity code cleanup patterns that do not reorder serialised fields ([#88](https://github.com/JetBrains/resharper-unity/issues/88), [#1676](https://github.com/JetBrains/resharper-unity/pull/1676))
-- Use `Range` attribute to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673))
+- Use `Range` and `Min` attributes to provide hints to integer dataflow analysis ([#1673](https://github.com/JetBrains/resharper-unity/pull/1673), [#1714](https://github.com/JetBrains/resharper-unity/pull/1714))
 - Improve namespace suggestions for packages ([#1161](https://github.com/JetBrains/resharper-unity/issues/1161), [RIDER-36546](https://youtrack.jetbrains.com/issue/RIDER-36546), [#1677](https://github.com/JetBrains/resharper-unity/pull/1677), [#1689](https://github.com/JetBrains/resharper-unity/pull/1689))
 - Add Unity specific spell check dictionary ([#1187](https://github.com/JetBrains/resharper-unity/issues/1187), [#1570](https://github.com/JetBrains/resharper-unity/pull/1570))
 - Rider: Add "pausepoints" a type of breakpoint that doesn't suspend code execution, but pauses the Unity editor ([#1272](https://github.com/JetBrains/resharper-unity/issues/1272), [#1661](https://github.com/JetBrains/resharper-unity/pull/1661))

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProvider.cs
@@ -52,7 +52,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
         {
             if (GetCoroutineMustUseReturnValueAttribute(element, out var collection)) return collection;
             if (GetPublicAPIImplicitlyUsedAttribute(element, out collection)) return collection;
-            if (GetValueRangeFromRangeAttribute(element, out collection)) return collection;
+            if (GetValueRangeAttribute(element, out collection)) return collection;
 
             return EmptyList<IAttributeInstance>.Instance;
         }
@@ -119,12 +119,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
         }
 
         // Treat Unity's RangeAttribute as ReSharper's ValueRangeAttribute annotation
-        private bool GetValueRangeFromRangeAttribute(IClrDeclaredElement element,
-            out ICollection<IAttributeInstance> collection)
+        private bool GetValueRangeAttribute(IClrDeclaredElement element,
+                                            out ICollection<IAttributeInstance> collection)
         {
             collection = EmptyList<IAttributeInstance>.InstanceList;
 
             if (!(element is IField field) || !element.IsFromUnityProject()) return false;
+
+            if (!myUnityApi.IsSerialisedField(field))
+                return false;
 
             // Integer value analysis only works on integers, but it will make use of annotations applied to values that
             // are convertible to int, such as byte/sbyte and short/ushort. It doesn't currently use values applied to
@@ -140,9 +143,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
 
             foreach (var attributeInstance in field.GetAttributeInstances(KnownTypes.RangeAttribute, false))
             {
-                if (!myUnityApi.IsSerialisedField(field))
-                    continue;
-
                 // Values are floats, but applied to an integer field. Convert to integer values
                 var unityFrom = attributeInstance.PositionParameter(0);
                 var unityTo = attributeInstance.PositionParameter(1);
@@ -155,22 +155,42 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeAnnotations
 
                 // The check above means this is not null. We take the floor, because that's how Unity works.
                 // E.g. Unity's Inspector treats [Range(1.7f, 10.9f)] as between 1 and 10 inclusive
-                var f = Math.Floor((float) unityFrom.ConstantValue.Value.NotNull());
-                var t = Math.Floor((float) unityTo.ConstantValue.Value.NotNull());
+                var from = Convert.ToInt64(Math.Floor((float) unityFrom.ConstantValue.Value.NotNull()));
+                var to = Convert.ToInt64(Math.Floor((float) unityTo.ConstantValue.Value.NotNull()));
 
-                // The ctorArguments lambda result is not cached, so let's allocate everything up front
-                var from = new AttributeValue(new ConstantValue(Convert.ToInt64(Math.Floor(f)), predefinedType.Long));
-                var to = new AttributeValue(new ConstantValue(Convert.ToInt64(Math.Floor(t)), predefinedType.Long));
-                var args = new[] {from, to};
+                collection = CreateRangeAttributeInstance(element, predefinedType, from, to);
+                return true;
+            }
 
-                collection = new[]
-                {
-                    new SpecialAttributeInstance(ourValueRangeAttributeFullName, GetModule(element), () => args)
-                };
+            foreach (var attributeInstance in field.GetAttributeInstances(KnownTypes.MinAttribute, false))
+            {
+                var unityMinValue = attributeInstance.PositionParameter(0);
+
+                if (!unityMinValue.IsConstant || !unityMinValue.ConstantValue.IsFloat())
+                    continue;
+
+                // Even though the constructor for ValueRange takes long, it only works with int.MaxValue
+                var min = Convert.ToInt64(Math.Floor((float) unityMinValue.ConstantValue.Value.NotNull()));
+                var max = int.MaxValue;
+
+                collection = CreateRangeAttributeInstance(element, predefinedType, min, max);
                 return true;
             }
 
             return false;
+        }
+
+        private SpecialAttributeInstance[] CreateRangeAttributeInstance(IClrDeclaredElement element,
+                                                                        PredefinedType predefinedType,
+                                                                        long from, long to)
+        {
+            var args = new[]
+            {
+                new AttributeValue(new ConstantValue(from, predefinedType.Long)),
+                new AttributeValue(new ConstantValue(to, predefinedType.Long))
+            };
+
+            return new[] {new SpecialAttributeInstance(ourValueRangeAttributeFullName, GetModule(element), () => args)};
         }
 
         private IPsiModule GetModule(IClrDeclaredElement element)

--- a/resharper/resharper-unity/src/KnownTypes.cs
+++ b/resharper/resharper-unity/src/KnownTypes.cs
@@ -24,6 +24,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName LayerMask = new ClrTypeName("UnityEngine.LayerMask");
         public static readonly IClrTypeName Material = new ClrTypeName("UnityEngine.Material");
         public static readonly IClrTypeName MaterialPropertyBlock = new ClrTypeName("UnityEngine.MaterialPropertyBlock");
+        public static readonly IClrTypeName MinAttribute = new ClrTypeName("UnityEngine.MinAttribute");
         public static readonly IClrTypeName MonoBehaviour = new ClrTypeName("UnityEngine.MonoBehaviour");
         public static readonly IClrTypeName Object = new ClrTypeName("UnityEngine.Object");
         public static readonly IClrTypeName Physics = new ClrTypeName("UnityEngine.Physics");

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/MinAttributeAsValueRangeAttribute.cs
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/MinAttributeAsValueRangeAttribute.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Diagnostics;
+using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    [Min(100)] public int intValue;
+    [Min(100)] public uint uintValue;
+    [Min(100)] public long longValue;
+    [Min(100)] public ulong ulongValue;
+    [Min(100)] public byte byteValue;
+    [Min(100)] public sbyte sbyteValue;
+    [Min(100)] public short shortValue;
+    [Min(100)] public ushort ushortValue;
+
+    [Min(1.3f)] public int intWithFloatRange;
+
+    [Min(100)] private int nonSerialisedField;
+
+    public void Update()
+    {
+        // Only the types that are implicitly converted into int will have
+        // integer value analysis warnings
+        if (intValue < 100) { }
+        if (uintValue < 100) { }
+        if (longValue < 100) { }
+        if (ulongValue < 100) { }
+        if (byteValue < 100) { }
+        if (sbyteValue < 100) { }
+        if (shortValue < 100) { }
+        if (ushortValue < 100) { }
+
+        if (nonSerialisedField < 100) { }
+
+        if (intWithFloatRange < 1) { }
+        if (intWithFloatRange == 0) { }
+        if (intWithFloatRange == 1) { }
+        if (intWithFloatRange == 2) { }
+    }
+
+    public void LateUpdate()
+    {
+        if (intValue > 500) { }
+        if (uintValue > 500) { }
+        if (longValue > 500) { }
+        if (ulongValue > 500) { }
+        if (byteValue > 500) { }
+        if (sbyteValue > 500) { }
+        if (shortValue > 500) { }
+        if (ushortValue > 500) { }
+    }
+}
+
+// We contribute a custom attribute instance when we see RangeAttribute on an
+// int field. In a production context, this attribute instance resolves with
+// JetBrains.Annotations loaded from the install directory by the external
+// annotations module. This doesn't happen in a test context, so we have to
+// provide the class here in the test, so there's something to resolve against.
+// Other annotation based tests can work because Unity.Engine includes an old
+// subset of JetBrains.Annotations
+//
+// ReSharper disable All
+namespace JetBrains.Annotations
+{
+  [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Delegate, AllowMultiple = true)]
+  [Conditional("JETBRAINS_ANNOTATIONS")]
+  public sealed class ValueRangeAttribute : Attribute
+  {
+    public object From { get; }
+
+    public object To { get; }
+
+    public ValueRangeAttribute(long from, long to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(ulong from, ulong to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(long value) => this.From = this.To = (object) value;
+
+    public ValueRangeAttribute(ulong value) => this.From = this.To = (object) value;
+  }
+}
+// ReSharper enable All
+

--- a/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/MinAttributeAsValueRangeAttribute.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Psi/CodeAnnotations/MinAttributeAsValueRangeAttribute.cs.gold
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Diagnostics;
+using UnityEngine;
+
+public class MyMonoBehaviour : MonoBehaviour
+{
+    [Min(100)] public int intValue;
+    [Min(100)] public uint uintValue;
+    [Min(100)] public long longValue;
+    [Min(100)] public ulong ulongValue;
+    [Min(100)] public byte byteValue;
+    [Min(100)] public sbyte sbyteValue;
+    [Min(100)] public short shortValue;
+    [Min(100)] public ushort ushortValue;
+
+    [Min(1.3f)] public int intWithFloatRange;
+
+    [Min(100)] private int nonSerialisedField;
+
+    public void Update()
+    {
+        // Only the types that are implicitly converted into int will have
+        // integer value analysis warnings
+        if (|intValue < 100|(0)) { }
+        if (uintValue < 100) { }
+        if (longValue < 100) { }
+        if (ulongValue < 100) { }
+        if (|byteValue < 100|(1)) { }
+        if (|sbyteValue < 100|(2)) { }
+        if (|shortValue < 100|(3)) { }
+        if (|ushortValue < 100|(4)) { }
+
+        if (nonSerialisedField < 100) { }
+
+        if (|intWithFloatRange < 1|(5)) { }
+        if (|intWithFloatRange == 0|(6)) { }
+        if (intWithFloatRange == 1) { }
+        if (intWithFloatRange == 2) { }
+    }
+
+    public void LateUpdate()
+    {
+        if (intValue > 500) { }
+        if (uintValue > 500) { }
+        if (longValue > 500) { }
+        if (ulongValue > 500) { }
+        if (byteValue > 500) { }
+        if (sbyteValue > 500) { }
+        if (shortValue > 500) { }
+        if (ushortValue > 500) { }
+    }
+}
+
+// We contribute a custom attribute instance when we see RangeAttribute on an
+// int field. In a production context, this attribute instance resolves with
+// JetBrains.Annotations loaded from the install directory by the external
+// annotations module. This doesn't happen in a test context, so we have to
+// provide the class here in the test, so there's something to resolve against.
+// Other annotation based tests can work because Unity.Engine includes an old
+// subset of JetBrains.Annotations
+//
+// ReSharper disable All
+namespace JetBrains.Annotations
+{
+  [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Delegate, AllowMultiple = true)]
+  [Conditional("JETBRAINS_ANNOTATIONS")]
+  public sealed class ValueRangeAttribute : Attribute
+  {
+    public object From { get; }
+
+    public object To { get; }
+
+    public ValueRangeAttribute(long from, long to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(ulong from, ulong to)
+    {
+      this.From = (object) from;
+      this.To = (object) to;
+    }
+
+    public ValueRangeAttribute(long value) => this.From = this.To = (object) value;
+
+    public ValueRangeAttribute(ulong value) => this.From = this.To = (object) value;
+  }
+}
+// ReSharper enable All
+
+
+---------------------------------------------------------
+(0): ReSharper Warning: Expression is always false
+(1): ReSharper Warning: Expression is always false
+(2): ReSharper Warning: Expression is always false
+(3): ReSharper Warning: Expression is always false
+(4): ReSharper Warning: Expression is always false
+(5): ReSharper Warning: Expression is always false
+(6): ReSharper Warning: Expression is always false

--- a/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProviderTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Psi/CodeAnnotations/CustomCodeAnnotationProviderTest.cs
@@ -28,5 +28,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.CodeAnnotations
         // external annotations module cannot load JetBrains.Annotations in a test context. Other annotation based tests
         // work because Unity.Engine includes a subset of our annotations, and it's enough to run the tests
         [Test] public void TestRangeAttributeAsValueRangeAttribute() { DoNamedTest2(); }
+        [Test] public void TestMinAttributeAsValueRangeAttribute() { DoNamedTest2(); }
     }
 }


### PR DESCRIPTION
Similar to #1673, this uses Unity's `MinAttribute` to create a custom/dynamic `ValueRange` annotation for data flow analysis.