### PR TITLE
Handle non-version suffixes in package cache for shader includes

### DIFF
--- a/resharper/resharper-unity/src/HlslSupport/Feature/Services/TypingAssists/InjectedHlslDummyFormatter.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Feature/Services/TypingAssists/InjectedHlslDummyFormatter.cs
@@ -24,7 +24,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Feature.Services.TypingA
 
     public override CppCachingKeywordResolvingLexer ComposeKeywordResolvingLexer(ITextControl textControl)
     {
-      var dialect = new CppHLSLDialect(true);
+      var dialect = new CppHLSLDialect(true, false);
       var cachingLexer = new ShaderLabLexerGenerated(textControl.Document.Buffer, CppLexer.Create).ToCachingLexer().TokenBuffer.CreateLexer();
       
       return new CppCachingKeywordResolvingLexer(cachingLexer, dialect);


### PR DESCRIPTION
Fixes the transformation of shader include file paths to package cache folders when the package cache contains packages that don't have a version, such as git based packages, where the filename is based on `{name}@{commit-hash}` rather than `{name}@{version}`.