### PR TITLE
fix DEXP-527982

### DIFF
--- a/resharper/resharper-unity/src/Rider/UnityRefreshTracker.cs
+++ b/resharper/resharper-unity/src/Rider/UnityRefreshTracker.cs
@@ -112,8 +112,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                     {
                         using (mySolution.GetComponent<VfsListener>().PauseChanges())
                         {
-                            await myEditorProtocol.UnityModel.Value.Refresh.Start(lifetimeDef.Lifetime, refreshType).AsTask();
-                            await myLocks.Tasks.YieldTo(myLifetime, Scheduling.MainGuard);
+                            try
+                            {
+                                await myEditorProtocol.UnityModel.Value.Refresh.Start(lifetimeDef.Lifetime, refreshType).AsTask();
+                            }
+                            finally
+                            {
+                                await myLocks.Tasks.YieldTo(myLifetime, Scheduling.MainGuard); 
+                            }
                         }
                     }
                     else // it is a risk to pause vfs https://github.com/JetBrains/resharper-unity/issues/1601


### PR DESCRIPTION
exception on Refresh in Unity 2017.x