### PR TITLE
Improve discoverability of Unity file layout settings

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingAttributeIds.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/UnityHighlightingAttributeIds.cs
@@ -39,11 +39,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings
         // The internal action Dump Rider Highlighters Tree is very helpful, but it doesn't include a lot of the C#
         // highlights and will include e.g. dead code highlights. You'll have to edit manually.
         // When editing, it's useful to inject XML, but be very careful of the angle brackets in `GetComponent<Grid>`!
-        public const string DEMO_TEXT =
+        private const string DEMO_TEXT =
 @"<CSHARP_KEYWORD>public</CSHARP_KEYWORD> <CSHARP_KEYWORD>class</CSHARP_KEYWORD> <CSHARP_CLASS_IDENTIFIER><UNITY_IMPLICITLY_USED_IDENTIFIER>MyMonoBehaviour</UNITY_IMPLICITLY_USED_IDENTIFIER></CSHARP_CLASS_IDENTIFIER> : <CSHARP_CLASS_IDENTIFIER>MonoBehaviour</CSHARP_CLASS_IDENTIFIER>
 <CSHARP_BRACES>{</CSHARP_BRACES>
   <CSHARP_LINE_COMMENT>// This method is called very frequently by Unity</CSHARP_LINE_COMMENT>
-  <CSHARP_LINE_COMMENT>//</CSHARP_LINE_COMMENT> <UNITY_PERFORMANCE_CRITICAL_LINE_MARKER>(line marker highlight)</UNITY_PERFORMANCE_CRITICAL_LINE_MARKER>
   <CSHARP_KEYWORD>public</CSHARP_KEYWORD> <CSHARP_KEYWORD>void</CSHARP_KEYWORD> <CSHARP_METHOD_IDENTIFIER><UNITY_IMPLICITLY_USED_IDENTIFIER>Update</UNITY_IMPLICITLY_USED_IDENTIFIER></CSHARP_METHOD_IDENTIFIER><CSHARP_PARENTHESES>()</CSHARP_PARENTHESES>
   <CSHARP_BRACES>{</CSHARP_BRACES>
     <CSHARP_LINE_COMMENT>// Camera.main is inefficient inside a performance critical context</CSHARP_LINE_COMMENT>

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Resources/AdditionalFileLayoutPatterns.xaml
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Resources/AdditionalFileLayoutPatterns.xaml
@@ -1,7 +1,10 @@
 <Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"
           xmlns:unity="urn:schemas-jetbrains-com:member-reordering-patterns-unity">
 
-  <!-- Based on the "Default Pattern" pattern -->
+  <!-- Pattern to match classes used by Unity that contain serialised fields and event
+       function methods. Based on the standard "Default Pattern", this will also order
+       event functions before normal methods, and does not reorder serialised fields,
+       as this order is reflected in the Unity editor's Inspector -->
   <TypePattern DisplayName="Unity classes" Priority="100">
     <TypePattern.Match>
       <unity:SerializableClass />

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Resources/AdditionalFileLayoutPatternsWithRegions.xaml
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Resources/AdditionalFileLayoutPatternsWithRegions.xaml
@@ -1,7 +1,11 @@
 <Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"
           xmlns:unity="urn:schemas-jetbrains-com:member-reordering-patterns-unity">
 
-  <!-- Based on the "Default Pattern" pattern -->
+  <!-- Pattern to match classes used by Unity that contain serialised fields and event
+       function methods. Based on the standard "Default Pattern", this will also order
+       event functions before normal methods, and does not reorder serialised fields,
+       as this order is reflected in the Unity editor's Inspector.
+       Additionally, this pattern wraps type members in regions -->
   <TypePattern DisplayName="Unity classes" Priority="100">
     <TypePattern.Match>
       <unity:SerializableClass />

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Settings/Rider/AdditionalFileLayoutSettingsHelper.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Settings/Rider/AdditionalFileLayoutSettingsHelper.cs
@@ -6,7 +6,7 @@ using JetBrains.ReSharper.Host.Features.Dialog;
 using JetBrains.ReSharper.Host.Features.Settings.OptionsPage.CSharpFileLayout;
 using JetBrains.Util;
 
-namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeStyle
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeStyle.Settings
 {
     public class AdditionalFileLayoutSettingsHelper
     {

--- a/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Settings/Rider/UnityFileLayoutPageTab.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/CodeStyle/Settings/Rider/UnityFileLayoutPageTab.cs
@@ -2,34 +2,33 @@ using JetBrains.Application.UI.Options;
 using JetBrains.Application.UI.Options.OptionsDialog;
 using JetBrains.IDE.UI.Extensions;
 using JetBrains.IDE.UI.Extensions.Properties;
-using JetBrains.IDE.UI.Options;
 using JetBrains.Lifetimes;
-using JetBrains.ReSharper.Feature.Services.Resources;
 using JetBrains.ReSharper.Host.Features.Dialog;
 using JetBrains.ReSharper.Host.Features.Settings.OptionsPage.CSharpFileLayout;
-using JetBrains.ReSharper.Plugins.Unity.Rider;
 using JetBrains.Rider.Model;
 using JetBrains.Rider.Model.UIAutomation;
 
-namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeStyle
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeStyle.Settings
 {
-    [OptionsPage(PID, "Additional C# File Layout",
-        typeof(FeaturesEnvironmentOptionsThemedIcons.TypeMembersLayout),
-        ParentId = UnityOptionsPage.PID
-    )]
-    public class AdditionalFileLayoutOptionsPage : BeSimpleOptionsPage
+    [OptionsComponent]
+    public class UnityFileLayoutPageTab : IFileLayoutPageTab
     {
-        private const string PID = "UnityAdditionalFileLayout";
-
+        private readonly RiderDialogHost myDialogHost;
         private readonly RdLanguage myFileLayoutLanguage = new RdLanguage("XML");
+
         private const string DummyFileName = "Dummy.filelayout";
 
-        public AdditionalFileLayoutOptionsPage(Lifetime lifetime, OptionsPageContext optionsPageContext,
-                                               OptionsSettingsSmartContext optionsSettingsSmartContext,
-                                               RiderDialogHost dialogHost)
-            : base(lifetime, optionsPageContext, optionsSettingsSmartContext)
+        public UnityFileLayoutPageTab(RiderDialogHost dialogHost)
         {
-            var fileLayoutSettings = new AdditionalFileLayoutSettingsHelper(lifetime, optionsSettingsSmartContext, dialogHost);
+            myDialogHost = dialogHost;
+        }
+
+        public string Title => "Unity";
+
+        public BeControl Create(Lifetime lifetime, OptionsPageContext optionsPageContext,
+                                OptionsSettingsSmartContext optionsSettingsSmartContext)
+        {
+            var fileLayoutSettings = new AdditionalFileLayoutSettingsHelper(lifetime, optionsSettingsSmartContext, myDialogHost);
             var textControl = BeControls.GetLanguageTextControl(fileLayoutSettings.Text, lifetime, false, myFileLayoutLanguage, DummyFileName, true);
             var toolbar = BeControls.GetToolbar(textControl);
 
@@ -45,9 +44,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.CodeStyle
             grid.AddElement(toolbar, BeSizingType.Fill);
 
             var margin = BeMargins.Create(5, 1, 5, 1);
-            AddControl(grid.WithMargin(margin), true);
-
-            AddKeyword("File Layout");
+            return grid.WithMargin(margin);
         }
     }
 }

--- a/resharper/resharper-unity/src/rider-unity.csproj
+++ b/resharper/resharper-unity/src/rider-unity.csproj
@@ -155,6 +155,6 @@
   <Import Project="$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props" Condition="Exists('$(DotNetSdkPath)\Build\SubplatformReference.ReSharperAutomationTools_src_ReSharperHost.Props')" />
   <Import Project="$(DotNetSdkPath)\Build\SubplatformReference.Psi.Features_Cpp_Src_Core.Props" Condition="Exists('$(DotNetSdkPath)\Build\SubplatformReference.Psi.Features_Cpp_Src_Core.Props')" />
   <Target Name="CppHack" AfterTargets="PrepareForRun">
-     <Move SourceFiles="$(OutDir)JetBrains.ReSharper.Psi.Cpp.dll" DestinationFiles="$(OutDir)x86\JetBrains.ReSharper.Psi.Cpp.dll"/>
+     <Move SourceFiles="$(OutDir)JetBrains.ReSharper.Psi.Cpp.dll" DestinationFiles="$(OutDir)x86\JetBrains.ReSharper.Psi.Cpp.dll" />
   </Target>
 </Project>

--- a/resharper/resharper-unity/src/rider-unity.csproj.DotSettings
+++ b/resharper/resharper-unity/src/rider-unity.csproj.DotSettings
@@ -1,7 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=annotations/@EntryIndexedValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=cg_005Crider/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=csharp_005Cpsi_005Ccodestyle_005Crider/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=csharp_005Cpsi_005Ccodestyle_005Csettings_005Crider/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=settings_005Crider/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shaderlab_005Cdaemon_005Ccontexthighlighters_005Crider/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shaderlab_005Crider/@EntryIndexedValue">True</s:Boolean>

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/settings/fileLayout/AdditionalFileLayoutOptionsPage.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/settings/fileLayout/AdditionalFileLayoutOptionsPage.kt
@@ -1,9 +1,0 @@
-package com.jetbrains.rider.plugins.unity.settings.fileLayout
-
-import com.jetbrains.rider.settings.simple.SimpleOptionsPage
-
-class AdditionalFileLayoutOptionsPage : SimpleOptionsPage("Additional File Layout", "UnityAdditionalFileLayout") {
-    override fun getId(): String {
-        return "preferences.build.unityFileLayout"
-    }
-}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,6 @@
 
     <!-- Options pages -->
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.UnityPluginOptionsPage" id="preferences.build.unityPlugin" />
-    <applicationConfigurable groupId="preferences.build.unityPlugin" instance="com.jetbrains.rider.plugins.unity.settings.fileLayout.AdditionalFileLayoutOptionsPage" id="preferences.build.unityFileLayout" />
 
     <projectConfigurable parentId="FileTemplatesSettingsId" instance="com.jetbrains.rider.settings.templates.UnityFileTemplatesOptionPage" groupWeight="-120" />
     <projectConfigurable parentId="LiveTemplatesSettingsId" instance="com.jetbrains.rider.settings.templates.UnityLiveTemplatesOptionPage" groupWeight="-120" />


### PR DESCRIPTION
Moves the Unity file layout options page to be a tab, as part of the main C# file layout settings.

Also fixes a minor UI issue, removing the performance critical line marker from the demo text in the Unity colour schemes options page (was rendering as a nasty orange background, instead of the expected line marker).