### PR TITLE
Support git packages in Unity 2019.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ resharper/**/*_lex.depends
 resharper/**/test/data/**/*.tmp
 resharper/**/test/JetTestPackages
 
+# Generated file. Includes the nuget packages from the gradle downloaded SDK
+NuGet.Config
+
 rider/**/testData/**/*.tmp
 
 # Backup & report files from converting an old project file to a newer Visual Studio version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix incorrect method signature validation for methods marked with `OnOpenedAsset` ([#1053](https://github.com/JetBrains/resharper-unity/issues/1053), [#1679](https://github.com/JetBrains/resharper-unity/pull/1679))
 - Fix missing information in `.asmdef` schema file ([#1739](https://github.com/JetBrains/resharper-unity/issues/1739), [#1743](https://github.com/JetBrains/resharper-unity/pull/1743))
 - Rider: Fix debugger sometimes treating user code as external code ([#1671](https://github.com/JetBrains/resharper-unity/issues/1671), [RIDER-43846](https://youtrack.jetbrains.com/issue/RIDER-43846), [#1697](https://github.com/JetBrains/resharper-unity/pull/1697))
+- Rider: Fix timeout in debugger due to logging while evaluating properties ([RIDER-37068](https://youtrack.jetbrains.com/issue/RIDER-37068), [#1765](https://github.com/JetBrains/resharper-unity/pull/1765))
 - Rider: Fix grouping assets by directory in Find Usages results ([#1668](https://github.com/JetBrains/resharper-unity/pull/1668))
 - Rider: Fix exception trying to upgrade Unity editor plugin ([RIDER-42475](https://youtrack.jetbrains.com/issue/RIDER-42475), [#1658](https://github.com/JetBrains/resharper-unity/pull/1658))
 - Rider: Fix unit tests not running unless Rider has focus ([RIDER-37990](https://youtrack.jetbrains.com/issue/RIDER-37990), [#1672](https://github.com/JetBrains/resharper-unity/pull/1672))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Update `.meta` file icons to something less distracting ([RIDER-45675](https://youtrack.jetbrains.com/issue/RIDER-45675), [#1698](https://github.com/JetBrains/resharper-unity/pull/1698))
 - Update API information to Unity 2020.2.0a18 ([#1760](https://github.com/JetBrains/resharper-unity/pull/1760))
 - Added undocumented event functions for `Editor` and `EditorWindow` ([#986](https://github.com/JetBrains/resharper-unity/issues/986), [#1453](https://github.com/JetBrains/resharper-unity/issues/1453), [#1760](https://github.com/JetBrains/resharper-unity/pull/1760))
+- Improve searching for Linux Unity installations ([#1763](https://github.com/JetBrains/resharper-unity/pull/1763))
 - Rider: Significant reduction in memory usage while indexing assets ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Better support for prefab modifications in Find Usages and showing Inspector values ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
 - Rider: Show method handlers for Unity events in the editor ([#1645](https://github.com/JetBrains/resharper-unity/pull/1645))
@@ -51,6 +52,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Disable "Start Unity" action when Unity is running ([RIDER-36108](https://youtrack.jetbrains.com/issue/RIDER-36108), [#1554](https://github.com/JetBrains/resharper-unity/pull/1554))
 - Rider: Unity Log view optionally scrolls to show new items ([RIDER-14377](https://youtrack.jetbrains.com/issue/RIDER-14377), [#1678](https://github.com/JetBrains/resharper-unity/pull/1678))
 - Rider: Play/pause/step buttons no longer disabled while Rider is indexing ([#1678](https://github.com/JetBrains/resharper-unity/pull/1678))
+- Rider: Support local tarball packages in Unity Explorer ([#1589](https://github.com/JetBrains/resharper-unity/issues/1589), [#1769](https://github.com/JetBrains/resharper-unity/pull/1769))
+- Rider: Support `UPM_CACHE_PATH` environment variable for package cache fallback in Unity Explorer ([#1766](https://github.com/JetBrains/resharper-unity/issues/1766), [#1769](https://github.com/JetBrains/resharper-unity/pull/1769))
 
 ### Fixed
 
@@ -68,6 +71,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Suppress incorrect refresh behaviour when saving files that are in multiple projects (e.g. Player projects) ([#1669](https://github.com/JetBrains/resharper-unity/pull/1669))
 - Rider: Fix incorrect component name shown in Code Vision ([#1713](https://github.com/JetBrains/resharper-unity/pull/1713))
 - Rider: Fix issues moving files in Unity Explorer when player projects are generated ([RIDER-46467](https://youtrack.jetbrains.com/issue/RIDER-46467), [#1738](https://github.com/JetBrains/resharper-unity/pull/1738))
+- Rider: Fix git packages resolving in Unity Explorer in Unity 2019.4+ ([RIDER-47191](https://youtrack.jetbrains.com/issue/RIDER-47191), [#1769](https://github.com/JetBrains/resharper-unity/pull/1769))
 - Unity editor: Fix reporting of duration of Unity tests (released in Rider package 2.0.4) ([RIDER-44853](https://youtrack.jetbrains.com/issue/RIDER-44853))
 - Unity editor: Delay calling Unity API to workaround potential Unity crash ([RIDER-43951](https://youtrack.jetbrains.com/issue/RIDER-43951), [#1647](https://github.com/JetBrains/resharper-unity/pull/1647))
 - Unity editor: Unchecking sending Console messages to Rider is respected without having to restart ([#1733](https://github.com/JetBrains/resharper-unity/pull/1733))

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -105,6 +105,7 @@ class PackageNode(project: Project, private val packageManager: PackageManager, 
             PackageSource.Registry -> UnityIcons.Explorer.ReferencedPackage
             PackageSource.Embedded -> UnityIcons.Explorer.EmbeddedPackage
             PackageSource.Local -> UnityIcons.Explorer.LocalPackage
+            PackageSource.LocalTarball -> UnityIcons.Explorer.LocalTarballPackage
             PackageSource.BuiltIn -> UnityIcons.Explorer.BuiltInPackage
             PackageSource.Git -> UnityIcons.Explorer.GitPackage
             PackageSource.Unknown -> UnityIcons.Explorer.UnknownPackage
@@ -128,6 +129,7 @@ class PackageNode(project: Project, private val packageManager: PackageManager, 
         tooltip += when (packageData.source) {
             PackageSource.Embedded -> if (virtualFile.name != name) "<br/><br/>Folder name: ${virtualFile.name}" else ""
             PackageSource.Local -> "<br/><br/>Folder location: ${virtualFile.path}"
+            PackageSource.LocalTarball -> "<br/><br/>Tarball location: ${packageData.tarballLocation}"
             PackageSource.Git -> {
                 var text = "<br/><br/>Git URL: ${packageData.gitDetails?.url}"
                 if (!packageData.gitDetails?.hash.isNullOrEmpty()) {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/PackagesRoot.kt
@@ -11,6 +11,7 @@ import com.intellij.ui.SimpleTextAttributes
 import com.jetbrains.rider.plugins.unity.packageManager.PackageData
 import com.jetbrains.rider.plugins.unity.packageManager.PackageManager
 import com.jetbrains.rider.plugins.unity.packageManager.PackageSource
+import com.jetbrains.rider.plugins.unity.util.UnityInstallationFinder
 import com.jetbrains.rider.projectView.views.FileSystemNodeBase
 import com.jetbrains.rider.projectView.views.SolutionViewNode
 import com.jetbrains.rider.projectView.views.addNonIndexedMark
@@ -239,8 +240,22 @@ class ReadOnlyPackagesRoot(project: Project, private val packageManager: Package
     override fun calculateChildren(): MutableList<AbstractTreeNode<*>> {
         val children = mutableListOf<AbstractTreeNode<*>>()
 
-        if (packageManager.hasBuiltInPackages)
+        if (packageManager.hasBuiltInPackages) {
             children.add(BuiltinPackagesRoot(project!!, packageManager))
+
+            // Add the builtin packages root folder to the list of folders we know are under this node. This lets us
+            // correctly handle `contains()` for built in packages, which in turn means we can navigate to a built in
+            // package by folder (e.g. by double clicking a dependency node)
+            try {
+                UnityInstallationFinder.getInstance(myProject).getBuiltInPackagesRoot()?.let {
+                    VfsUtil.findFile(it, true)?.let { vfile ->
+                        addPackageFolder(vfile)
+                    }
+                }
+            } catch (throwable: Throwable) {
+                // Do nothing. It just means navigation to built in packages from dependency nodes won't work
+            }
+        }
 
         for (packageData in packageManager.immutablePackages) {
             if (packageData.source == PackageSource.BuiltIn) continue
@@ -404,9 +419,3 @@ private fun formatDescription(packageData: PackageData): String {
         description
     }
 }
-
-class LockDetails(val hash: String?, val revision: String?)
-
-// TODO: What are "testables"?
-class ManifestJson(val dependencies: Map<String, String>, val testables: Array<String>?, val registry: String?, val lock: Map<String, LockDetails>?)
-

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageData.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageData.kt
@@ -8,6 +8,7 @@ enum class PackageSource {
     Registry,
     Embedded,
     Local,
+    LocalTarball,
     Git;
 
     fun isEditable(): Boolean {
@@ -16,7 +17,7 @@ enum class PackageSource {
 }
 
 data class PackageData(val name: String, val packageFolder: VirtualFile?, val details: PackageDetails,
-                       val source: PackageSource, val gitDetails: GitDetails? = null) {
+                       val source: PackageSource, val gitDetails: GitDetails? = null, val tarballLocation: String? = null) {
     companion object {
         fun unknown(name: String, version: String, source: PackageSource = PackageSource.Unknown): PackageData {
             return PackageData(name, null, PackageDetails(name, "$name@$version", version,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageData.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageData.kt
@@ -56,9 +56,30 @@ data class PackageDetails(val canonicalName: String, val displayName: String, va
     }
 }
 
-data class GitDetails(val url: String, val revision: String, val hash: String)
+data class GitDetails(val url: String, val hash: String, val revision: String?)
+
+// Git lock details have moved to packages-lock.json in Unity 2019.4+
+class LockDetails(val hash: String?, val revision: String?)
+class ManifestJson(val dependencies: Map<String, String>, val testables: Array<String>?, val registry: String?, val lock: Map<String, LockDetails>?)
+
 
 // Other properties are available: category, keywords, unity (supported version)
 data class PackageJson(val name: String?, val displayName: String?, val version: String?, val description: String?,
                        val author: Any?, val dependencies: Map<String, String>?)
 
+
+// packages-lock.json (note the 's', this isn't NPM's package-lock.json)
+// This was introduced in Unity 2019.4 and appears to be a full list of packages, dependencies and transitive
+// dependencies. It also contains the git hash for git based packages.
+// By observation:
+// * `source` can be `builtin`, `registry`, `embedded`, `git`. Likely also includes other members of PackageSource, such
+//    as local and local tarball
+// * `version` is a semver value for `builtin`, `registry`, a `file:` url for `embedded` and a url for `git`
+// * `url` is only available for registry packages, and is the url of the registry, e.g. https://packages.unity.com
+// * `hash` is the commit hash for git packages
+// * `dependencies` is a map of package name to version
+// * `depth` is unknown, but could be an indicator of a transitive dependency rather than a direct dependency. E.g.
+//    a package only used as a dependency of another package can have a depth of 1, while the parent package has a depth
+//    of 0
+class PackagesLockDependency(val version: String, val depth: Int?, val source: String?, val dependencies: Map<String, String>, val url: String?, val hash: String?)
+class PackagesLockJson(val dependencies: Map<String, PackagesLockDependency>)

--- a/rider/src/main/kotlin/icons/UnityIcons.kt
+++ b/rider/src/main/kotlin/icons/UnityIcons.kt
@@ -126,6 +126,7 @@ class UnityIcons {
             val ReferencedPackage = IconLoader.getIcon("/Icons/Explorer/FolderPackageReferenced.svg")
             val EmbeddedPackage = IconLoader.getIcon("/Icons/Explorer/FolderPackageEmbedded.svg")
             val LocalPackage = IconLoader.getIcon("/Icons/Explorer/FolderPackageLocal.svg")
+            val LocalTarballPackage = LocalPackage
             val GitPackage = IconLoader.getIcon("/Icons/Explorer/FolderGit.svg")
             val UnknownPackage = IconLoader.getIcon("/Icons/Explorer/UnityPackageUnresolved.svg")
             val PackageDependency = IconLoader.getIcon("/Icons/Explorer/UnityPackageDependency.svg")


### PR DESCRIPTION
Unity 2019.4+ has moved git hash details from `manifest.json` and into a new `packages-lock.json`. This file contains a full graph of packages, including transitive dependencies.

This PR:

* Reads package details from `packages-lock.json` if it exists, falling back to `manifest.json` ([RIDER-47191](https://youtrack.jetbrains.com/issue/RIDER-47191))
* Supports local tarball packages (the manifest references a `package.tgz` file with the package expanded to `Library/PackageCache`) (#1589)
* Supports `UPM_CACHE_PATH` environment variable for fallback to global package cache (#1766)