### PR TITLE
Fix Attach to Unity process dialog not showing

### DIFF
--- a/debugger/ios-list-usb-devices/src/Program.cs
+++ b/debugger/ios-list-usb-devices/src/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Sockets;
 using System.Threading;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.iOS.ListUsbDevices
@@ -15,6 +16,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.iOS.ListUsbDevices
                 Console.WriteLine("  Type 'stop' to finish");
                 return -1;
             }
+            
+            InitialiseWinSock();
 
             var thread = new Thread(ThreadFunc);
             thread.Start(args);
@@ -31,6 +34,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.iOS.ListUsbDevices
             thread.Join();
 
             return 0;
+        }
+
+        private static void InitialiseWinSock()
+        {
+            // Small hack to force WinSock to initialise on Windows. If we don't do this, the C based socket APIs in the
+            // native dll will fail, because no-one has bothered to initialise sockets.
+            try
+            {
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                socket.Dispose();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed to create socket (force initialising WinSock on Windows)");
+                Console.WriteLine(e);
+            }
         }
 
         private static void ThreadFunc(object state)

--- a/debugger/ios-list-usb-devices/src/ios-list-usb-devices.csproj
+++ b/debugger/ios-list-usb-devices/src/ios-list-usb-devices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
         <AssemblyName>JetBrains.Rider.Unity.ListIosUsbDevices</AssemblyName>
         <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Rider.iOS.ListUsbDevices</RootNamespace>
         <LangVersion>7.3</LangVersion>

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -93,6 +93,12 @@ def debuggerDllFiles = [
 ]
 
 def helperExeFiles = [
+    "../resharper/build/ios-list-usb-devices/bin/$BuildConfiguration/netcoreapp3.1/JetBrains.Rider.Unity.ListIosUsbDevices.dll",
+    "../resharper/build/ios-list-usb-devices/bin/$BuildConfiguration/netcoreapp3.1/JetBrains.Rider.Unity.ListIosUsbDevices.pdb",
+    "../resharper/build/ios-list-usb-devices/bin/$BuildConfiguration/netcoreapp3.1/JetBrains.Rider.Unity.ListIosUsbDevices.runtimeconfig.json",
+]
+
+def helperExeNetFxFiles = [
     "../resharper/build/ios-list-usb-devices/bin/$BuildConfiguration/net461/JetBrains.Rider.Unity.ListIosUsbDevices.exe",
     "../resharper/build/ios-list-usb-devices/bin/$BuildConfiguration/net461/JetBrains.Rider.Unity.ListIosUsbDevices.pdb",
 ]
@@ -145,6 +151,11 @@ tasks.withType(PrepareSandboxTask).configureEach {
             if (!file.exists()) throw new RuntimeException("File $file does not exist")
         })
 
+        helperExeNetFxFiles.forEach({ f ->
+            def file = file("$f")
+            if (!file.exists()) throw new RuntimeException("File $file does not exist")
+        })
+
         unityEditorDllFiles.forEach({ f ->
             def file = file("$f")
             if (!file.exists() && !f.endsWith("pdb")) throw new RuntimeException("File $file does not exist")
@@ -156,7 +167,10 @@ tasks.withType(PrepareSandboxTask).configureEach {
     unityEditorDllFiles.forEach({ f -> from(file(f), { into "$intellij.pluginName/EditorPlugin" }) })
 
     // This folder name allows RiderEnvironment.getBundledFile(file, pluginClass = this.class) to work
+    // Helper apps must be netcoreapp3.1 for Mac/Linux, but we don't yet bundle netcore for Windows, so fall back to
+    // netfx. Get rid of the netfx folder as soon as we can
     helperExeFiles.forEach({f -> from(file(f), { into "$intellij.pluginName/DotFiles" }) })
+    helperExeNetFxFiles.forEach({f -> from(file(f), { into "$intellij.pluginName/DotFiles/netfx" }) })
 
     from('../resharper/resharper-unity/src/annotations', { into "$intellij.pluginName/dotnet/Extensions/com.intellij.resharper.unity/annotations" })
     from('projectTemplates', { into "$intellij.pluginName/projectTemplates" })

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/AppleDeviceListener.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/AppleDeviceListener.kt
@@ -7,6 +7,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.exists
 import com.intellij.util.io.isDirectory
 import com.jetbrains.rider.AssemblyExecutionContext
@@ -146,8 +147,13 @@ class AppleDeviceListener(project: Project,
         // Get the helper exe from the DotFiles folder. TBH, I suspect the 'DotFiles' name is incorrect, as Rider plugin
         // files (including the 'Extensions' folder) live under 'dotnet'. ReSharper plugins ship in a 'DotFiles' folder,
         // but are installed into the main install folder. No-one actually uses 'DotFiles' now
-        val helperExe = RiderEnvironment.getBundledFile("JetBrains.Rider.Unity.ListIosUsbDevices.exe",
-            pluginClass = javaClass)
+        val assembly = if (SystemInfo.isWindows) {
+            "netfx/JetBrains.Rider.Unity.ListIosUsbDevices.exe"
+        }
+        else {
+            "JetBrains.Rider.Unity.ListIosUsbDevices.dll"
+        }
+        val helperExe = RiderEnvironment.getBundledFile(assembly, pluginClass = javaClass)
 
         val commandLine = AssemblyExecutionContext(helperExe, RiderEnvironment.customExecutionOs, null,
             iosSupportPath.toString(), "$refreshPeriod").fillCommandLine(GeneralCommandLine())

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
@@ -80,7 +80,8 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
                 button("Add player address manually...", actionListener = { enterCustomIp() })
             }
             commentRow("Please ensure both the <i>Development Build</i> and <i>Script Debugging</i> options are checked in Unity's <i>Build Settings</i> dialog. " +
-                "Device players must be visible to the current network.")
+                "Device players must be visible to the current network and firewall rules need to allow incoming UDP messages for the current process. " +
+                "Apple USB devices require iTunes or the Apple Mobile Device service to be installed.")
         }.apply { preferredSize = Dimension(650, 450) }
 
         isOKActionEnabled = false


### PR DESCRIPTION
Fixes the _Attach to Unity Process_ dialog, which broke on Mac/Linux due to removing Mono backend.

* Catches exceptions spawning the helper exe, so failure to execute no longer break the whole dialog
* Create a .net core version of the `iOS-list-usb-devices` project for Mac/Linux. EAP7 will remove the bundled Mono, so we need a .net core version. Rider will bundle .net core 3.1 for Mac/Linux, but not for Windows, so we use the net461 version on Windows.
* Update the _Attach to Unity Process_ dialog to execute the correct version of the helper exe
* Fix the helper exe on Windows failing to find any iOS devices over USB due to calling into a native library that uses sockets but which doesn't initialise the WinSock API. Creating a `Socket` in managed code and immediately disposing it is enough to fix things.