### PR TITLE
Update API information for 2020.2.0a18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Improved method signature validation and usage suppression using Unity's `RequiredSignature` attribute ([#1679](https://github.com/JetBrains/resharper-unity/pull/1679), [#1689](https://github.com/JetBrains/resharper-unity/pull/1689))
 - Fields must have correct type to be considered a serialised field ([#1605](https://github.com/JetBrains/resharper-unity/issues/1605), [#1638](https://github.com/JetBrains/resharper-unity/pull/1638), [#1720](https://github.com/JetBrains/resharper-unity/pull/1720))
 - Update `.meta` file icons to something less distracting ([RIDER-45675](https://youtrack.jetbrains.com/issue/RIDER-45675), [#1698](https://github.com/JetBrains/resharper-unity/pull/1698))
+- Update API information to Unity 2020.2.0a18 ([#1760](https://github.com/JetBrains/resharper-unity/pull/1760))
+- Added undocumented event functions for `Editor` and `EditorWindow` ([#986](https://github.com/JetBrains/resharper-unity/issues/986), [#1453](https://github.com/JetBrains/resharper-unity/issues/1453), [#1760](https://github.com/JetBrains/resharper-unity/pull/1760))
 - Rider: Significant reduction in memory usage while indexing assets ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Better support for prefab modifications in Find Usages and showing Inspector values ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Show method handlers for Unity events in the editor ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))

--- a/apiParser/src/ApiParser.cs
+++ b/apiParser/src/ApiParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using System.Xml;
 using JetBrains.Annotations;
@@ -195,6 +196,14 @@ namespace ApiParser
             var argumentNames = EmptyArray<string>.Instance;
             var isStaticFromExample = false;
 
+            // Unity 2020.2.0a18 includes EditorWindow.hasUnsavedChanges and EditorWindow.saveChangesMessage as messages
+            if (className == "EditorWindow" &&
+                (messageName == "hasUnsavedChanges" || messageName == "saveChangesMessage"))
+            {
+                Console.WriteLine($"Skipping {className}.{messageName} - not a message");
+                return null;
+            }
+
             var examples = PickExample(details);
             if (examples.Length > 0)
             {
@@ -298,7 +307,7 @@ namespace ApiParser
             var arguments = argumentStrings.Select((arg, i) =>
             {
                 var argName = total > 1 ? $"arg{i + 1}" : @"arg";
-                var typeName = arg;
+                var typeName = WebUtility.HtmlDecode(arg);    // E.g. for List&lt;string&gt;
                 if (arg.Contains(' '))
                 {
                     var parts = arg.Split(' ');
@@ -415,7 +424,6 @@ namespace ApiParser
 
 #pragma warning disable 649
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        [SuppressMessage("ReSharper", "NotNullMemberIsNotInitialized")]
         private class Toc
         {
             public string link;

--- a/apiParser/src/ApiType.cs
+++ b/apiParser/src/ApiType.cs
@@ -8,6 +8,7 @@ namespace ApiParser
         public static readonly ApiType String = new ApiType("System.String");
         public static readonly ApiType StringArray = new ApiType("System.String[]");
         public static readonly ApiType Bool = new ApiType("System.Boolean");
+        public static readonly ApiType Int = new ApiType("System.Int32");
         public static readonly ApiType StringByRef = new ApiType("System.String&");
         public static readonly ApiType IEnumerator = new ApiType("System.Collections.IEnumerator");
 

--- a/apiParser/src/Program.cs
+++ b/apiParser/src/Program.cs
@@ -179,9 +179,9 @@ namespace ApiParser
                     function.SetIsStatic();
                     function.SetReturnType(ApiType.Bool);
                     var newParameter = new UnityApiParameter("assetPath", ApiType.String, string.Empty);
-                    function.UpdateParameter("arg1", newParameter);
+                    function.UpdateParameterIfExists("arg1", newParameter);
                     newParameter = new UnityApiParameter("message", ApiType.StringByRef, string.Empty);
-                    function.UpdateParameter("arg2", newParameter);
+                    function.UpdateParameterIfExists("arg2", newParameter);
                 }
 
                 foreach (var function in type.FindEventFunctions("OnWillDeleteAsset"))
@@ -189,9 +189,9 @@ namespace ApiParser
                     function.SetIsStatic();
                     function.SetReturnType(typeResolver.CreateApiType("UnityEditor.AssetDeleteResult"));
                     var newParameter = new UnityApiParameter("assetPath", ApiType.String, string.Empty);
-                    function.UpdateParameter("arg1", newParameter);
+                    function.UpdateParameterIfExists("arg1", newParameter);
                     newParameter = new UnityApiParameter("options", new ApiType("UnityEditor.RemoveAssetOptions"), string.Empty);
-                    function.UpdateParameter("arg2", newParameter);
+                    function.UpdateParameterIfExists("arg2", newParameter);
                 }
 
                 foreach (var function in type.FindEventFunctions("OnWillMoveAsset"))
@@ -199,9 +199,9 @@ namespace ApiParser
                     function.SetIsStatic();
                     function.SetReturnType(typeResolver.CreateApiType("UnityEditor.AssetMoveResult"));
                     var newParameter = new UnityApiParameter("sourcePath", ApiType.String, string.Empty);
-                    function.UpdateParameter("arg1", newParameter);
+                    function.UpdateParameterIfExists("arg1", newParameter);
                     newParameter = new UnityApiParameter("destinationPath", ApiType.String, string.Empty);
-                    function.UpdateParameter("arg2", newParameter);
+                    function.UpdateParameterIfExists("arg2", newParameter);
                 }
             }
 

--- a/apiParser/src/Program.cs
+++ b/apiParser/src/Program.cs
@@ -214,6 +214,12 @@ namespace ApiParser
             }
         }
 
+        // Note that if we add new undocumented APIs, this won't set the correct min/max version range, and will only
+        // apply the given api versions. That gives us two options:
+        // 1) Recreate the api.xml file from scratch by parsing the documentation of every Unity version since 5.0
+        // 2) Cheat a little. When incrementally updating an existing api.xml for a single version and also adding new
+        //    undocumented APIs, add extra calls to AddUndocumentedApis with the min/max version for those new APIs.
+        //    Don't check these extra calls in!
         private static void AddUndocumentedApis(UnityApi unityApi, Version apiVersion)
         {
             // From AssetPostprocessingInternal
@@ -318,17 +324,142 @@ namespace ApiParser
             // ScriptableObjects. Off the top of my head this includes, Awake, OnEnable, OnDisable, OnDestroy,
             // OnValidate, and Reset, but there could be more.
             type = unityApi.FindType("ScriptableObject");
-            if (type != null)
+            if (type != null && apiVersion < new Version(2020, 2))
             {
+                // Documented in 2020.2
                 var eventFunction = new UnityApiEventFunction("OnValidate", false, false, ApiType.Void, apiVersion,
                     description:
                     "This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).",
                     undocumented: true);
                 type.MergeEventFunction(eventFunction, apiVersion);
 
+                // Documented in 2020.2
                 eventFunction = new UnityApiEventFunction("Reset", false, false, ApiType.Void, apiVersion,
                     description: "Reset to default values.", undocumented: true);
                 type.MergeEventFunction(eventFunction, apiVersion);
+            }
+
+            // TODO: Check if these event functions are available in 5.0 - 5.6
+            type = unityApi.FindType("Editor");
+            if (type != null && apiVersion >= new Version(2017, 1))
+            {
+                // Editor.OnPreSceneGUI has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/SceneView/SceneView.cs#L2436
+                var eventFunction = new UnityApiEventFunction("OnPreSceneGUI", false, false, ApiType.Void, apiVersion,
+                    description: "Called before the Scene view is drawn.",
+                    undocumented: true);
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                // Editor.OnSceneDrag has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/GUI/EditorCache.cs#L63
+                eventFunction = new UnityApiEventFunction("OnSceneDrag", false, false, ApiType.Void, apiVersion,
+                    description: "Called for each object dragged onto the scene view",
+                    undocumented: true);
+                eventFunction.AddParameter("sceneView", new ApiType("UnityEditor.SceneView"), "The current scene view");
+                eventFunction.AddParameter("index", ApiType.Int, "The index into the DragAndDrop.objectReferences array");
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                if (apiVersion < new Version(2020, 2))
+                {
+                    // Editor.HasFrameBounds has been around since at least 2017.1. First documented in 2020.2
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/SceneView/SceneView.cs#L2296
+                    // https://docs.unity3d.com/2020.2/Documentation/ScriptReference/Editor.HasFrameBounds.html
+                    eventFunction = new UnityApiEventFunction("HasFrameBounds", false, false, ApiType.Bool,
+                        apiVersion,
+                        description: "Validates whether custom bounds can be calculated for this editor.",
+                        undocumented: true);
+                    type.MergeEventFunction(eventFunction, apiVersion);
+
+                    // Editor.OnGetFrameBounds has been around since at least 2017.1. First documented in 2020.2
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/SceneView/SceneView.cs#L2303
+                    // https://docs.unity3d.com/2020.2/Documentation/ScriptReference/Editor.OnGetFrameBounds.html
+                    eventFunction = new UnityApiEventFunction("OnGetFrameBounds", false, false,
+                        new ApiType("UnityEngine.Bounds"), apiVersion,
+                        description: "Gets custom bounds for the target of this editor.",
+                        undocumented: true);
+                    type.MergeEventFunction(eventFunction, apiVersion);
+                }
+            }
+
+            // TODO: Check if these event functions are available in 5.0 - 5.6
+            type = unityApi.FindType("EditorWindow");
+            if (type != null && apiVersion >= new Version(2017, 1))
+            {
+                // EditorWindow.ModifierKeysChanged has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/HostView.cs#L290
+                // http://www.improck.com/2014/11/editorwindow-modifier-keys/
+                var eventFunction = new UnityApiEventFunction("ModifierKeysChanged", false, false, ApiType.Void, apiVersion,
+                    description: "Called when the modifier keys are changed. Automatically registers and de-registers the EditorApplication.modifierKeysChanged event",
+                    undocumented: true);
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                // EditorWindow.ShowButton has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/HostView.cs#L356
+                // http://www.improck.com/2014/11/editorwindow-inspector-lock-icon/
+                eventFunction = new UnityApiEventFunction("ShowButton", false, false, ApiType.Void, apiVersion,
+                    description: "Allow Editor panes to show a small button next to the generic menu (e.g. inspector lock icon)",
+                    undocumented: true);
+                eventFunction.AddParameter("rect", new ApiType("UnityEngine.Rect"), "Position to draw the button");
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                // EditorWindow.OnBecameVisible has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/HostView.cs#L302
+                eventFunction = new UnityApiEventFunction("OnBecameVisible", false, false, ApiType.Void, apiVersion,
+                    description: "Called when an editor window has been opened",
+                    undocumented: true);
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                // EditorWindow.OnBecameInvisible has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/HostView.cs#L337
+                eventFunction = new UnityApiEventFunction("OnBecameInvisible", false, false, ApiType.Void, apiVersion,
+                    description: "Called when an editor window has been closed",
+                    undocumented: true);
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                // EditorWindow.OnDidOpenScene has been around since at least 2017.1. Still undocumented as of 2020.2
+                // https://github.com/Unity-Technologies/UnityCsReference/blob/2017.1/Editor/Mono/HostView.cs#L163
+                eventFunction = new UnityApiEventFunction("OnDidOpenScene", false, false, ApiType.Void, apiVersion,
+                    description: "Called when a scene has been opened",
+                    undocumented: true);
+                type.MergeEventFunction(eventFunction, apiVersion);
+
+                if (apiVersion >= new Version(2019, 1))
+                {
+                    // EditorWindow.OnAddedAsTab was introduced in 2019.1. Still undocumented as of 2020.2
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Editor/Mono/GUI/DockArea.cs#L188
+                    eventFunction = new UnityApiEventFunction("OnAddedAsTab", false, false, ApiType.Void, apiVersion,
+                        description: "Called when the editor window is added as a tab",
+                        undocumented: true);
+                    type.MergeEventFunction(eventFunction, apiVersion);
+
+                    // EditorWindow.OnBeforeRemovedAsTab was introduced in 2019.1
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Editor/Mono/GUI/DockArea.cs#L195
+                    eventFunction = new UnityApiEventFunction("OnBeforeRemovedAsTab", false, false, ApiType.Void, apiVersion,
+                        description: "Called before an editor window is removed as a tab",
+                        undocumented: true);
+                }
+
+                if (apiVersion >= new Version(2019, 3))
+                {
+                    // EditorWindow.OnTabDetached was introduced in 2019.3
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2019.3/Editor/Mono/GUI/DockArea.cs#L940
+                    eventFunction = new UnityApiEventFunction("OnTabDetached", false, false, ApiType.Void, apiVersion,
+                        description: "Called during drag and drop, when an editor window tab is detached",
+                        undocumented: true);
+                    type.MergeEventFunction(eventFunction, apiVersion);
+                }
+
+                if (apiVersion >= new Version(2020, 1))
+                {
+                    // EditorWindow.OnMainWindowMove was introduced in 2020.1
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2020.1/Editor/Mono/HostView.cs#L343
+                    // See comment here
+                    // https://github.com/Unity-Technologies/UnityCsReference/blob/2020.1/Editor/Mono/ExternalPlayModeView/ExternalPlayModeView.cs#L112
+                    eventFunction = new UnityApiEventFunction("OnMainWindowMove", false, false, ApiType.Void, apiVersion,
+                        description: "Called when the main window is moved",
+                        undocumented: true);
+                    type.MergeEventFunction(eventFunction, apiVersion);
+                }
             }
         }
     }

--- a/apiParser/src/TypeResolver.cs
+++ b/apiParser/src/TypeResolver.cs
@@ -22,6 +22,13 @@ namespace ApiParser
             myFullNames.Add("float", typeof(float).FullName);
             myFullNames.Add("double", typeof(double).FullName);
             myFullNames.Add("IEnumerator", typeof(IEnumerator).FullName);
+
+            // TODO: Provide a better way of handling generics?
+            // We only have one use so far, in AssetModificationProcessor.CanOpenForEdit in 2020.2. ApiParser will fail
+            // if we get any others, as the list above are the only non-Unity types we recognise. Note that using
+            // typeof(List<string>).FullName will give an assembly qualified name for the type parameter, including
+            // culture, version and public key token. We need a simple type name.
+            myFullNames.Add("List<string>", "System.Collections.Generic.List`1[[System.String]]");
         }
 
         private string ResolveFullName([NotNull] string name, string namespaceHint)
@@ -60,7 +67,7 @@ namespace ApiParser
             if (candidates.Count > 1)
             {
                 // If we have more than one type with the same name, choose the one in the same namespace as the owning
-                // message. This works for experimental types that move namespaces PlayState and Playable
+                // message. This works for experimental types that move namespaces such as PlayState and Playable
                 foreach (var candidate in candidates)
                 {
                     Console.WriteLine($"Namespace hint: {namespaceHint}");

--- a/apiParser/src/UnityApi.cs
+++ b/apiParser/src/UnityApi.cs
@@ -91,7 +91,7 @@ namespace ApiParser
         public static UnityApi ImportFrom(FileSystemPath apiXml)
         {
             var doc = XDocument.Load(apiXml.FullPath);
-            var apiNode = doc.FirstNode as XElement;
+            var apiNode = doc.Root;
             if (apiNode?.Name != "api")
                 throw new InvalidDataException("Cannot find root api node");
             var api = new UnityApi();

--- a/apiParser/src/UnityApi.cs
+++ b/apiParser/src/UnityApi.cs
@@ -315,14 +315,11 @@ namespace ApiParser
                 myParameters[0].SetOptional(justification);
         }
 
-        public void UpdateParameter(string name, UnityApiParameter newParameter)
+        public void UpdateParameterIfExists(string name, UnityApiParameter newParameter)
         {
-            var parameter = myParameters.SingleOrDefault(p => p.Name == name);
-            if (parameter == null)
-                parameter = myParameters.SingleOrDefault(p => p.Name == newParameter.Name);
-            if (parameter == null)
-                throw new InvalidOperationException($"Cannot update parameter {name}");
-            parameter.Update(newParameter, Name);
+            var parameter = myParameters.SingleOrDefault(p => p.Name == name) ??
+                            myParameters.SingleOrDefault(p => p.Name == newParameter.Name);
+            parameter?.Update(newParameter, Name);
         }
 
         public void ExportTo(XmlTextWriter xmlWriter, HasVersionRange defaultVersions)

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/IncorrectObjectInstantiationProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/IncorrectObjectInstantiationProblemAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Util;
 
@@ -22,16 +21,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
 
         protected override void Analyze(IObjectCreationExpression element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
         {
-            var createdType = element.ExplicitType();
-            var monoBehaviourType = TypeFactory.CreateTypeByCLRName(KnownTypes.MonoBehaviour, element.GetPsiModule());
-            var scriptableObjectType =
-                TypeFactory.CreateTypeByCLRName(KnownTypes.ScriptableObject, element.GetPsiModule());
+            var createdType = element.ExplicitType().GetTypeElement();
 
-            if (createdType.IsSubtypeOf(monoBehaviourType))
+            if (createdType.DerivesFromMonoBehaviour())
             {
                 consumer.AddHighlighting(new IncorrectMonoBehaviourInstantiationWarning(element));
             }
-            else if (createdType.IsSubtypeOf(scriptableObjectType))
+            else if (createdType.DerivesFromScriptableObject())
             {
                 consumer.AddHighlighting(new IncorrectScriptableObjectInstantiationWarning(element));
             }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/PropertyDrawerOnGUIBaseProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/PropertyDrawerOnGUIBaseProblemAnalyzer.cs
@@ -31,8 +31,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
         private static bool IsOnGUIBaseCall(IInvocationExpression expression)
         {
             var reference = expression.Reference;
-            if (reference == null)
-                return false;
 
             if (!IsBaseCallReference(expression))
                 return false;
@@ -52,7 +50,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
 
             return true;
         }
-        
+
         private static bool IsBaseCallReference(IInvocationExpression expression)
         {
             var referenceExpression = expression.InvokedExpression as IReferenceExpression;
@@ -81,8 +79,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
         private static bool IsInsidePropertyDrawer(IInvocationExpression expression)
         {
             var containingType = expression.GetContainingNode<IClassLikeDeclaration>()?.DeclaredElement;
-            var propertyDrawer = TypeFactory.CreateTypeByCLRName(KnownTypes.PropertyDrawer, expression.PsiModule);
-            return containingType?.IsDescendantOf(propertyDrawer.GetTypeElement()) != false;
+            return containingType.DerivesFrom(KnownTypes.PropertyDrawer);
         }
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/SyncVarUsageProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/SyncVarUsageProblemAnalyzer.cs
@@ -16,15 +16,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
 
         protected override void Analyze(IAttribute element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
         {
-            var type = element.TypeReference?.Resolve()?.DeclaredElement as ITypeElement;
-            if (type != null && Equals(type.GetClrName(), KnownTypes.SyncVarAttribute))
+            if (element.TypeReference?.Resolve().DeclaredElement is ITypeElement type &&
+                Equals(type.GetClrName(), KnownTypes.SyncVarAttribute))
             {
                 var containingType = element.GetContainingNode<IClassLikeDeclaration>()?.DeclaredElement;
-                var networkBehaviour = TypeFactory.CreateTypeByCLRName(KnownTypes.NetworkBehaviour, element.PsiModule);
-                if (containingType?.IsDescendantOf(networkBehaviour.GetTypeElement()) == false)
-                {
+                if (!containingType.DerivesFrom(KnownTypes.NetworkBehaviour))
                     consumer.AddHighlighting(new SyncVarUsageError(element));
-                }
             }
         }
     }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityObjectNullCoalescingProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityObjectNullCoalescingProblemAnalyzer.cs
@@ -2,7 +2,6 @@
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Util;
@@ -24,8 +23,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
             var resolve = leftOperand.Reference.Resolve();
             if (resolve.ResolveErrorType != ResolveErrorType.OK)
                 return;
-            var unityObjectType = TypeFactory.CreateTypeByCLRName(KnownTypes.Object, expression.GetPsiModule());
-            if (!leftOperand.Type().IsSubtypeOf(unityObjectType))
+
+            if (!leftOperand.Type().GetTypeElement().DerivesFrom(KnownTypes.Object))
                 return;
 
             consumer.AddHighlighting(new UnityObjectNullCoalescingWarning(expression));

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityObjectNullPropagationProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Analysis/UnityObjectNullPropagationProblemAnalyzer.cs
@@ -2,7 +2,6 @@
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Dispatcher;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Util;
@@ -26,8 +25,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis
             var resolve = qualifier.Reference.Resolve();
             if (resolve.ResolveErrorType != ResolveErrorType.OK)
                 return;
-            var unityObjectType = TypeFactory.CreateTypeByCLRName(KnownTypes.Object, expression.GetPsiModule());
-            if (!qualifier.Type().IsSubtypeOf(unityObjectType))
+
+            if (!qualifier.Type().GetTypeElement().DerivesFrom(KnownTypes.Object))
                 return;
 
             consumer.AddHighlighting(new UnityObjectNullPropagationWarning(expression));

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.ProjectModel;
@@ -25,7 +24,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         {
             myUnityApi = unityApi;
         }
-        
+
         public override bool AddDeclarationHighlighting(IDeclaration element, IHighlightingConsumer consumer, DaemonProcessKind kind)
         {
             if (!(element is IFieldDeclaration field))
@@ -40,23 +39,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             {
                 const string displayText = "Serializable";
                 const string baseTooltip = "This field is initialized from Inspector";
-                if (UnityApi.IsDescendantOfMonoBehaviour(declaredElement.GetContainingType()) ||
-                    UnityApi.IsDescendantOfScriptableObject(declaredElement.GetContainingType()))
+                var containingType = declaredElement.GetContainingType();
+                if (containingType.DerivesFromMonoBehaviour() || containingType.DerivesFromScriptableObject())
                 {
                     AddMonoBehaviourHighlighting(consumer, field, displayText, baseTooltip, kind);
                     return true;
+                }
 
-                } else if (myUnityApi.IsInjectedField(declaredElement))
+                if (myUnityApi.IsInjectedField(declaredElement))
                 {
                     AddECSHighlighting(consumer, field, displayText, "This field is injected by Unity", kind);
                     return true;
-                } else 
-                {
-                    AddSerializableHighlighting(consumer, field, displayText, "This field is serialized by Unity", kind);
                 }
 
+                AddSerializableHighlighting(consumer, field, displayText, "This field is serialized by Unity", kind);
                 return false;
-            } 
+            }
 
             return false;
         }
@@ -66,25 +64,25 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         {
             AddHighlighting(consumer, element, text, tooltip, kind);
         }
-        
+
         protected virtual void AddScriptableObjectHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text, string tooltip,
             DaemonProcessKind kind)
         {
             AddHighlighting(consumer, element, text, tooltip, kind);
         }
-        
+
         protected virtual void AddECSHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text, string tooltip,
             DaemonProcessKind kind)
         {
             AddHighlighting(consumer, element, text, tooltip, kind);
         }
-        
+
         protected virtual void AddSerializableHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text, string tooltip,
             DaemonProcessKind kind)
         {
             AddHighlighting(consumer, element, text, tooltip, kind);
         }
-        
+
         protected override void AddHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text, string tooltip,
             DaemonProcessKind kind)
         {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -37,16 +37,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             var typeElement = element.DeclaredElement;
             if (typeElement != null)
             {
-                if (UnityApi.IsDescendantOfMonoBehaviour(typeElement))
+                if (typeElement.DerivesFromMonoBehaviour())
                 {
                     AddMonoBehaviourHiglighting(consumer, element, "Script", "Unity script", kind);
                 }
-                else if (UnityApi.IsDescendantOf(KnownTypes.Editor, typeElement) ||
-                         UnityApi.IsDescendantOf(KnownTypes.EditorWindow, typeElement))
+                else if (typeElement.DerivesFrom(KnownTypes.Editor) || typeElement.DerivesFrom(KnownTypes.EditorWindow))
                 {
                     AddEditorHiglighting(consumer, element, "Editor", "Custom Unity Editor", kind);
                 }
-                else if (UnityApi.IsDescendantOfScriptableObject(typeElement))
+                else if (typeElement.DerivesFromScriptableObject())
                 {
                     AddMonoBehaviourHiglighting(consumer, element, "Scriptable object", "Scriptable Object", kind);
                 }
@@ -110,6 +109,5 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
 
             return result;
         }
-
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Analyzers/MultiplicationOrderAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Analyzers/MultiplicationOrderAnalyzer.cs
@@ -17,26 +17,26 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
     {
         private static readonly HashSet<IClrTypeName> ourKnownTypes = new HashSet<IClrTypeName>()
         {
-            new ClrTypeName("UnityEngine.Vector2"),
-            new ClrTypeName("UnityEngine.Vector3"),
-            new ClrTypeName("UnityEngine.Vector4"),
-            new ClrTypeName("UnityEngine.Vector2Int"),
-            new ClrTypeName("UnityEngine.Vector3Int"),
-            new ClrTypeName("UnityEngine.Quaternion"),
-            new ClrTypeName("UnityEngine.Matrix4x4"),
+            KnownTypes.Vector2,
+            KnownTypes.Vector3,
+            KnownTypes.Vector4,
+            KnownTypes.Vector2Int,
+            KnownTypes.Vector3Int,
+            KnownTypes.Quaternion,
+            KnownTypes.Matrix4x4
         };
-        
+
         protected override void Analyze(IMultiplicativeExpression expression, IDaemonProcess daemonProcess, DaemonProcessKind kind, IHighlightingConsumer consumer)
         {
             if (IsStartPoint(expression))
             {
                 var count = 0;
                 bool hasMatrix = false;
-         
+
                 var enumerator = expression.ThisAndDescendants<ICSharpExpression>();
                 var scalars = new List<ICSharpExpression>();
                 var matrices = new List<ICSharpExpression>();
-                
+
                 while (enumerator.MoveNext())
                 {
                     var element = enumerator.Current;
@@ -57,7 +57,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
                             hasMatrix = true;
                             matrices.Add(element);
                         }
-                        
+
                         enumerator.SkipThisNode();
                     }
                     else
@@ -71,7 +71,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
                         }
                     }
                 }
-                
+
                 if (hasMatrix & count > 1)
                     consumer.AddHighlighting(new InefficientMultiplicationOrderWarning(expression, scalars, matrices));
             }
@@ -94,7 +94,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
         {
             return IsMatrixTypeInner(expression) == MatrixTypeState.Matrix;
         }
-        
+
         private static MatrixTypeState IsMatrixTypeInner(ICSharpExpression expression)
         {
             var type = expression?.GetExpressionType().ToIType() as IDeclaredType;
@@ -105,7 +105,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
 
             if (ourKnownTypes.Contains(type.GetClrName()))
                 return MatrixTypeState.Matrix;
-            
+
             return MatrixTypeState.Unknown;
         }
 

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/PerformanceCriticalCodeStageUtil.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/PerformanceCriticalCodeStageUtil.cs
@@ -14,7 +14,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
     {
         public static bool IsInvocationExpensive([NotNull] IInvocationExpression invocationExpression)
         {
-            invocationExpression.GetPsiServices().Locks.AssertReadAccessAllowed();;
+            invocationExpression.GetPsiServices().Locks.AssertReadAccessAllowed();
 
             var reference = (invocationExpression.InvokedExpression as IReferenceExpression)?.Reference;
             if (reference == null)
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
 
             if (clrTypeName.Equals(KnownTypes.Transform))
                 knownCostlyMethods = ourKnownTransformCostlyMethods;
-            
+
             if (clrTypeName.Equals(KnownTypes.Debug))
                 knownCostlyMethods = ourKnownDebugCostlyMethods;
 
@@ -115,7 +115,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
 
                 var suffix = equalityExpression.EqualityType == EqualityExpressionType.NE ? "NotNull" : "Null";
 
-                string baseName = null;
+                string baseName;
                 if (expression is IReferenceExpression referenceExpression)
                 {
                     baseName = referenceExpression.NameIdentifier.Name;
@@ -136,12 +136,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
         {
             return HasSpecificAttribute(attributesOwner, "PerformanceCharacteristicsHintAttribute");
         }
-        
+
         public static bool HasFrequentlyCalledMethodAttribute(IAttributesOwner attributesOwner)
         {
             return HasSpecificAttribute(attributesOwner, "FrequentlyCalledMethodAttribute");
         }
-        
+
         public static bool HasSpecificAttribute(IAttributesOwner attributesOwner, string name)
         {
             return attributesOwner.GetAttributeInstances(true)
@@ -153,7 +153,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
 
             if (!(node is ICSharpDeclaration declaration))
                 return false;
-            
+
             // TODO: 20.1, support lambda
             if (declaration.DeclaredElement is IAttributesOwner attributesOwner && HasFrequentlyCalledMethodAttribute(attributesOwner))
                 return true;
@@ -162,19 +162,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
                 return false;
 
             var typeElement = typeMemberDeclaration.DeclaredElement?.GetContainingType();
-            
+
             if (typeElement == null)
                 return false;
 
-            if (!UnityApi.IsDescendantOfMonoBehaviour(typeElement))
+            if (!typeElement.DerivesFromMonoBehaviour())
                 return false;
-            
+
             if (declaration.DeclaredElement is IClrDeclaredElement clrDeclaredElement)
                 return ourKnownHotMonoBehaviourMethods.Contains(clrDeclaredElement.ShortName);
 
             return false;
         }
-        
+
         #region data
 
         private static readonly ISet<string> ourKnownHotMonoBehaviourMethods = new HashSet<string>()

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Bulbs/ConvertFromCoroutineBulbAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Bulbs/ConvertFromCoroutineBulbAction.cs
@@ -26,12 +26,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Bulbs
             var unityApi = solution.GetComponent<UnityApi>();
             var eventFunction = unityApi.GetUnityEventFunction(element);
 
-            IType returnType = TypeFactory.CreateTypeByCLRName(eventFunction.ReturnType, myMethodDeclaration.GetPsiModule());
-            if (eventFunction.ReturnTypeIsArray)
-                returnType = TypeFactory.CreateArrayType(returnType, 1);
+            var returnType = eventFunction.ReturnType.AsIType(myMethodDeclaration.GetPsiModule());
 
-            var language = myMethodDeclaration.Language;
-            var changeTypeHelper = LanguageManager.Instance.GetService<IChangeTypeHelper>(language);
+            var changeTypeHelper = LanguageManager.Instance.GetService<IChangeTypeHelper>(myMethodDeclaration.Language);
             changeTypeHelper.ChangeType(returnType, element);
 
             return null;

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Bulbs/ConvertFromCoroutineBulbAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Bulbs/ConvertFromCoroutineBulbAction.cs
@@ -24,9 +24,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Bulbs
             if (element == null) return null;
 
             var unityApi = solution.GetComponent<UnityApi>();
+            var knownTypesCache = solution.GetComponent<KnownTypesCache>();
             var eventFunction = unityApi.GetUnityEventFunction(element);
 
-            var returnType = eventFunction.ReturnType.AsIType(myMethodDeclaration.GetPsiModule());
+            var returnType = eventFunction.ReturnType.AsIType(knownTypesCache, myMethodDeclaration.GetPsiModule());
 
             var changeTypeHelper = LanguageManager.Instance.GetService<IChangeTypeHelper>(myMethodDeclaration.Language);
             changeTypeHelper.ChangeType(returnType, element);

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionBehavior.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionBehavior.cs
@@ -89,7 +89,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
                     // Note that the generated code will use the access rights, if specified. However, if they haven't
                     // been specified (NONE) or they are the default for methods (PRIVATE), the generated code will be
                     // whatever the current code style setting is - implicit or explicit
-                    var declaredElement = myEventFunction.CreateDeclaration(factory, classDeclaration, myAccessRights, makeCoroutine: isCoroutine)
+                    var knownTypesCache = solution.GetComponent<KnownTypesCache>();
+                    var declaredElement = myEventFunction.CreateDeclaration(factory, knownTypesCache, classDeclaration,
+                            myAccessRights, makeCoroutine: isCoroutine)
                         .DeclaredElement.NotNull("declaredElement != null");
                     context.InputElements.Clear();
                     context.InputElements.Add(new GeneratorDeclaredElement(declaredElement));

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
@@ -240,7 +240,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
             var lookupItem = LookupItemFactory.CreateLookupItem(textualInfo)
                 .WithPresentation(item =>
                 {
-                    var displayName = new RichText($"{modifier}{text} {{ … }}");
+                    var displayName = new RichText($"{modifier}{text} {{ ... }}");
 
                     // GenerateMemberPresentation marks everything as bold, and the parameters + block syntax as not important
                     var parameterStartOffset = modifier.Length + parameterOffset;

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
@@ -201,7 +201,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
             // search and modifies the PSI file. This only affects ReSharper, Rider has different code completion
             // mechanism
             var factory = CSharpElementFactory.GetInstance(declaration, false);
-            var methodDeclaration = eventFunction.CreateDeclaration(factory, declaration, accessRights);
+            var knownTypesCache = context.BasicContext.Solution.GetComponent<KnownTypesCache>();
+            var methodDeclaration = eventFunction.CreateDeclaration(factory, knownTypesCache, declaration, accessRights);
             if (methodDeclaration.DeclaredElement == null)
                 return null;
 
@@ -216,7 +217,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
                     if (i > 0) sb.Append(", ");
 
                     var parameter = eventFunction.Parameters[i];
-                    var type = parameter.TypeSpec.AsIType(context.PsiModule);
+                    var type = parameter.TypeSpec.AsIType(knownTypesCache, context.PsiModule);
                     var typeName = type.GetPresentableName(CSharpLanguage.Instance);
                     sb.AppendFormat("{0}{1}", parameter.IsByRef ? "out" : string.Empty, typeName);
                 }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionRule.cs
@@ -5,7 +5,6 @@ using System.Text;
 using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.DocumentModel;
-using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Impl;
@@ -208,7 +207,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
 
             // This is effectively the same as GenerateMemberPresentation, but without the overhead that comes
             // with the flexibility of formatting any time of declared element. We just hard code the format
-            var predefinedType = context.PsiModule.GetPredefinedType();
             var parameters = string.Empty;
             if (eventFunction.Parameters.Length > 0)
             {
@@ -218,11 +216,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
                     if (i > 0) sb.Append(", ");
 
                     var parameter = eventFunction.Parameters[i];
-                    var type = predefinedType.TryGetType(parameter.ClrTypeName, NullableAnnotation.Unknown);
-                    var typeName = type?.GetPresentableName(CSharpLanguage.Instance) ??
-                                   parameter.ClrTypeName.ShortName;
-                    sb.AppendFormat("{0}{1}{2}", parameter.IsByRef ? "out" : string.Empty,
-                        typeName, parameter.IsArray ? "[]" : string.Empty);
+                    var type = parameter.TypeSpec.AsIType(context.PsiModule);
+                    var typeName = type.GetPresentableName(CSharpLanguage.Instance);
+                    sb.AppendFormat("{0}{1}", parameter.IsByRef ? "out" : string.Empty, typeName);
                 }
                 parameters = sb.ToString();
             }
@@ -244,7 +240,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.CodeCompleti
             var lookupItem = LookupItemFactory.CreateLookupItem(textualInfo)
                 .WithPresentation(item =>
                 {
-                    var displayName = new RichText($"{modifier}{text} {{ ... }}");
+                    var displayName = new RichText($"{modifier}{text} {{ … }}");
 
                     // GenerateMemberPresentation marks everything as bold, and the parameters + block syntax as not important
                     var parameterStartOffset = modifier.Length + parameterOffset;

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddInspectorAttributeAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/AddInspectorAttributeAction.cs
@@ -4,22 +4,18 @@ using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Application.UI.Controls.BulbMenu.Anchors;
 using JetBrains.Application.UI.Controls.BulbMenu.Positions;
-using JetBrains.DocumentModel;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Feature.Services.CSharp.Analyses.Bulbs;
 using JetBrains.ReSharper.Feature.Services.Intentions;
-using JetBrains.ReSharper.Feature.Services.LiveTemplates.Hotspots;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Impl;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Modules;
-using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.ReSharper.Psi.Util;
 using JetBrains.TextControl;
 using JetBrains.Util;
 using JetBrains.Util.Extension;
@@ -108,8 +104,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
             // Only for UnityObject types, not [Serialized] types
             var classDeclaration = fieldDeclaration.GetContainingTypeDeclaration();
             var classElement = classDeclaration?.DeclaredElement;
-            return UnityApi.IsDescendantOfMonoBehaviour(classElement) ||
-                   UnityApi.IsDescendantOfScriptableObject(classElement);
+            return classElement.DerivesFromMonoBehaviour() || classElement.DerivesFromScriptableObject();
         }
 
         private BulbActionBase GetActionToApplyToEntireFieldDeclaration(

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/CreateAssetMenuContextAction.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/ContextActions/CreateAssetMenuContextAction.cs
@@ -3,19 +3,15 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Application.UI.Controls.BulbMenu.Anchors;
-using JetBrains.DocumentModel;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Feature.Services.CSharp.Analyses.Bulbs;
 using JetBrains.ReSharper.Feature.Services.Intentions;
-using JetBrains.ReSharper.Feature.Services.LiveTemplates.Hotspots;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Modules;
-using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.ReSharper.Psi.Util;
 using JetBrains.TextControl;
 using JetBrains.Util;
 
@@ -54,9 +50,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
             var classLikeDeclaration = ClassLikeDeclarationNavigator.GetByNameIdentifier(identifier);
             if (classLikeDeclaration == null)
                 return false;
-            
+
             var existingAttribute = classLikeDeclaration.GetAttribute(KnownTypes.CreateAssetMenuAttribute);
-            return existingAttribute == null && UnityApi.IsDescendantOfScriptableObject(classLikeDeclaration.DeclaredElement);
+            return existingAttribute == null && classLikeDeclaration.DeclaredElement.DerivesFromScriptableObject();
         }
 
         private class CreateAssetMenuAction : BulbActionBase
@@ -80,10 +76,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                     new Pair<string, AttributeValue>("fileName", new AttributeValue(new ConstantValue(myClassLikeDeclaration.DeclaredName, myModule))),
                     new Pair<string, AttributeValue>("order", new AttributeValue(new ConstantValue(0, myModule))),
                 };
-                
-                var attribute = AttributeUtil.AddAttributeToSingleDeclaration(myClassLikeDeclaration, KnownTypes.CreateAssetMenuAttribute, EmptyArray<AttributeValue>.Instance, 
+
+                var attribute = AttributeUtil.AddAttributeToSingleDeclaration(myClassLikeDeclaration, KnownTypes.CreateAssetMenuAttribute, EmptyArray<AttributeValue>.Instance,
                     values, myModule, myElementFactory);
-                
+
                 return attribute.CreateHotspotSession();
             }
 

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Generate/GenerateUnityEventFunctionsProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Generate/GenerateUnityEventFunctionsProvider.cs
@@ -19,11 +19,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Generate
     {
         private readonly UnityApi myUnityApi;
         private readonly UnityVersion myUnityVersion;
+        private readonly KnownTypesCache myKnownTypesCache;
 
-        public GenerateUnityEventFunctionsProvider(UnityApi unityApi, UnityVersion unityVersion)
+        public GenerateUnityEventFunctionsProvider(UnityApi unityApi, UnityVersion unityVersion,
+                                                   KnownTypesCache knownTypesCache)
         {
             myUnityApi = unityApi;
             myUnityVersion = unityVersion;
+            myKnownTypesCache = knownTypesCache;
         }
 
         public override void Populate(CSharpGeneratorContext context)
@@ -54,7 +57,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Generate
                 // https://youtrack.jetbrains.com/issue/RIDER-25194
                 if (!groupingTypeLookup.TryGetValue(eventFunction.TypeName, out var groupingType))
                 {
-                    groupingType = TypeFactory.CreateTypeByCLRName(eventFunction.TypeName, context.PsiModule)
+                    groupingType = myKnownTypesCache.GetByClrTypeName(eventFunction.TypeName, context.PsiModule)
                         .GetTypeElement();
                     groupingTypeLookup.Add(eventFunction.TypeName, groupingType);
                 }
@@ -80,7 +83,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Generate
                 }
 
                 var newMethodDeclaration = eventFunction
-                    .CreateDeclaration(factory, context.ClassDeclaration, accessRights, makeVirtual);
+                    .CreateDeclaration(factory, myKnownTypesCache, context.ClassDeclaration, accessRights, makeVirtual);
                 if (makeVirtual)
                 {
                     // Make the parameter names are the same as the overridden method, or the "redundant override"

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/ConvertToScriptableObjectCreateInstanceQuickFix.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/QuickFixes/ConvertToScriptableObjectCreateInstanceQuickFix.cs
@@ -4,7 +4,6 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
 using JetBrains.ReSharper.Intentions.Util;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
@@ -28,8 +27,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
         {
             using (WriteLockCookie.Create())
             {
+                var knownTypesCache = solution.GetComponent<KnownTypesCache>();
                 var scriptableObjectType =
-                    TypeFactory.CreateTypeByCLRName(KnownTypes.ScriptableObject, myWarningCreationExpression.GetPsiModule());
+                    knownTypesCache.GetByClrTypeName(KnownTypes.ScriptableObject, myWarningCreationExpression.GetPsiModule());
 
                 var factory = CSharpElementFactory.GetInstance(myWarningCreationExpression);
                 var newExpression = factory.CreateExpression("$0.CreateInstance<$1>()",

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/FormerlySerializedAsAtomicRename.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/FormerlySerializedAsAtomicRename.cs
@@ -3,10 +3,8 @@ using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Application.Settings;
 using JetBrains.Diagnostics;
-using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Refactorings;
 using JetBrains.ReSharper.Feature.Services.Refactorings.Specific.Rename;
-using JetBrains.ReSharper.Plugins.Unity.Utils;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Impl;
@@ -22,11 +20,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
 {
     public class FormerlySerializedAsAtomicRename : AtomicRenameBase
     {
+        private readonly KnownTypesCache myKnownTypesCache;
         private readonly SerializedFieldRenameModel myModel;
         private readonly IDeclaredElementPointer<IDeclaredElement> myPointer;
 
-        public FormerlySerializedAsAtomicRename(IDeclaredElement declaredElement, string newName, ISettingsStore settingsStore)
+        public FormerlySerializedAsAtomicRename(IDeclaredElement declaredElement, string newName,
+                                                ISettingsStore settingsStore, KnownTypesCache knownTypesCache)
         {
+            myKnownTypesCache = knownTypesCache;
             myModel = new SerializedFieldRenameModel(settingsStore);
 
             myPointer = declaredElement.CreateElementPointer();
@@ -151,7 +152,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
         private IAttribute CreateFormerlySerializedAsAttribute(IPsiModule module)
         {
             var elementFactory = CSharpElementFactory.GetInstance(module);
-            var attributeType = TypeFactory.CreateTypeByCLRName(KnownTypes.FormerlySerializedAsAttribute, module);
+            var attributeType = myKnownTypesCache.GetByClrTypeName(KnownTypes.FormerlySerializedAsAttribute, module);
             var attributeTypeElement = attributeType.GetTypeElement();
             if (attributeTypeElement == null)
                 return null;

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/FormerlySerializedAsAtomicRenameFactory.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/FormerlySerializedAsAtomicRenameFactory.cs
@@ -28,7 +28,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
             bool doNotAddBindingConflicts)
         {
             var settingsStore = declaredElement.GetSolution().GetComponent<ISettingsStore>();
-            return new[] {new FormerlySerializedAsAtomicRename(declaredElement, newName, settingsStore)};
+            var knownTypesCache = declaredElement.GetSolution().GetComponent<KnownTypesCache>();
+            return new[] {new FormerlySerializedAsAtomicRename(declaredElement, newName, settingsStore, knownTypesCache)};
         }
     }
 }

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Refactorings/Rename/UnityEventTargetAtomicRenameFactory.cs
@@ -32,7 +32,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
 
         private static bool IsPossibleEventHandler(IDeclaredElement declaredElement)
         {
-
             var clrDeclaredElement = declaredElement as IClrDeclaredElement;
 
             switch (clrDeclaredElement)
@@ -43,18 +42,21 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Refactorings
                     if (containingType == null)
                         return false;
 
-                    var unityObjectType = TypeFactory.CreateTypeByCLRName(KnownTypes.Object, clrDeclaredElement.Module).GetTypeElement();
+                    var solution = clrDeclaredElement.GetSolution();
+
+                    var knownTypesCache = solution.GetComponent<KnownTypesCache>();
+                    var unityObjectType = knownTypesCache.GetByClrTypeName(KnownTypes.Object, clrDeclaredElement.Module).GetTypeElement();
                     var result = containingType.IsDescendantOf(unityObjectType);
                     if (!result)
                         return false;
-                    var solution = clrDeclaredElement.GetSolution();
                     var cacheController = solution.GetComponent<DeferredCacheController>();
 
                     if (cacheController.IsProcessingFiles())
                         return true;
-                    
+
                     var methods = solution.GetComponent<UnityEventsElementContainer>();
                     return methods.GetAssetUsagesCount(clrDeclaredElement, out bool estimatedResult) > 0 || estimatedResult;
+
                 default:
                     return false;
             }

--- a/resharper/resharper-unity/src/CSharp/Psi/Colors/UnityColorTypes.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/Colors/UnityColorTypes.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using JetBrains.Metadata.Reader.API;
-using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Colors;
 using JetBrains.ReSharper.Psi.Modules;
@@ -13,8 +11,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Colors
     public class UnityColorTypes
     {
         private static readonly Key<UnityColorTypes> ourColorTypesKey = new Key<UnityColorTypes>("UnityColorTypes");
-        private static readonly IClrTypeName UnityColorTypeName = new ClrTypeName("UnityEngine.Color");
-        private static readonly IClrTypeName UnityColor32TypeName = new ClrTypeName("UnityEngine.Color32");
 
         public static UnityColorTypes GetInstance(IPsiModule module)
         {
@@ -32,8 +28,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Colors
         {
             var cache = module.GetPsiServices().Symbols.GetSymbolScope(module, true, true);
 
-            UnityColorType = cache.GetTypeElementByCLRName(UnityColorTypeName);
-            UnityColor32Type = cache.GetTypeElementByCLRName(UnityColor32TypeName);
+            UnityColorType = cache.GetTypeElementByCLRName(KnownTypes.Color);
+            UnityColor32Type = cache.GetTypeElementByCLRName(KnownTypes.Color32);
         }
 
         [CanBeNull] public ITypeElement UnityColorType { get; }

--- a/resharper/resharper-unity/src/DeclaredElementExtensions.cs
+++ b/resharper/resharper-unity/src/DeclaredElementExtensions.cs
@@ -29,12 +29,12 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return false;
         }
 
-        public static bool DerivesFrom(this IDeclaredElement candidate, IClrTypeName baseTypeName)
+        public static bool DerivesFrom([CanBeNull] this ITypeElement candidate, IClrTypeName baseTypeName)
         {
-            if (!(candidate is ITypeElement element))
+            if (candidate == null)
                 return false;
-            var baseType = GetTypeElement(baseTypeName, element.Module);
-            return element.IsDescendantOf(baseType);
+            var baseType = GetTypeElement(baseTypeName, candidate.Module);
+            return candidate.IsDescendantOf(baseType);
         }
 
         private static ITypeElement GetTypeElement(IClrTypeName typeName, IPsiModule module)
@@ -44,6 +44,21 @@ namespace JetBrains.ReSharper.Plugins.Unity
                 var type = TypeFactory.CreateTypeByCLRName(typeName, module);
                 return type.GetTypeElement();
             }
+        }
+
+        public static bool DerivesFromMonoBehaviour([CanBeNull] this ITypeElement candidate)
+        {
+            return candidate.DerivesFrom(KnownTypes.MonoBehaviour);
+        }
+
+        public static bool DerivesFromScriptableObject([CanBeNull] this ITypeElement candidate)
+        {
+            return candidate.DerivesFrom(KnownTypes.ScriptableObject);
+        }
+
+        public static bool DerivesFromUnityEvent([CanBeNull] this ITypeElement candidate)
+        {
+            return candidate.DerivesFrom(KnownTypes.UnityEvent);
         }
 
         [CanBeNull]
@@ -62,19 +77,16 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
             return unityEventFunction.TypeName.GetFullNameFast() + "." + element.ShortName;
         }
-        
-        public static bool IsUnityComponent(this ITypeElement typeElement, out bool IsBuiltin)
+
+        public static bool IsUnityComponent(this ITypeElement typeElement, out bool isBuiltin)
         {
             // User components must derive from MonoBehaviour, but built in components only have to derive from
             // Component. A built in component will be something that isn't an asset, which means it's come from
             // one of the UnityEngine assemblies, or UnityEditor.dll. Another check might be that the referenced
             // module lives in Assets, but packages makes a mess of that (referenced packages are compiled and
             // referenced from Library or local packages can include a dll as an asset, external to the project)
-            IsBuiltin = typeElement.IsBuiltInUnityClass();
-            if (IsBuiltin)
-                return typeElement.DerivesFrom(KnownTypes.Component);
-
-            return typeElement.DerivesFrom(KnownTypes.MonoBehaviour);
+            isBuiltin = typeElement.IsBuiltInUnityClass();
+            return isBuiltin ? typeElement.DerivesFrom(KnownTypes.Component) : typeElement.DerivesFromMonoBehaviour();
         }
     }
 }

--- a/resharper/resharper-unity/src/DeclaredElementExtensions.cs
+++ b/resharper/resharper-unity/src/DeclaredElementExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
+using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Impl.Reflection2;
@@ -33,15 +34,17 @@ namespace JetBrains.ReSharper.Plugins.Unity
         {
             if (candidate == null)
                 return false;
-            var baseType = GetTypeElement(baseTypeName, candidate.Module);
+            var knownTypesCache = candidate.GetSolution().GetComponent<KnownTypesCache>();
+            var baseType = GetTypeElement(baseTypeName, knownTypesCache, candidate.Module);
             return candidate.IsDescendantOf(baseType);
         }
 
-        private static ITypeElement GetTypeElement(IClrTypeName typeName, IPsiModule module)
+        private static ITypeElement GetTypeElement(IClrTypeName typeName, KnownTypesCache knownTypesCache,
+                                                   IPsiModule module)
         {
             using (CompilationContextCookie.GetExplicitUniversalContextIfNotSet())
             {
-                var type = TypeFactory.CreateTypeByCLRName(typeName, module);
+                var type = knownTypesCache.GetByClrTypeName(typeName, module);
                 return type.GetTypeElement();
             }
         }

--- a/resharper/resharper-unity/src/KnownTypes.cs
+++ b/resharper/resharper-unity/src/KnownTypes.cs
@@ -68,6 +68,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             new ClrTypeName("UnityEngine.Serialization.FormerlySerializedAsAttribute");
 
         // UnityEditor
+        public static readonly IClrTypeName BuildTarget = new ClrTypeName("UnityEditor.BuildTarget");
         public static readonly IClrTypeName CanEditMultipleObjects = new ClrTypeName("UnityEditor.CanEditMultipleObjects");
         public static readonly IClrTypeName CustomEditor = new ClrTypeName("UnityEditor.CustomEditor");
         public static readonly IClrTypeName Editor = new ClrTypeName("UnityEditor.Editor");

--- a/resharper/resharper-unity/src/KnownTypes.cs
+++ b/resharper/resharper-unity/src/KnownTypes.cs
@@ -52,7 +52,9 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName TooltipAttribute = new ClrTypeName("UnityEngine.TooltipAttribute");
         public static readonly IClrTypeName Transform = new ClrTypeName("UnityEngine.Transform");
         public static readonly IClrTypeName Vector2 = new ClrTypeName("UnityEngine.Vector2");
+        public static readonly IClrTypeName Vector2Int = new ClrTypeName("UnityEngine.Vector2Int");
         public static readonly IClrTypeName Vector3 = new ClrTypeName("UnityEngine.Vector3");
+        public static readonly IClrTypeName Vector3Int = new ClrTypeName("UnityEngine.Vector3Int");
         public static readonly IClrTypeName Vector4 = new ClrTypeName("UnityEngine.Vector4");
         public static readonly IClrTypeName UnityEvent = new ClrTypeName("UnityEngine.Events.UnityEventBase");
 
@@ -92,7 +94,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public static readonly IClrTypeName JobComponentSystem = new ClrTypeName("Unity.Entities.JobComponentSystem");
         public static readonly IClrTypeName ComponentSystem = new ClrTypeName("Unity.Entities.ComponentSystem");
         public static readonly IClrTypeName InjectAttribute = new ClrTypeName("Unity.Entities.InjectAttribute");
-        
+
         // Burst
         public static readonly IClrTypeName Job = new ClrTypeName("Unity.Jobs.IJob");
         public static readonly IClrTypeName BurstCompiler = new ClrTypeName("Unity.Burst.BurstCompiler");

--- a/resharper/resharper-unity/src/KnownTypesCache.cs
+++ b/resharper/resharper-unity/src/KnownTypesCache.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+using JetBrains.Annotations;
+using JetBrains.Metadata.Reader.API;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Modules;
+
+namespace JetBrains.ReSharper.Plugins.Unity
+{
+    [SolutionComponent]
+    public class KnownTypesCache
+    {
+        private readonly ConcurrentDictionary<IClrTypeName, IDeclaredType> myTypes = new ConcurrentDictionary<IClrTypeName, IDeclaredType>();
+
+        [NotNull]
+        public IDeclaredType GetByClrTypeName(IClrTypeName typeName, IPsiModule module)
+        {
+            return module.GetPredefinedType().TryGetType(typeName, NullableAnnotation.Unknown)
+                ?? myTypes.GetOrAdd(typeName, name => TypeFactory.CreateTypeByCLRName(name, module));
+        }
+    }
+}

--- a/resharper/resharper-unity/src/MethodSignatureExtensions.cs
+++ b/resharper/resharper-unity/src/MethodSignatureExtensions.cs
@@ -2,14 +2,16 @@ using JetBrains.Annotations;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity
 {
     public static class MethodSignatureExtensions
     {
-        public static MethodSignature AsMethodSignature(this UnityEventFunction eventFunction, IPsiModule module)
+        public static MethodSignature AsMethodSignature(this UnityEventFunction eventFunction,
+                                                        KnownTypesCache knownTypesCache, IPsiModule module)
         {
-            var returnType = eventFunction.ReturnType.AsIType(module);
+            var returnType = eventFunction.ReturnType.AsIType(knownTypesCache, module);
 
             if (eventFunction.Parameters.Length == 0)
                 return new MethodSignature(returnType, eventFunction.IsStatic);
@@ -19,7 +21,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             for (var i = 0; i < eventFunction.Parameters.Length; i++)
             {
                 var parameter = eventFunction.Parameters[i];
-                var paramType = parameter.TypeSpec.AsIType(module);
+                var paramType = parameter.TypeSpec.AsIType(knownTypesCache, module);
                 parameterTypes[i] = paramType;
                 parameterNames[i] = parameter.Name;
             }
@@ -114,10 +116,48 @@ namespace JetBrains.ReSharper.Plugins.Unity
                    || (eventFunction.CanBeCoroutine && IsEnumerator(method.ReturnType));
         }
 
-        private static bool DoTypesMatch(IType type, UnityTypeSpec expectedTypeSpec)
+        private static bool DoTypesMatch(IType type, UnityTypeSpec typeSpec)
         {
-            var expectedType = expectedTypeSpec.AsIType(type.Module);
-            return Equals(expectedType, type);
+            // TODO: Replace with Equals(type, typeSpec.AsIType) if this gets more complex
+            // This handles the types we currently have to deal with - scalars, simple arrays and simple generics. This
+            // method is called frequently, so use KnownTypesCache to mitigate creating too many instances of IType for
+            // the type spec
+            if (typeSpec.IsArray != type is IArrayType)
+                return false;
+
+            // This doesn't handle an array of generic types, but that's ok
+            if (type is IArrayType arrayType)
+                return Equals(arrayType.ElementType.GetTypeElement()?.GetClrName(), typeSpec.ClrTypeName);
+
+            var typeElement = type.GetTypeElement();
+            if (typeElement == null)
+                return false;
+
+            if (Equals(typeElement.GetClrName(), typeSpec.ClrTypeName))
+            {
+                // Now check generics
+                if (typeElement.TypeParameters.Count != typeSpec.TypeParameters.Length)
+                    return false;
+
+                if (typeSpec.TypeParameters.Length > 0)
+                {
+                    var substitution = (type as IDeclaredType)?.GetSubstitution();
+                    if (substitution == null)
+                        return false;
+
+                    var i = 0;
+                    foreach (var typeParameter in substitution.Domain)
+                    {
+                        var typeParameterType = substitution[typeParameter];
+                        if (!Equals(typeParameterType.GetTypeElement()?.GetClrName(), typeSpec.TypeParameters[i]))
+                            return false;
+                        i++;
+                    }
+                }
+                return true;
+            }
+
+            return false;
         }
 
         private static bool IsEnumerator(IType type)

--- a/resharper/resharper-unity/src/UnityApi.cs
+++ b/resharper/resharper-unity/src/UnityApi.cs
@@ -31,11 +31,13 @@ namespace JetBrains.ReSharper.Plugins.Unity
         };
 
         private readonly UnityVersion myUnityVersion;
+        private readonly KnownTypesCache myKnownTypesCache;
         private readonly Lazy<UnityTypes> myTypes;
 
-        public UnityApi(UnityVersion unityVersion)
+        public UnityApi(UnityVersion unityVersion, KnownTypesCache knownTypesCache)
         {
             myUnityVersion = unityVersion;
+            myKnownTypesCache = knownTypesCache;
             myTypes = Lazy.Of(() =>
             {
                 var apiXml = new ApiXml();
@@ -286,7 +288,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return types.Types.Where(t =>
             {
                 using (CompilationContextCookie.GetExplicitUniversalContextIfNotSet())
-                    return t.SupportsVersion(normalisedVersion) && type.IsDescendantOf(t.GetTypeElement(type.Module));
+                    return t.SupportsVersion(normalisedVersion) && type.IsDescendantOf(t.GetTypeElement(myKnownTypesCache, type.Module));
             });
         }
 

--- a/resharper/resharper-unity/src/UnityApi.cs
+++ b/resharper/resharper-unity/src/UnityApi.cs
@@ -67,20 +67,10 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return GetBaseUnityTypes(type).Any();
         }
 
-        public bool IsUnityECSType([CanBeNull] ITypeElement type)
+        public bool IsUnityECSType([CanBeNull] ITypeElement typeElement)
         {
-            if (type == null)
-                return false;
-
-            var jobComponentSystem = TypeFactory.CreateTypeByCLRName(KnownTypes.JobComponentSystem, type.Module);
-            if (type.IsDescendantOf(jobComponentSystem.GetTypeElement()))
-                return true;
-
-            var componentSystem = TypeFactory.CreateTypeByCLRName(KnownTypes.ComponentSystem, type.Module);
-            if (type.IsDescendantOf(componentSystem.GetTypeElement()))
-                return true;
-
-            return false;
+            return typeElement.DerivesFrom(KnownTypes.JobComponentSystem) ||
+                   typeElement.DerivesFrom(KnownTypes.ComponentSystem);
         }
 
         // A serialised field cannot be abstract or generic, but a type declaration that will be serialised can be. This
@@ -175,7 +165,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return type != null && (type.IsSimplePredefined()
                                     || type.IsEnumType()
                                     || IsUnityBuiltinType(type as IDeclaredType)
-                                    || IsDescendantOfUnityObject(type.GetTypeElement())
+                                    || type.GetTypeElement().DerivesFrom(KnownTypes.Object)
                                     || IsSerializableType(type.GetTypeElement(), project, true));
         }
 
@@ -284,34 +274,6 @@ namespace JetBrains.ReSharper.Plugins.Unity
             }
 
             return null;
-        }
-
-        public static bool IsDescendantOf([NotNull] IClrTypeName unityTypeClrName, [CanBeNull] ITypeElement type)
-        {
-            if (type == null)
-                return false;
-            var mb = TypeFactory.CreateTypeByCLRName(unityTypeClrName, type.Module);
-            return type.IsDescendantOf(mb.GetTypeElement());
-        }
-
-        private static bool IsDescendantOfUnityObject([CanBeNull] ITypeElement type)
-        {
-            return IsDescendantOf(KnownTypes.Object, type);
-        }
-
-        public static bool IsDescendantOfMonoBehaviour([CanBeNull] ITypeElement type)
-        {
-            return IsDescendantOf(KnownTypes.MonoBehaviour, type);
-        }
-
-        public static bool IsDescendantOfScriptableObject([CanBeNull] ITypeElement type)
-        {
-            return IsDescendantOf(KnownTypes.ScriptableObject, type);
-        }
-
-        public static bool IsDescendantOfUnityEvent([CanBeNull] ITypeElement type)
-        {
-            return IsDescendantOf(KnownTypes.UnityEvent, type);
         }
 
         public Version GetNormalisedActualVersion(IProject project)

--- a/resharper/resharper-unity/src/UnityEventFunction.cs
+++ b/resharper/resharper-unity/src/UnityEventFunction.cs
@@ -45,6 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         [NotNull]
         public IMethodDeclaration CreateDeclaration([NotNull] CSharpElementFactory factory,
+                                                    [NotNull] KnownTypesCache knownTypesCache,
                                                     [NotNull] IClassLikeDeclaration classDeclaration,
                                                     AccessRights accessRights,
                                                     bool makeVirtual = false,
@@ -70,7 +71,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
                 builder.Append(PredefinedType.IENUMERATOR_FQN.FullName);
             else
             {
-                arg = GetTypeObject(ReturnType, module);
+                arg = GetTypeObject(ReturnType, knownTypesCache, module);
                 if (arg is string)
                 {
                     builder.Append(arg);
@@ -97,7 +98,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
                 // The only place it's currently being used is an out parameter
                 if (parameter.IsByRef) builder.Append("out ");
 
-                arg = GetTypeObject(parameter.TypeSpec, module);
+                arg = GetTypeObject(parameter.TypeSpec, knownTypesCache, module);
                 if (arg is string)
                 {
                     builder.Append(arg);
@@ -130,7 +131,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
             return myMinimumVersion <= unityVersion && unityVersion <= myMaximumVersion;
         }
 
-        private static object GetTypeObject(UnityTypeSpec typeSpec, IPsiModule module)
+        private static object GetTypeObject(UnityTypeSpec typeSpec, KnownTypesCache knownTypesCache, IPsiModule module)
         {
             if (typeSpec.TypeParameters.Length == 0)
             {
@@ -139,7 +140,7 @@ namespace JetBrains.ReSharper.Plugins.Unity
                     return keyword;
             }
 
-            return typeSpec.AsIType(module);
+            return typeSpec.AsIType(knownTypesCache, module);
         }
     }
 }

--- a/resharper/resharper-unity/src/UnityEventFunction.cs
+++ b/resharper/resharper-unity/src/UnityEventFunction.cs
@@ -7,6 +7,7 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Impl;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity
@@ -17,8 +18,8 @@ namespace JetBrains.ReSharper.Plugins.Unity
         private readonly Version myMaximumVersion;
 
         public UnityEventFunction([NotNull] string name, [NotNull] IClrTypeName typeName,
-                                  [NotNull] IClrTypeName returnType, bool returnTypeIsArray, bool isStatic,
-                                  bool canBeCoroutine, string description, bool undocumented, Version minimumVersion,
+                                  [NotNull] UnityTypeSpec returnType, bool isStatic, bool canBeCoroutine,
+                                  string description, bool undocumented, Version minimumVersion,
                                   Version maximumVersion, [NotNull] params UnityEventFunctionParameter[] parameters)
         {
             Description = description;
@@ -30,15 +31,13 @@ namespace JetBrains.ReSharper.Plugins.Unity
             Name = name;
             TypeName = typeName;
             ReturnType = returnType;
-            ReturnTypeIsArray = returnTypeIsArray;
             Parameters = parameters.Length > 0 ? parameters : EmptyArray<UnityEventFunctionParameter>.Instance;
         }
 
         [NotNull] public IClrTypeName TypeName { get; }
         [NotNull] public string Name { get; }
         [NotNull] public UnityEventFunctionParameter[] Parameters { get; }
-        [NotNull] public IClrTypeName ReturnType { get; }
-        public bool ReturnTypeIsArray { get; }
+        [NotNull] public UnityTypeSpec ReturnType { get; }
         public bool CanBeCoroutine { get; }
         public bool IsStatic { get; }
         [CanBeNull] public string Description { get; }
@@ -52,6 +51,10 @@ namespace JetBrains.ReSharper.Plugins.Unity
                                                     bool makeCoroutine = false)
         {
             var builder = new StringBuilder(128);
+            var args = new object[1 + Parameters.Length];
+            object arg;
+            var argIndex = 0;
+            var module = classDeclaration.GetPsiModule();
 
             if (accessRights != AccessRights.NONE)
             {
@@ -63,13 +66,21 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
             // Consider this declaration a template, and the final generated code implements (or overrides) this API
             if (makeVirtual) builder.Append("virtual ");
-            builder.Append("global::");
             if (makeCoroutine && CanBeCoroutine)
                 builder.Append(PredefinedType.IENUMERATOR_FQN.FullName);
             else
             {
-                builder.Append(ReturnType.FullName);
-                if (ReturnTypeIsArray) builder.Append("[]");
+                arg = GetTypeObject(ReturnType, module);
+                if (arg is string)
+                {
+                    builder.Append(arg);
+                    if (ReturnType.IsArray) builder.Append("[]");
+                }
+                else
+                {
+                    builder.Append("$0");
+                    args[argIndex++] = arg;
+                }
             }
 
             builder.Append(" ");
@@ -85,16 +96,25 @@ namespace JetBrains.ReSharper.Plugins.Unity
                 // From reflection point of view, it's a "ByRef" Type, and that's all we know...
                 // The only place it's currently being used is an out parameter
                 if (parameter.IsByRef) builder.Append("out ");
-                builder.Append("global::");
-                builder.Append(parameter.ClrTypeName.FullName);
-                if (parameter.IsArray) builder.Append("[]");
+
+                arg = GetTypeObject(parameter.TypeSpec, module);
+                if (arg is string)
+                {
+                    builder.Append(arg);
+                    if (parameter.TypeSpec.IsArray) builder.Append("[]");
+                }
+                else
+                {
+                    builder.Append($"${argIndex}");
+                    args[argIndex++] = arg;
+                }
                 builder.Append(' ');
                 builder.Append(parameter.Name);
             }
 
             builder.Append(");");
 
-            var declaration = (IMethodDeclaration) factory.CreateTypeMemberDeclaration(builder.ToString());
+            var declaration = (IMethodDeclaration) factory.CreateTypeMemberDeclaration(builder.ToString(), args);
             declaration.SetResolveContextForSandBox(classDeclaration, SandBoxContextType.Child);
             return declaration;
         }
@@ -108,6 +128,18 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public bool SupportsVersion(Version unityVersion)
         {
             return myMinimumVersion <= unityVersion && unityVersion <= myMaximumVersion;
+        }
+
+        private static object GetTypeObject(UnityTypeSpec typeSpec, IPsiModule module)
+        {
+            if (typeSpec.TypeParameters.Length == 0)
+            {
+                var keyword = CSharpTypeFactory.GetTypeKeyword(typeSpec.ClrTypeName);
+                if (keyword != null)
+                    return keyword;
+            }
+
+            return typeSpec.AsIType(module);
         }
     }
 }

--- a/resharper/resharper-unity/src/UnityEventFunctionParameter.cs
+++ b/resharper/resharper-unity/src/UnityEventFunctionParameter.cs
@@ -9,9 +9,8 @@ namespace JetBrains.ReSharper.Plugins.Unity
         public string Name { get; }
 
         [NotNull]
-        public IClrTypeName ClrTypeName { get; }
+        public UnityTypeSpec TypeSpec { get; }
 
-        public bool IsArray { get; }
         public bool IsByRef { get; }
         public bool IsOptional { get; }
         public string Justification { get; }
@@ -19,14 +18,13 @@ namespace JetBrains.ReSharper.Plugins.Unity
         [CanBeNull]
         public string Description { get; }
 
-        public UnityEventFunctionParameter([NotNull] string name, [NotNull] IClrTypeName clrTypeName,
-                                           [CanBeNull] string description, bool isArray, bool isByRef, bool isOptional,
+        public UnityEventFunctionParameter([NotNull] string name, [NotNull] UnityTypeSpec typeSpec,
+                                           [CanBeNull] string description, bool isByRef, bool isOptional,
                                            string justification)
         {
             Name = name;
-            ClrTypeName = clrTypeName;
+            TypeSpec = typeSpec;
             Description = description;
-            IsArray = isArray;
             IsByRef = isByRef;
             IsOptional = isOptional;
             Justification = justification;

--- a/resharper/resharper-unity/src/UnityType.cs
+++ b/resharper/resharper-unity/src/UnityType.cs
@@ -29,11 +29,11 @@ namespace JetBrains.ReSharper.Plugins.Unity
         }
 
         [CanBeNull]
-        public ITypeElement GetTypeElement([NotNull] IPsiModule module)
+        public ITypeElement GetTypeElement(KnownTypesCache knownTypesCache, [NotNull] IPsiModule module)
         {
             using (CompilationContextCookie.GetExplicitUniversalContextIfNotSet())
             {
-                var type = TypeFactory.CreateTypeByCLRName(myTypeName, module);
+                var type = knownTypesCache.GetByClrTypeName(myTypeName, module);
                 return type.GetTypeElement();
             }
         }

--- a/resharper/resharper-unity/src/UnityTypeSpec.cs
+++ b/resharper/resharper-unity/src/UnityTypeSpec.cs
@@ -21,21 +21,25 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         // CLR type name, not C# type name. Mostly the same, but can only represent open generics
         // E.g. System.Collections.Generics.List`1
+        // Even though ApiXml contains a closed type generic name in CLR format, we parse that, and only use open here
         public IClrTypeName ClrTypeName { get; }
         public bool IsArray { get; }
         public IClrTypeName[] TypeParameters { get; }
 
         // TODO: Perhaps this should be an extension method
         [NotNull]
-        public IType AsIType(IPsiModule module)
+        public IType AsIType(KnownTypesCache knownTypesCache, IPsiModule module)
         {
-            IType type = TypeFactory.CreateTypeByCLRName(ClrTypeName, module);
+            // TODO: It would be nice to also cache the closed generic and array types
+            // We would need a different key for that
+
+            IType type = knownTypesCache.GetByClrTypeName(ClrTypeName, module);
             if (TypeParameters.Length > 0)
             {
                 var typeParameters = new IType[TypeParameters.Length];
                 for (int i = 0; i < TypeParameters.Length; i++)
                 {
-                    typeParameters[i] = TypeFactory.CreateTypeByCLRName(TypeParameters[i], module);
+                    typeParameters[i] = knownTypesCache.GetByClrTypeName(TypeParameters[i], module);
                 }
 
                 var typeElement = type.GetTypeElement().NotNull("typeElement != null");

--- a/resharper/resharper-unity/src/UnityTypeSpec.cs
+++ b/resharper/resharper-unity/src/UnityTypeSpec.cs
@@ -1,0 +1,51 @@
+using JetBrains.Annotations;
+using JetBrains.Diagnostics;
+using JetBrains.Metadata.Reader.API;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Unity
+{
+    public class UnityTypeSpec
+    {
+        public static UnityTypeSpec Void = new UnityTypeSpec(PredefinedType.VOID_FQN);
+
+        public UnityTypeSpec(IClrTypeName typeName, bool isArray = false, IClrTypeName[] typeParameters = null)
+        {
+           ClrTypeName = typeName;
+           IsArray = isArray;
+           TypeParameters = typeParameters ?? EmptyArray<IClrTypeName>.Instance;
+        }
+
+        // CLR type name, not C# type name. Mostly the same, but can only represent open generics
+        // E.g. System.Collections.Generics.List`1
+        public IClrTypeName ClrTypeName { get; }
+        public bool IsArray { get; }
+        public IClrTypeName[] TypeParameters { get; }
+
+        // TODO: Perhaps this should be an extension method
+        [NotNull]
+        public IType AsIType(IPsiModule module)
+        {
+            IType type = TypeFactory.CreateTypeByCLRName(ClrTypeName, module);
+            if (TypeParameters.Length > 0)
+            {
+                var typeParameters = new IType[TypeParameters.Length];
+                for (int i = 0; i < TypeParameters.Length; i++)
+                {
+                    typeParameters[i] = TypeFactory.CreateTypeByCLRName(TypeParameters[i], module);
+                }
+
+                var typeElement = type.GetTypeElement().NotNull("typeElement != null");
+                type = TypeFactory.CreateType(typeElement, typeParameters);
+            }
+
+            if (IsArray)
+                type = TypeFactory.CreateArrayType(type, 1);
+
+            return type;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Navigation/UnityInspectorValuesOccurrence.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Navigation/UnityInspectorValuesOccurrence.cs
@@ -27,12 +27,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
             var declaredElement = DeclaredElementPointer.FindDeclaredElement();
             if (declaredElement == null)
                 return base.GetDisplayText();
-            
+
             var solution = GetSolution();
             var valuePresentation = InspectorVariableUsage.Value.GetPresentation(solution, declaredElement , true);
             if (SourceFile.GetLocation().IsAsset())
                 return valuePresentation;
-            
+
             var richText = new RichText(valuePresentation);
             var inText = new RichText(" in ", TextStyle.FromForeColor(Color.DarkGray));
             var objectText = base.GetDisplayText();
@@ -40,7 +40,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
             return richText.Append(inText).Append(objectText);
         }
 
-        private bool IsRelatedToScriptableObject() => UnityApi.IsDescendantOfScriptableObject((DeclaredElementPointer.FindDeclaredElement() as IField)?.Type.GetTypeElement());
+        private bool IsRelatedToScriptableObject()
+        {
+            var field = DeclaredElementPointer.FindDeclaredElement() as IField;
+            return field?.Type.GetTypeElement().DerivesFromScriptableObject() == true;
+        }
 
         public override string ToString()
         {
@@ -51,7 +55,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
                     var de = DeclaredElementPointer.FindDeclaredElement();
                     if (de == null)
                         return "INVALID";
-                    
+
                     if (IsRelatedToScriptableObject())
                     {
                         var value = InspectorVariableUsage.Value.GetFullPresentation(GetSolution(), DeclaredElementPointer.FindDeclaredElement(), true);

--- a/resharper/resharper-unity/src/Yaml/Feature/Services/Navigation/UnityScriptsOccurrence.cs
+++ b/resharper/resharper-unity/src/Yaml/Feature/Services/Navigation/UnityScriptsOccurrence.cs
@@ -1,10 +1,8 @@
 using System;
-using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarchy.Elements;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarchy.References;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Pointers;
 using JetBrains.UI.RichText;
-using JetBrains.Util.Extension;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
 {
@@ -24,10 +22,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
             var declaredElement = DeclaredElementPointer.FindDeclaredElement();
             if (declaredElement == null)
                 return base.GetDisplayText();
-            
-            if (UnityApi.IsDescendantOfScriptableObject(declaredElement as IClass))
-                return SourceFile.GetLocation().Name;  
-            
+
+            if ((declaredElement as IClass).DerivesFromScriptableObject())
+                return SourceFile.GetLocation().Name;
+
             return base.GetDisplayText();
         }
 
@@ -37,9 +35,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation
                 return null;
             return base.GetRelatedFilePresentation();
         }
-        
-        private bool IsRelatedToScriptableObject() => UnityApi.IsDescendantOfScriptableObject(DeclaredElementPointer.FindDeclaredElement() as IClass);
-        
+
+        private bool IsRelatedToScriptableObject()
+        {
+            return (DeclaredElementPointer.FindDeclaredElement() as IClass).DerivesFromScriptableObject();
+        }
+
         public override string ToString()
         {
             return $"Guid: {myGuid:N}";

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetInspectorValues/Values/AssetReferenceValue.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetInspectorValues/Values/AssetReferenceValue.cs
@@ -18,7 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetInspect
     [PolymorphicMarshaller]
     public class AssetReferenceValue : IAssetValue
     {
-        [UsedImplicitly] 
+        [UsedImplicitly]
         public static UnsafeReader.ReadDelegate<object> ReadDelegate = Read;
 
         private static object Read(UnsafeReader reader) => new AssetReferenceValue( HierarchyReferenceUtil.ReadReferenceFrom(reader));
@@ -30,9 +30,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetInspect
         {
             value.Reference.WriteTo(writer);
         }
-        
+
         public IHierarchyReference Reference { get; }
-        
+
         public AssetReferenceValue(IHierarchyReference reference)
         {
             Assertion.Assert(reference != null, "reference != null");
@@ -62,11 +62,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetInspect
             solution.GetComponent<IShellLocks>().AssertReadAccessAllowed();
             var hierarchyContainer = solution.GetComponent<AssetDocumentHierarchyElementContainer>();
 
-            if (UnityApi.IsDescendantOfScriptableObject((declaredElement as IField)?.Type.GetTypeElement()))
+            if ((declaredElement as IField)?.Type.GetTypeElement().DerivesFromScriptableObject() == true)
             {
                 if (Reference is LocalReference localReference && localReference.LocalDocumentAnchor == 0)
                     return "None";
-                
+
                 var sourceFile = hierarchyContainer.GetSourceFile(Reference, out _);
                 if (sourceFile == null)
                     return "...";
@@ -76,10 +76,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetInspect
 
                 return sourceFile.GetLocation().Name + $" (in {sourceFile.DisplayName.Replace('\\', '/').RemoveStart("Assets/").RemoveEnd("/" + sourceFile.GetLocation().Name)})";
             }
-            
+
             if (Reference.LocalDocumentAnchor == 0)
                 return "None";
-                
+
             var processor = solution.GetComponent<AssetHierarchyProcessor>();
             var consumer = new UnityScenePathGameObjectConsumer(true);
             var element = hierarchyContainer.GetHierarchyElement(Reference, prefabImport);

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetUtils.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetUtils.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using JetBrains.Collections;
-using JetBrains.Metadata.Reader.API;
-using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Daemon.UsageChecking;
@@ -19,14 +17,13 @@ using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.JavaScript.Util.Literals;
 using JetBrains.ReSharper.Psi.Parsing;
-using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.Text;
 using JetBrains.Util;
 using JetBrains.Util.Collections;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 {
-    public class AssetUtils
+    public static class AssetUtils
     {
         private static readonly StringSearcher ourMonoBehaviourCheck = new StringSearcher("!u!114 ", true);
         private static readonly StringSearcher ourFileIdCheck = new StringSearcher("fileID:", false);
@@ -55,20 +52,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
         public static bool IsReferenceValue(IBuffer buffer) =>
             ourFileIdCheck.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
-        
+
         public static bool IsPrefabModification(IBuffer buffer) =>
             ourPrefabModificationSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
-        
+
         public static bool IsTransform(IBuffer buffer) =>
             ourTransformSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0 ||
             ourRectTransformSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
-        
+
         public static bool IsGameObject(IBuffer buffer) =>
             ourGameObjectSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
-        
+
         public static bool IsStripped(IBuffer buffer) =>
             ourStrippedSearcher.Find(buffer, 0, Math.Min(buffer.Length, 150)) >= 0;
-        
+
         public static ulong? GetAnchorFromBuffer(IBuffer buffer)
         {
             var index = 0;
@@ -76,7 +73,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
             {
                 if (index == buffer.Length)
                     return null;
-                
+
                 if (buffer[index] == '&')
                     break;
 
@@ -101,11 +98,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
         [CanBeNull]
         public static IHierarchyReference GetGameObjectReference(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer) =>
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourGameObjectFieldSearcher);
-        
+
         [CanBeNull]
         public static IHierarchyReference GetTransformFather(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer) =>
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourFatherSearcher);
-        
+
         [CanBeNull]
         public static IHierarchyReference GetSourcePrefab(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer) =>
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourSourcePrefabSearcher) ??
@@ -124,7 +121,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
                 else
                     break;
             }
-            
+
             var result = new StringBuilder();
 
             while (start < assetDocumentBuffer.Length)
@@ -155,7 +152,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
                 eol = ourEndLine2Searcher.Find(buffer, start, buffer.Length);
             if (eol < 0)
                 return null;
-            
+
             var nameBuffer = ProjectedBuffer.Create(buffer, new TextRange(start, eol + 1));
             var lexer = new YamlLexer(nameBuffer, false, false);
             var parser = new YamlParser(lexer.ToCachingLexer());
@@ -164,7 +161,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
             return (document.Body.BlockNode as IBlockMappingNode)?.Entries.FirstOrDefault()?.Content.Value
                 .GetPlainScalarText();
         }
-        
+
         [CanBeNull]
         public static IHierarchyReference GetPrefabInstance(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer) =>
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourPrefabInstanceSearcher) ??
@@ -174,7 +171,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
         public static IHierarchyReference GetCorrespondingSourceObject(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer) =>
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourCorrespondingObjectSearcher) ??
             GetReferenceBySearcher(assetSourceFile, assetDocumentBuffer, ourCorrespondingObjectSearcher2017);
-        
+
         [CanBeNull]
         public static IHierarchyReference GetReferenceBySearcher(IPsiSourceFile assetSourceFile, IBuffer assetDocumentBuffer, StringSearcher searcher)
         {
@@ -184,7 +181,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
             var end = ourBracketSearcher.Find(assetDocumentBuffer, start, assetDocumentBuffer.Length);
             if (end < 0)
                 return null;
-            
+
             var buffer = ProjectedBuffer.Create(assetDocumentBuffer, new TextRange(start, end + 1));
             var lexer = new YamlLexer(buffer, false, false);
             var parser = new YamlParser(lexer.ToCachingLexer());
@@ -192,7 +189,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
             return (document.Body.BlockNode as IBlockMappingNode)?.Entries.FirstOrDefault()?.Content.Value.ToHierarchyReference(assetSourceFile);
         }
-        
+
         [CanBeNull]
         public static IBlockMappingNode GetPrefabModification(IYamlDocument yamlDocument)
         {
@@ -200,12 +197,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
             return yamlDocument.GetUnityObjectPropertyValue(UnityYamlConstants.ModificationProperty) as IBlockMappingNode;
         }
 
-        private static readonly IClrTypeName ourFormerlySerializedAsAttribute = new ClrTypeName("UnityEngine.Serialization.FormerlySerializedAsAttribute");
         public static IEnumerable<string> GetAllNamesFor(IField field)
         {
             yield return field.ShortName;
 
-            foreach (var attribute in field.GetAttributeInstances(ourFormerlySerializedAsAttribute, false))
+            foreach (var attribute in field.GetAttributeInstances(KnownTypes.FormerlySerializedAsAttribute, false))
             {
                 var result = attribute.PositionParameters().FirstOrDefault()?.ConstantValue.Value as string;
                 if (result == null)
@@ -233,7 +229,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
             return assetDocumentBuffer.GetText(new TextRange(startPos, pos));
         }
-        
+
         public static string GetComponentName(MetaFileGuidCache metaFileGuidCache, IComponentHierarchy componentHierarchy)
         {
             if (componentHierarchy is IScriptComponentHierarchy scriptComponent)
@@ -285,13 +281,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
             return null;
         }
-        
+
         public static Guid? GetGuidFor(MetaFileGuidCache metaFileGuidCache, ITypeElement typeElement)
         {
             var sourceFile = typeElement.GetDeclarations().FirstOrDefault()?.GetSourceFile();
             if (sourceFile == null || !sourceFile.IsValid())
                 return null;
-            
+
             if (typeElement.TypeParameters.Count != 0)
                 return null;
 
@@ -307,7 +303,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
         public static bool HasPossibleDerivedTypesWithMember(Guid ownerGuid, ITypeElement containingType, IEnumerable<string> memberNames, OneToCompactCountingSet<int, Guid> nameHashToGuids)
         {
-            
+
             var count = 0;
             foreach (var possibleName in memberNames)
             {
@@ -319,7 +315,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
 
             if (count > 1)
             {
-                // TODO: drop daemon dependency and inject compoentns in consructor
+                // TODO: drop daemon dependency and inject components in constructor
                 var configuration = containingType.GetSolution().GetComponent<SolutionAnalysisConfiguration>();
                 if (configuration.Enabled.Value && configuration.CompletedOnceAfterStart.Value &&
                     configuration.Loaded.Value)

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityAssetReferenceSearcher.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityAssetReferenceSearcher.cs
@@ -36,7 +36,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
         {
             if (!myDeferredCacheController.CompletedOnce.Value)
                 return false;
-            
+
             foreach (var element in myElements)
             {
                 if (element is IMethod || element is IProperty)
@@ -60,7 +60,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
 
                 if (element is IField field)
                 {
-                    if (UnityApi.IsDescendantOfUnityEvent(field.Type.GetTypeElement()))
+                    if (field.Type.GetTypeElement().DerivesFromUnityEvent())
                     {
                         foreach (var findResult in myUnityEventsElementContainer.GetMethodsForUnityEvent(sourceFile, field))
                         {

--- a/resharper/resharper-unity/src/Yaml/Psi/Search/UnityAssetSearchGuru.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Search/UnityAssetSearchGuru.cs
@@ -52,7 +52,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
                         set.Add(sourceFile);
                     break;
                 case IField field:
-                    if (UnityApi.IsDescendantOfUnityEvent(field.Type.GetTypeElement()))
+                    if (field.Type.GetTypeElement().DerivesFromUnityEvent())
                     {
                         foreach (var sourceFile in myUnityEventsElementContainer.GetPossibleFilesWithUsage(element))
                             set.Add(sourceFile);
@@ -65,7 +65,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Search
 
                     break;
             }
-            
+
             return new UnityYamlSearchGuruId(set);
         }
 

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -348,6 +348,22 @@
     <message name="OnSceneGUI" static="False" description="Enables the Editor to handle an event in the Scene view." path="Documentation/en/ScriptReference/Editor.OnSceneGUI.html">
       <returns type="System.Void" array="False" />
     </message>
+    <message name="HasFrameBounds" static="False" minimumVersion="2017.1" maximumVersion="2020.1" undocumented="True" description="Validates whether custom bounds can be calculated for this editor.">
+      <returns type="System.Boolean" array="False" />
+    </message>
+    <message name="OnGetFrameBounds" static="False" minimumVersion="2017.1" maximumVersion="2020.1" undocumented="True" description="Gets custom bounds for the target of this editor.">
+      <returns type="UnityEngine.Bounds" array="False" />
+    </message>
+    <message name="OnPreSceneGUI" static="False" minimumVersion="2017.1" undocumented="True" description="Called before the Scene view is drawn.">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnSceneDrag" static="False" minimumVersion="2017.1" undocumented="True" description="Called for each object dragged onto the scene view">
+      <parameters>
+        <parameter type="UnityEditor.SceneView" array="False" name="sceneView" description="The current scene view" />
+        <parameter type="System.Int32" array="False" name="index" description="The index into the DragAndDrop.objectReferences array" />
+      </parameters>
+      <returns type="System.Void" array="False" />
+    </message>
   </type>
   <type kind="class" name="EditorWindow" ns="UnityEditor" path="Documentation/en/ScriptReference/EditorWindow.html">
     <message name="Awake" static="False" minimumVersion="5.5" description="Called as the new window is opened." path="Documentation/en/ScriptReference/EditorWindow.Awake.html">
@@ -378,6 +394,33 @@
       <returns type="System.Void" array="False" />
     </message>
     <message name="Update" static="False" description="Called multiple times per second on all visible windows." path="Documentation/en/ScriptReference/EditorWindow.Update.html">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="ModifierKeysChanged" static="False" minimumVersion="2017.1" undocumented="True" description="Called when the modifier keys are changed. Automatically registers and de-registers the EditorApplication.modifierKeysChanged event">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnAddedAsTab" static="False" minimumVersion="2019.1" undocumented="True" description="Called when the editor window is added as a tab">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnBecameInvisible" static="False" minimumVersion="2017.1" undocumented="True" description="Called when an editor window has been closed">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnBecameVisible" static="False" minimumVersion="2017.1" undocumented="True" description="Called when an editor window has been opened">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnDidOpenScene" static="False" minimumVersion="2017.1" undocumented="True" description="Called when a scene has been opened">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnMainWindowMove" static="False" minimumVersion="2020.1" undocumented="True" description="Called when the main window is moved">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnTabDetached" static="False" minimumVersion="2019.3" undocumented="True" description="Called during drag and drop, when an editor window tab is detached">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="ShowButton" static="False" minimumVersion="2017.1" undocumented="True" description="Allow Editor panes to show a small button next to the generic menu (e.g. inspector lock icon)">
+      <parameters>
+        <parameter type="UnityEngine.Rect" array="False" name="rect" description="Position to draw the button" />
+      </parameters>
       <returns type="System.Void" array="False" />
     </message>
   </type>
@@ -840,10 +883,16 @@
     <message name="OnEnable" static="False" description="This function is called when the object is loaded." path="Documentation/en/ScriptReference/ScriptableObject.OnEnable.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="OnValidate" static="False" undocumented="True" description="This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).">
+    <message name="OnValidate" static="False" minimumVersion="2020.2" description="This function is called when the script is loaded or a value is changed in the Inspector (Called in the editor only)." path="Documentation/en/ScriptReference/ScriptableObject.OnValidate.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="Reset" static="False" undocumented="True" description="Reset to default values.">
+    <message name="Reset" static="False" minimumVersion="2020.2" description="Reset to default values." path="Documentation/en/ScriptReference/ScriptableObject.Reset.html">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnValidate" static="False" maximumVersion="2020.1" undocumented="True" description="This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="Reset" static="False" maximumVersion="2020.1" undocumented="True" description="Reset to default values.">
       <returns type="System.Void" array="False" />
     </message>
   </type>

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -1,10 +1,41 @@
 ﻿<!--This file is auto-generated-->
-<api minimumVersion="5.0" maximumVersion="2020.1">
+<api minimumVersion="5.0" maximumVersion="2020.2">
   <type kind="class" name="AssetModificationProcessor" ns="UnityEditor" path="Documentation/en/ScriptReference/AssetModificationProcessor.html">
-    <message name="IsOpenForEdit" static="True" description="This is called by Unity when inspecting an asset to determine if an editor should be disabled." path="Documentation/en/ScriptReference/AssetModificationProcessor.IsOpenForEdit.html">
+    <message name="CanOpenForEdit" static="True" minimumVersion="2020.2" description="This is called by Unity when inspecting assets to determine if they can potentially be opened for editing." path="Documentation/en/ScriptReference/AssetModificationProcessor.CanOpenForEdit.html">
+      <parameters>
+        <parameter type="System.String" array="True" name="assetOrMetaFilePaths" description="Paths to Assets or their .meta files, relative to the project folder." />
+        <parameter type="System.Collections.Generic.List`1[[System.String]]" array="False" name="outNotEditablePaths" description="Destination list of non-editable Asset paths." />
+        <parameter type="UnityEditor.StatusQueryOptions" array="False" name="statusQueryOptions" description="Specifies how Unity should query the version control system. The default value is StatusQueryOptions.UseCachedIfPossible." />
+      </parameters>
+      <returns type="System.Boolean" array="False" />
+    </message>
+    <message name="FileModeChanged" static="True" minimumVersion="2020.2" description="Unity calls this method when file mode has been changed for one or more files." path="Documentation/en/ScriptReference/AssetModificationProcessor.FileModeChanged.html">
+      <parameters>
+        <parameter type="System.String" array="True" name="paths" />
+        <parameter type="UnityEditor.VersionControl.FileMode" array="False" name="mode" />
+      </parameters>
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="IsOpenForEdit" static="True" maximumVersion="2020.1" description="This is called by Unity when inspecting an asset to determine if an editor should be disabled." path="Documentation/en/ScriptReference/AssetModificationProcessor.IsOpenForEdit.html">
       <parameters>
         <parameter type="System.String" array="False" name="assetPath" />
         <parameter type="System.String" array="False" byRef="True" name="message" />
+      </parameters>
+      <returns type="System.Boolean" array="False" />
+    </message>
+    <message name="IsOpenForEdit" static="True" minimumVersion="2020.2" description="This is called by Unity when inspecting assets to determine if an editor should be disabled." path="Documentation/en/ScriptReference/AssetModificationProcessor.IsOpenForEdit.html">
+      <parameters>
+        <parameter type="System.String" array="True" name="assetOrMetaFilePaths" description="Paths to Assets or their .meta files, relative to the project folder." />
+        <parameter type="System.Collections.Generic.List`1[[System.String]]" array="False" name="outNotEditablePaths" description="Destination list of non-editable Asset paths." />
+        <parameter type="UnityEditor.StatusQueryOptions" array="False" name="statusQueryOptions" description="Specifies how Unity should query the version control system. The default value is StatusQueryOptions.UseCachedIfPossible." />
+      </parameters>
+      <returns type="System.Boolean" array="False" />
+    </message>
+    <message name="MakeEditable" static="True" minimumVersion="2020.2" description="Unity calls this method when one or more files need to be opened for editing." path="Documentation/en/ScriptReference/AssetModificationProcessor.MakeEditable.html">
+      <parameters>
+        <parameter type="System.String" array="True" name="paths" description="Specifies an array of file paths relative to the project root." />
+        <parameter type="System.String" array="False" name="prompt" description="Dialog prompt to show to the user, if a version control operation needs to be done. If null (default), no prompt is shown." />
+        <parameter type="System.Collections.Generic.List`1[[System.String]]" array="False" name="outNotEditablePaths" description="Output list of file paths that could not be made editable." />
       </parameters>
       <returns type="System.Boolean" array="False" />
     </message>
@@ -116,6 +147,12 @@
       <returns type="System.Void" array="False" />
     </message>
     <message name="OnPostprocessModel" static="False" description="Add this function to a subclass to get a notification when a model has completed importing." path="Documentation/en/ScriptReference/AssetPostprocessor.OnPostprocessModel.html">
+      <parameters>
+        <parameter type="UnityEngine.GameObject" array="False" name="g" />
+      </parameters>
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="OnPostprocessPrefab" static="False" minimumVersion="2020.2" description="Gets a notification when a Prefab completes importing." path="Documentation/en/ScriptReference/AssetPostprocessor.OnPostprocessPrefab.html">
       <parameters>
         <parameter type="UnityEngine.GameObject" array="False" name="g" />
       </parameters>
@@ -302,6 +339,12 @@
     </message>
   </type>
   <type kind="class" name="Editor" ns="UnityEditor" path="Documentation/en/ScriptReference/Editor.html">
+    <message name="HasFrameBounds" static="False" minimumVersion="2020.2" description="Validates whether custom bounds can be calculated for this editor." path="Documentation/en/ScriptReference/Editor.HasFrameBounds.html">
+      <returns type="System.Boolean" array="False" />
+    </message>
+    <message name="OnGetFrameBounds" static="False" minimumVersion="2020.2" description="Gets custom bounds for the target of this editor." path="Documentation/en/ScriptReference/Editor.OnGetFrameBounds.html">
+      <returns type="UnityEngine.Bounds" array="False" />
+    </message>
     <message name="OnSceneGUI" static="False" description="Enables the Editor to handle an event in the Scene view." path="Documentation/en/ScriptReference/Editor.OnSceneGUI.html">
       <returns type="System.Void" array="False" />
     </message>
@@ -815,7 +858,7 @@
       <returns type="System.Void" array="False" />
     </message>
   </type>
-  <type kind="class" name="ScriptedImporter" ns="UnityEditor.Experimental.AssetImporters" minimumVersion="2019.1" path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.html">
+  <type kind="class" name="ScriptedImporter" ns="UnityEditor.Experimental.AssetImporters" minimumVersion="2019.1" maximumVersion="2020.1" path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.html">
     <message name="GatherDependenciesFromSourceFile" static="True" minimumVersion="2020.1" description="A static callback that you can implement to set up artifact dependencies to other Assets, and optimize the order your assets are imported." path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.GatherDependenciesFromSourceFile.html">
       <parameters>
         <parameter type="System.String" array="False" name="assetPath" />
@@ -826,6 +869,20 @@
       <returns type="System.Void" array="False" />
     </message>
     <message name="Reset" static="False" description="Reset to default values." path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.Reset.html">
+      <returns type="System.Void" array="False" />
+    </message>
+  </type>
+  <type kind="class" name="ScriptedImporter" ns="UnityEditor.AssetImporters" minimumVersion="2020.2" path="Documentation/en/ScriptReference/AssetImporters.ScriptedImporter.html">
+    <message name="GatherDependenciesFromSourceFile" static="True" description="A static callback that you can implement to set up artifact dependencies to other Assets, and optimize the order your assets are imported." path="Documentation/en/ScriptReference/AssetImporters.ScriptedImporter.GatherDependenciesFromSourceFile.html">
+      <parameters>
+        <parameter type="System.String" array="False" name="assetPath" />
+      </parameters>
+      <returns type="System.String" array="True" />
+    </message>
+    <message name="OnValidate" static="False" description="This function is called when the importer is loaded or a value is changed in the Inspector." path="Documentation/en/ScriptReference/AssetImporters.ScriptedImporter.OnValidate.html">
+      <returns type="System.Void" array="False" />
+    </message>
+    <message name="Reset" static="False" description="Reset to default values." path="Documentation/en/ScriptReference/AssetImporters.ScriptedImporter.Reset.html">
       <returns type="System.Void" array="False" />
     </message>
   </type>

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -816,6 +816,12 @@
     </message>
   </type>
   <type kind="class" name="ScriptedImporter" ns="UnityEditor.Experimental.AssetImporters" minimumVersion="2019.1" path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.html">
+    <message name="GatherDependenciesFromSourceFile" static="True" minimumVersion="2020.1" description="A static callback that you can implement to set up artifact dependencies to other Assets, and optimize the order your assets are imported." path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.GatherDependenciesFromSourceFile.html">
+      <parameters>
+        <parameter type="System.String" array="False" name="assetPath" />
+      </parameters>
+      <returns type="System.String" array="True" />
+    </message>
     <message name="OnValidate" static="False" description="This function is called when the importer is loaded or a value is changed in the Inspector." path="Documentation/en/ScriptReference/Experimental.AssetImporters.ScriptedImporter.OnValidate.html">
       <returns type="System.Void" array="False" />
     </message>

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -21,7 +21,7 @@
       </parameters>
       <returns type="UnityEditor.AssetDeleteResult" array="False" />
     </message>
-    <message name="OnWillMoveAsset" static="True" description="This is called by Unity when it is about to move an asset on disk." path="Documentation/en/ScriptReference/AssetModificationProcessor.OnWillMoveAsset.html">
+    <message name="OnWillMoveAsset" static="True" description="Unity calls this method when it is about to move an Asset on disk." path="Documentation/en/ScriptReference/AssetModificationProcessor.OnWillMoveAsset.html">
       <parameters>
         <parameter type="System.String" array="False" name="sourcePath" />
         <parameter type="System.String" array="False" name="destinationPath" />

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
@@ -1,4 +1,4 @@
-﻿# 1120 ITEMS #
+﻿# 1127 ITEMS #
 
 + private Awake() { ... }
 private OnDestroy() { ... }
@@ -12,8 +12,15 @@ private OnLostFocus() { ... }
 private OnProjectChange() { ... }
 private OnSelectionChange() { ... }
 private Update() { ... }
+private ModifierKeysChanged() { ... }
+private OnAddedAsTab() { ... }
+private OnBecameInvisible() { ... }
+private OnBecameVisible() { ... }
+private OnDidOpenScene() { ... }
+private OnTabDetached() { ... }
 private OnValidate() { ... }
 private Reset() { ... }
+private ShowButton(Rect) { ... }
 abstract
 async
 bool
@@ -1121,7 +1128,7 @@ public override GetExtraPaneTypes() { … }    IEnumerable<Type>
 public override GetHashCode() { … }    int
 public override ToString() { … }    string
 # AUTOMATIC #
-# 1120 ITEMS #
+# 1127 ITEMS #
 
 + private Awake() { ... }
 private OnDestroy() { ... }
@@ -1135,8 +1142,15 @@ private OnLostFocus() { ... }
 private OnProjectChange() { ... }
 private OnSelectionChange() { ... }
 private Update() { ... }
+private ModifierKeysChanged() { ... }
+private OnAddedAsTab() { ... }
+private OnBecameInvisible() { ... }
+private OnBecameVisible() { ... }
+private OnDidOpenScene() { ... }
+private OnTabDetached() { ... }
 private OnValidate() { ... }
 private Reset() { ... }
+private ShowButton(Rect) { ... }
 abstract
 async
 bool

--- a/resharper/resharper-unity/test/data/CSharp/Generate/HasExistingBaseFunctions.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Generate/HasExistingBaseFunctions.cs.gold
@@ -4,16 +4,23 @@
  2: Update():System.Void
  3: OnEnable():System.Void
  4: OnDisable():System.Void
- 5: OnFocus():System.Void
- 6: OnHierarchyChange():System.Void
- 7: OnInspectorUpdate():System.Void
- 8: OnLostFocus():System.Void
- 9: OnProjectChange():System.Void
- 10: OnSelectionChange():System.Void
- 11: OnValidate():System.Void
- 12: OnWizardCreate():System.Void
- 13: OnWizardOtherButton():System.Void
- 14: OnWizardUpdate():System.Void
+ 5: ModifierKeysChanged():System.Void
+ 6: OnAddedAsTab():System.Void
+ 7: OnBecameInvisible():System.Void
+ 8: OnBecameVisible():System.Void
+ 9: OnDidOpenScene():System.Void
+ 10: OnFocus():System.Void
+ 11: OnHierarchyChange():System.Void
+ 12: OnInspectorUpdate():System.Void
+ 13: OnLostFocus():System.Void
+ 14: OnProjectChange():System.Void
+ 15: OnSelectionChange():System.Void
+ 16: OnTabDetached():System.Void
+ 17: OnValidate():System.Void
+ 18: OnWizardCreate():System.Void
+ 19: OnWizardOtherButton():System.Void
+ 20: OnWizardUpdate():System.Void
+ 21: ShowButton(UnityEngine.Rect):System.Void
 
 // ${KIND:Unity.EventFunctions}
 using UnityEditor;

--- a/resharper/resharper-unity/test/data/CSharp/Generate/ListElements08.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Generate/ListElements08.cs.gold
@@ -4,8 +4,12 @@
  2: OnEnable():System.Void
  3: OnDisable():System.Void
  4: OnDestroy():System.Void
- 5: OnSceneGUI():System.Void
- 6: OnValidate():System.Void
+ 5: HasFrameBounds():System.Boolean
+ 6: OnGetFrameBounds():UnityEngine.Bounds
+ 7: OnPreSceneGUI():System.Void
+ 8: OnSceneDrag(UnityEditor.SceneView,System.Int32):System.Void
+ 9: OnSceneGUI():System.Void
+ 10: OnValidate():System.Void
 
 // ${KIND:Unity.EventFunctions}
 using UnityEditor;

--- a/resharper/resharper-unity/test/data/CSharp/Generate/ListElements09.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Generate/ListElements09.cs.gold
@@ -6,13 +6,20 @@
  4: OnDisable():System.Void
  5: OnDestroy():System.Void
  6: OnGUI():System.Void
- 7: OnFocus():System.Void
- 8: OnHierarchyChange():System.Void
- 9: OnInspectorUpdate():System.Void
- 10: OnLostFocus():System.Void
- 11: OnProjectChange():System.Void
- 12: OnSelectionChange():System.Void
- 13: OnValidate():System.Void
+ 7: ModifierKeysChanged():System.Void
+ 8: OnAddedAsTab():System.Void
+ 9: OnBecameInvisible():System.Void
+ 10: OnBecameVisible():System.Void
+ 11: OnDidOpenScene():System.Void
+ 12: OnFocus():System.Void
+ 13: OnHierarchyChange():System.Void
+ 14: OnInspectorUpdate():System.Void
+ 15: OnLostFocus():System.Void
+ 16: OnProjectChange():System.Void
+ 17: OnSelectionChange():System.Void
+ 18: OnTabDetached():System.Void
+ 19: OnValidate():System.Void
+ 20: ShowButton(UnityEngine.Rect):System.Void
 
 // ${KIND:Unity.EventFunctions}
 using UnityEditor;


### PR DESCRIPTION
This PR updates the API information to Unity 2020.2.0a18.

It should be that simple, but Unity have introduced a method that takes a `List<string>` and it's the first generic argument we've had to handle and it breaks everything. We were storing parameter and types as `IClrTypeName`, and using this interchangeably with C# types (e.g. when generating method declarations for code completion).

However, `IClrTypeName` can only hold, as the name suggests, CLR type names. This means open generics, rather than closed generics. And it does it in CLR format, not C# format. So it can hold `System.Collections.Generic.List'1` (that should be a backtick, but markdown), but it can't hold `System.Collections.Generic.List`1[[System.String]]`. We also can't generate a method declaration from the open generic CLR type name, but need to convert it to a closed generic type first.

- [x] Update API information to Unity 2020.2.0a18. Closed generics are written in CLR form into the `api.xml` file and parsed into open generic + type parameter types when reading
- [x] API information is converted into `IType` using `TypeFactory`. This gives us proper type information, including closed generics
- [x] We create a lot of instances of types for "derives from" checks, completion + inspections, so the types are now cached per solution in a new class - `KnownTypesCache`
- [x] Added extra undocumented event functions