### PR TITLE
Fix missing "Scene Path" value in debugger

### DIFF
--- a/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/ScenePathValueHelper.cs
+++ b/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/ScenePathValueHelper.cs
@@ -46,7 +46,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
 
                 var targetTransformReference = gameObjectRole.GetInstancePropertyReference("transform");
                 var targetTransformRole = targetTransformReference?.AsObjectSafe(options);
-                var rootTransformReference = targetTransformRole?.GetInstancePropertyReference("root");
+                // Search in bases - transform might be a RectTransform or a Transform, and root is defined on Transform
+                var rootTransformReference = targetTransformRole?.GetInstancePropertyReference("root", true);
 
                 if (targetTransformReference == null || rootTransformReference == null)
                 {


### PR DESCRIPTION
The debugger extensions adds a "Scene Path" value to `Component` and `GameObject` instances. If the game object's `transform` is a `RectTransform` instead of just a `Transform` instance, we fail to find the `Transform.root` property. This PR changes behaviour to search in base classes too.