### PR TITLE
Compare API versions ignoring missing build numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,17 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Fixed
 
 - Correctly handle lambdas, actions and local functions in performance critical and Burst contexts ([#1787](https://github.com/JetBrains/resharper-unity/pull/1787))
+- Recognise `OnValidate` as a valid message for `ScriptableObject` in Unity 2020.1.x projects ([RIDER-49130](https://youtrack.jetbrains.com/issue/RIDER-49130), [#1807](https://github.com/JetBrains/resharper-unity/pull/1807))
 
 
 
 ## 2020.2.1
+* Released: [2020-08-21](https://blog.jetbrains.com/dotnet/2020/08/21/the-rider-2020-2-1-and-resharper-2020-2-1-hotfixes-are-here/)
+* Build: 2020.2.0.281
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net202-rtm-2020.2.0...net202-rtm-2020.2.0-rtm-2020.2.1)
+* No milestone
+* [GitHub release](https://github.com/JetBrains/resharper-unity/releases/tag/net202-rtm-2020.2.0-rtm-2020.2.1)
+* [ReSharper release](https://resharper-plugins.jetbrains.com/packages/JetBrains.Unity/2020.2.0.281)
 
 ### Changed
 

--- a/apiParser/src/Program.cs
+++ b/apiParser/src/Program.cs
@@ -324,16 +324,16 @@ namespace ApiParser
             // ScriptableObjects. Off the top of my head this includes, Awake, OnEnable, OnDisable, OnDestroy,
             // OnValidate, and Reset, but there could be more.
             type = unityApi.FindType("ScriptableObject");
-            if (type != null && apiVersion < new Version(2020, 2))
+            if (type != null && apiVersion < new Version(2020, 1))
             {
-                // Documented in 2020.2
+                // Documented in 2020.1
                 var eventFunction = new UnityApiEventFunction("OnValidate", false, false, ApiType.Void, apiVersion,
                     description:
                     "This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).",
                     undocumented: true);
                 type.MergeEventFunction(eventFunction, apiVersion);
 
-                // Documented in 2020.2
+                // Documented in 2020.1
                 eventFunction = new UnityApiEventFunction("Reset", false, false, ApiType.Void, apiVersion,
                     description: "Reset to default values.", undocumented: true);
                 type.MergeEventFunction(eventFunction, apiVersion);

--- a/resharper/resharper-unity/src/UnityEventFunction.cs
+++ b/resharper/resharper-unity/src/UnityEventFunction.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
+using JetBrains.ReSharper.Plugins.Unity.Utils;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Impl;
@@ -128,7 +129,12 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         public bool SupportsVersion(Version unityVersion)
         {
-            return myMinimumVersion <= unityVersion && unityVersion <= myMaximumVersion;
+            // Allow 2020.1 to also match 2020.1.4 for maximum version
+            // CompareToIgnoringUndefinedComponents will also allow myMinimumVersion and myMaximumVersion to contain a
+            // build and revision, e.g. an event function can be 2020.1.4 and correctly match a Unity version of
+            // 2020.1.4 or even 2020.1.4.2000
+            return myMinimumVersion.CompareToLenient(unityVersion) <= 0
+                   && unityVersion.CompareToLenient(myMaximumVersion) <= 0;
         }
 
         private static object GetTypeObject(UnityTypeSpec typeSpec, KnownTypesCache knownTypesCache, IPsiModule module)

--- a/resharper/resharper-unity/src/UnityType.cs
+++ b/resharper/resharper-unity/src/UnityType.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
+using JetBrains.ReSharper.Plugins.Unity.Utils;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Modules;
 
@@ -50,7 +51,8 @@ namespace JetBrains.ReSharper.Plugins.Unity
 
         public bool SupportsVersion(Version unityVersion)
         {
-            return myMinimumVersion <= unityVersion && unityVersion <= myMaximumVersion;
+            return myMinimumVersion.CompareToLenient(unityVersion) <= 0
+                   && unityVersion.CompareToLenient(myMaximumVersion) <= 0;
         }
     }
 }

--- a/resharper/resharper-unity/src/Utils/VersionEx.cs
+++ b/resharper/resharper-unity/src/Utils/VersionEx.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Utils
+{
+    public static class VersionEx
+    {
+        // Like Version.CompareTo but does not compare undefined components. E.g. 2020.1 == 2020.1.2
+        // Useful for API comparisons. If the API has a min version of 5.0 and max of 2020.1, then it should also be
+        // valid for 2020.1.2
+        [SuppressMessage("ReSharper", "ArrangeRedundantParentheses")]
+        public static int CompareToLenient([NotNull] this Version self, [NotNull] Version other)
+        {
+            return ReferenceEquals(other, self) ? 0 :
+                self.Major != other.Major ? (self.Major > other.Major ? 1 : -1) :
+                self.Minor == -1 || other.Minor == -1 ? 0 :
+                self.Minor != other.Minor ? (self.Minor > other.Minor ? 1 : -1) :
+                self.Build == -1 || other.Build == -1 ? 0 :
+                self.Build != other.Build ? (self.Build > other.Build ? 1 : -1) :
+                self.Revision == -1 || other.Revision == -1 ? 0 :
+                self.Revision != other.Revision ? (self.Revision > other.Revision ? 1 : -1) :
+                0;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -883,16 +883,16 @@
     <message name="OnEnable" static="False" description="This function is called when the object is loaded." path="Documentation/en/ScriptReference/ScriptableObject.OnEnable.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="OnValidate" static="False" minimumVersion="2020.2" description="This function is called when the script is loaded or a value is changed in the Inspector (Called in the editor only)." path="Documentation/en/ScriptReference/ScriptableObject.OnValidate.html">
+    <message name="OnValidate" static="False" minimumVersion="2020.1" description="This function is called when the script is loaded or a value is changed in the Inspector (Called in the editor only)." path="Documentation/en/ScriptReference/ScriptableObject.OnValidate.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="Reset" static="False" minimumVersion="2020.2" description="Reset to default values." path="Documentation/en/ScriptReference/ScriptableObject.Reset.html">
+    <message name="Reset" static="False" minimumVersion="2020.1" description="Reset to default values." path="Documentation/en/ScriptReference/ScriptableObject.Reset.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="OnValidate" static="False" maximumVersion="2020.1" undocumented="True" description="This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).">
+    <message name="OnValidate" static="False" maximumVersion="2019.4" undocumented="True" description="This function is called when the script is loaded or a value is changed in the inspector (Called in the editor only).">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="Reset" static="False" maximumVersion="2020.1" undocumented="True" description="Reset to default values.">
+    <message name="Reset" static="False" maximumVersion="2019.4" undocumented="True" description="Reset to default values.">
       <returns type="System.Void" array="False" />
     </message>
   </type>

--- a/resharper/resharper-unity/test/src/VersionExTests.cs
+++ b/resharper/resharper-unity/test/src/VersionExTests.cs
@@ -1,0 +1,65 @@
+using System;
+using JetBrains.ReSharper.Plugins.Unity.Utils;
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests
+{
+    [TestFixture]
+    public class VersionExTests
+    {
+        [Test]
+        public void CompareToLenient_MatchingMajorMinorComponents()
+        {
+            var version = new Version(2020, 2);
+
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 3)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 1)));
+        }
+
+        [Test]
+        public void CompareToLenient_MatchingMajorMinorBuildComponents()
+        {
+            var version = new Version(2020, 2, 100);
+
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2, 100)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 2, 101)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 2, 99)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 3, 100)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 1, 100)));
+        }
+
+        [Test]
+        public void CompareToLenient_MatchingMajorMinorBuildRevisionComponents()
+        {
+            var version = new Version(2020, 2, 100, 42);
+
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2, 100, 42)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 2, 100, 43)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 2, 100, 41)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 3, 100, 42)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 1, 100, 42)));
+        }
+
+        [Test]
+        public void CompareToLenient_OtherHasMoreComponents()
+        {
+            var version = new Version(2020, 2);
+
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2, 100)));
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2, 0)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 3, 100)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 1, 100)));
+        }
+
+        [Test]
+        public void CompareToLenient_OtherHasLessComponents()
+        {
+            var version = new Version(2020, 2, 1);
+
+            Assert.AreEqual(0, version.CompareToLenient(new Version(2020, 2)));
+            Assert.AreEqual(-1, version.CompareToLenient(new Version(2020, 3)));
+            Assert.AreEqual(1, version.CompareToLenient(new Version(2020, 1)));
+        }
+    }
+}


### PR DESCRIPTION
Rider 2020.2 updated API information for `ScriptableObject.OnValidate`. It is undocumented up to Unity 2020.1, and documented from Unity 2020.2. The implementation of `Version.CompareTo` will treat missing build and revision numbers as older, so a maximum API version of 2020.1 is less than the product version of 2020.1.1, and since this is also less than 2020.2, Rider does not find a record for `ScriptableObject.OnValidate`.

This change introduces an extension method for `Version` - `CompareToLenient`. This will only compare the components of both versions that are defined, so `2020.1` is considered equal to `2020.1.1`. This fixes the issue for `ScriptableObject.OnValidate`.

Fixes [RIDER-49130](https://youtrack.jetbrains.com/issue/RIDER-49130)