### PR TITLE
Fixes for Shader support

### DIFF
--- a/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/InjectedHlslInclusionContextProvider.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/InjectedHlslInclusionContextProvider.cs
@@ -39,7 +39,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
             {
                 properties.IncludePaths.Add(cgIncludeFolder);
                 properties.IncludePaths.Add(cache.Solution.SolutionDirectory);
-                properties.IncludePaths.Add(cache.Solution.SolutionDirectory.Combine("Library"));
             }
 
             var shaderCache = cache.Solution.GetComponent<InjectedHlslFileLocationTracker>();

--- a/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
@@ -38,6 +38,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
 
         public string TransformPath(CppInclusionContext context, string path)
         {
+            var solutionFolder = mySolution.SolutionDirectory;
+            if (solutionFolder.Combine(path).Exists != FileSystemPath.Existence.Missing)
+                return path;
+            
             var pos = path.IndexOf('/') + 1;
             if (pos == -1)
                 return path;
@@ -53,7 +57,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
             
             var localPackagePath = FileSystemPath.Parse("Packages")
                 .Combine(packageName + "@" + suffix + path.Substring(endPos));
-            if (mySolution.SolutionDirectory.Combine(localPackagePath).Exists == FileSystemPath.Existence.File)
+            if (solutionFolder.Combine(localPackagePath).Exists == FileSystemPath.Existence.File)
                 return localPackagePath.FullPath;
 
             var cachedPackagePath = FileSystemPath.Parse("Library").Combine("PackageCache")

--- a/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
@@ -48,17 +48,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
             var packageName = path.Substring(pos, endPos - pos);
 
             var suffix = GetCacheSuffix(packageName);
-            var localPackagePath = mySolution.SolutionDirectory.Combine("Packages")
+            if (suffix == null)
+                return path;
+            
+            var localPackagePath = FileSystemPath.Parse("Packages")
                 .Combine(packageName + "@" + suffix + path.Substring(endPos));
-            if (localPackagePath.Exists == FileSystemPath.Existence.File)
+            if (mySolution.SolutionDirectory.Combine(localPackagePath).Exists == FileSystemPath.Existence.File)
                 return localPackagePath.FullPath;
 
-            var cachedPackagePath = mySolution.SolutionDirectory.Combine("Library").Combine("PackageCache")
+            var cachedPackagePath = FileSystemPath.Parse("Library").Combine("PackageCache")
                 .Combine(packageName + "@" + suffix + path.Substring(endPos));
             return cachedPackagePath.FullPath;
         }
 
-        [NotNull]
+        [CanBeNull]
         private string GetCacheSuffix(string packageName)
         {
             // TODO: This cache should be based on resolved packages, like we have in the frontend for PackageManager

--- a/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityHlslCppCompilationPropertiesProvider.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Integration/Cpp/UnityHlslCppCompilationPropertiesProvider.cs
@@ -33,7 +33,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
 
                 properties.PredefinedMacros.Add(CppPPDefineSymbol.ParsePredefinedMacro("SHADER_API_D3D11"));
                 properties.IncludePaths.Add(globalCache.Solution.SolutionDirectory);
-                properties.IncludePaths.Add(globalCache.Solution.SolutionDirectory.Combine("Library"));
 
                 return properties;
             }

--- a/resharper/resharper-unity/src/HlslSupport/Integration/Injections/InjectedHlslFileLocationTracker.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Integration/Injections/InjectedHlslFileLocationTracker.cs
@@ -114,7 +114,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Injections
             }
 
             var lexer = CppLexer.Create(ProjectedBuffer.Create(buffer, range));
-            lexer.Advance();
+            lexer.Start();
             while (lexer.TokenType != null)
             {
                 var tokenType = lexer.TokenType;

--- a/resharper/resharper-unity/src/Templates/File/StandardSurfaceShader.md
+++ b/resharper/resharper-unity/src/Templates/File/StandardSurfaceShader.md
@@ -47,7 +47,7 @@ Shader "Custom/$NAME$" {
 		// #pragma instancing_options assumeuniformscaling
 		UNITY_INSTANCING_BUFFER_START(Props)
 			// put more per-instance properties here
-		UNITY_INSTANCING_BUFFER_END
+		UNITY_INSTANCING_BUFFER_END(Props)
 
 		void surf (Input IN, inout SurfaceOutputStandard o) {
 			// Albedo comes from a texture tinted by color


### PR DESCRIPTION
1) fix include path resolving for Mac OS(use relative paths instead o…f absolute, because R++ engine considers paths which are started from separator as special paths)
2) fix include resolving for local packages (fix RIDER-48210)
3) fix template for surface shader RIDER-48073