### PR TITLE
Workaround for debugger evaluation timeout

### DIFF
--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -29,7 +29,6 @@ namespace JetBrains.Rider.Unity.Editor
     private static readonly IPluginSettings ourPluginSettings;
     private static readonly RiderPathProvider ourRiderPathProvider;
     public static readonly List<ModelWithLifetime> UnityModels = new List<ModelWithLifetime>();
-    private static readonly UnityEventCollector ourLogEventCollector;
     private static bool ourInitialized;
     private static readonly ILog ourLogger = Log.GetLog("RiderPlugin");
     internal static string SlnFile;
@@ -41,7 +40,7 @@ namespace JetBrains.Rider.Unity.Editor
         return;
 
       PluginSettings.InitLog(); // init log before doing any logging
-      ourLogEventCollector = new UnityEventCollector(); // start collecting Unity messages asap
+      UnityEventLogSender.Start(); // start collecting Unity messages asap
 
       ourPluginSettings = new PluginSettings();
       ourRiderPathProvider = new RiderPathProvider(ourPluginSettings);
@@ -326,7 +325,6 @@ namespace JetBrains.Rider.Unity.Editor
           var pair = new ModelWithLifetime(model, connectionLifetime);
           connectionLifetime.OnTermination(() => { UnityModels.Remove(pair); });
           UnityModels.Add(pair);
-          new UnityEventLogSender(ourLogEventCollector);
         });
       }
       catch (Exception ex)

--- a/unity/EditorPlugin/UnityEventLogSender.cs
+++ b/unity/EditorPlugin/UnityEventLogSender.cs
@@ -11,7 +11,7 @@ namespace JetBrains.Rider.Unity.Editor
   public class UnityEventCollector
   {
     public readonly BoundedSynchronizedQueue<RdLogEvent> DelayedLogEvents = new BoundedSynchronizedQueue<RdLogEvent>(1000);
-    private bool myLogEventsCollectorEnabled;
+    public bool LogEventsCollectorEnabled;
 
     public UnityEventCollector()
     {
@@ -20,7 +20,7 @@ namespace JetBrains.Rider.Unity.Editor
 
       EditorApplication.update += () =>
       {
-          myLogEventsCollectorEnabled = PluginSettings.LogEventsCollectorEnabled; // can be called only from main thread
+          LogEventsCollectorEnabled = PluginSettings.LogEventsCollectorEnabled; // can be called only from main thread
       };
 
       // Both of these methods were introduced in 5.0+ but EditorPlugin.csproj still targets 4.7
@@ -65,7 +65,7 @@ namespace JetBrains.Rider.Unity.Editor
 
     private void ApplicationOnLogMessageReceived(string message, string stackTrace, LogType type)
     {
-      if (!myLogEventsCollectorEnabled) // stop collecting, if setting was disabled
+      if (!LogEventsCollectorEnabled) // stop collecting, if setting was disabled
         return;
       
       RdLogEventType eventType;
@@ -99,7 +99,7 @@ namespace JetBrains.Rider.Unity.Editor
     {
       EditorApplication.update += () =>
       {
-        if (!PluginSettings.LogEventsCollectorEnabled)
+        if (!collector.LogEventsCollectorEnabled)
           return;
 
         ProcessQueue(collector);
@@ -108,7 +108,7 @@ namespace JetBrains.Rider.Unity.Editor
 
     private void ProcessQueue(UnityEventCollector collector)
     {
-      if (PluginEntryPoint.UnityModels.Any(l => l.Lifetime.IsAlive))
+      if (PluginEntryPoint.UnityModels.Any())
       {
         RdLogEvent element;
         while ((element  = collector.DelayedLogEvents.Dequeue()) != null)

--- a/unity/EditorPlugin/UnityEventLogSender.cs
+++ b/unity/EditorPlugin/UnityEventLogSender.cs
@@ -94,23 +94,23 @@ namespace JetBrains.Rider.Unity.Editor
 
   public class UnityEventLogSender
   {
+    private readonly UnityEventCollector myCollector;
+
     public UnityEventLogSender(UnityEventCollector collector)
     {
-      EditorApplication.update += () =>
-      {
-        if (!collector.LogEventsCollectorEnabled)
-          return;
-
-        ProcessQueue(collector);
-      };
+      myCollector = collector;
+      EditorApplication.update += ProcessQueue;
     }
 
-    private void ProcessQueue(UnityEventCollector collector)
+    private void ProcessQueue()
     {
+      if (!myCollector.LogEventsCollectorEnabled)
+        return;
+      
       if (PluginEntryPoint.UnityModels.Count > 0)
       {
         RdLogEvent element;
-        while ((element  = collector.DelayedLogEvents.Dequeue()) != null)
+        while ((element  = myCollector.DelayedLogEvents.Dequeue()) != null)
         {
           SendLogEvent(element);
         }  

--- a/unity/EditorPlugin/UnityEventLogSender.cs
+++ b/unity/EditorPlugin/UnityEventLogSender.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using JetBrains.Platform.Unity.EditorPluginModel;
 using JetBrains.Rider.Unity.Editor.NonUnity;
@@ -108,7 +107,7 @@ namespace JetBrains.Rider.Unity.Editor
 
     private void ProcessQueue(UnityEventCollector collector)
     {
-      if (PluginEntryPoint.UnityModels.Any())
+      if (PluginEntryPoint.UnityModels.Count > 0)
       {
         RdLogEvent element;
         while ((element  = collector.DelayedLogEvents.Dequeue()) != null)

--- a/unity/EditorPlugin/UnityEventLogSender.cs
+++ b/unity/EditorPlugin/UnityEventLogSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Platform.Unity.EditorPluginModel;
 using JetBrains.Rider.Unity.Editor.NonUnity;
@@ -107,10 +108,13 @@ namespace JetBrains.Rider.Unity.Editor
 
     private void ProcessQueue(UnityEventCollector collector)
     {
-      RdLogEvent element;
-      while ((element  = collector.DelayedLogEvents.Dequeue()) != null)
+      if (PluginEntryPoint.UnityModels.Any(l => l.Lifetime.IsAlive))
       {
-        SendLogEvent(element);
+        RdLogEvent element;
+        while ((element  = collector.DelayedLogEvents.Dequeue()) != null)
+        {
+          SendLogEvent(element);
+        }  
       }
     }
 

--- a/unity/EditorPlugin/UnityEventLogSender.cs
+++ b/unity/EditorPlugin/UnityEventLogSender.cs
@@ -96,7 +96,7 @@ namespace JetBrains.Rider.Unity.Editor
 
     private static void ProcessQueue()
     {
-      if (PluginEntryPoint.UnityModels.Count > 0)
+      if (PluginEntryPoint.UnityModels.Count > 0) // maybe worth checking Any( with .Lifetime.IsAlive ), but shows up more expensive in Profiler
       {
         RdLogEvent element;
         while ((element  = ourDelayedLogEvents.Dequeue()) != null)


### PR DESCRIPTION
I need a repro of the lock to test this.