### PR TITLE
Minor package explorer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Fixed
 
 - Correctly handle lambdas, actions and local functions in performance critical and Burst contexts ([#1787](https://github.com/JetBrains/resharper-unity/pull/1787))
+- Rider: Correctly resolve local packages with too many parent segments in path ([#1796](https://github.com/JetBrains/resharper-unity/issues/1796), [#1811](https://github.com/JetBrains/resharper-unity/pull/1811))
+- Rider: Correctly resolve embedded package where folder name does not match package name ([#1778](https://github.com/JetBrains/resharper-unity/issues/1778), [#1811](https://github.com/JetBrains/resharper-unity/pull/1811))
 
 
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
@@ -373,7 +373,7 @@ class PackageManager(private val project: Project) {
         return try {
             val path = version.substring(5)
             val packagesPath = Paths.get(packagesFolder.path)
-            val filePath = packagesPath.resolve(path)
+            val filePath = packagesPath.resolve(path).normalize()
             val packageFolder = VfsUtil.findFile(filePath, false)
             when (packageFolder?.isDirectory) {
                 true -> getPackageDataFromFolder(name, packageFolder, PackageSource.Local)


### PR DESCRIPTION
- [x] Normalise path to handle improper count of "parent" (`..`) segments
- [x] Handle embedded packages where the folder name does not match the package name