### PR TITLE
Fix minor issues with changelog notes

### DIFF
--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -40,10 +40,10 @@ task packReSharperPlugin(type: nugetPack.class) {
     group = backendGroup
     description = 'Packs resulting DLLs into a NuGet package which is an R# extension.'
 
-    def changelogNotes = changelog.get(productVersion).withFilter({ line ->
+    def changelogNotes = changelog.get(pluginVersion).withFilter({ line ->
         !line.startsWith("- Rider:") && !line.startsWith("- Unity editor:")
     }).toPlainText().trim()
-    def ReleaseNotes = """New in $productVersion
+    def ReleaseNotes = """New in $pluginVersion
 
 ${changelogNotes}
 

--- a/rider/backend.gradle
+++ b/rider/backend.gradle
@@ -43,6 +43,14 @@ task packReSharperPlugin(type: nugetPack.class) {
     def changelogNotes = changelog.get(pluginVersion).withFilter({ line ->
         !line.startsWith("- Rider:") && !line.startsWith("- Unity editor:")
     }).toPlainText().trim()
+
+    // There's a bug in the changelog plugin that adds extra newlines on Windows, possibly
+    // due to Unix/Windows line ending mismatch.
+    // Remove this hack once JetBrains/gradle-changelog-plugin#8 is fixed
+    if (isWindows) {
+      changelogNotes = changelogNotes.replaceAll("\n\n", "\r\n")
+    }
+
     def ReleaseNotes = """New in $pluginVersion
 
 ${changelogNotes}

--- a/rider/build.gradle
+++ b/rider/build.gradle
@@ -16,6 +16,7 @@ plugins {
 ext.repoRoot = project.file("..")
 ext.isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
 ext.bundledRiderSdkRoot = new File(projectDir, "dependencies")  // SDK from TC configuration/artifacts
+ext.pluginVersion = ext.productVersion + "." + ext.maintenanceVersion
 
 repositories {
     maven { url "https://cache-redirector.jetbrains.com/intellij-repository/snapshots" }
@@ -36,7 +37,7 @@ wrapper {
     distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 
-version "${productVersion}.0.$BuildCounter"
+version "${pluginVersion}.$BuildCounter"
 
 ext.buildServer = BuildServerKt.initBuildServer(gradle)
 if (buildServer.automatedBuild) {

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -71,9 +71,9 @@ intellij {
 patchPluginXml {
     changeNotes """
         <body>
-        <p><b>New in $productVersion</b></p>
+        <p><b>New in $pluginVersion</b></p>
         <p>
-        ${changelog.get(productVersion).toHTML()}
+        ${changelog.get(pluginVersion).toHTML()}
         </p>
         <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net202/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
         </body>

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -5,7 +5,12 @@
 BuildCounter=9999
 BuildConfiguration=Debug
 
+# Base version for SDK resolution. Also used for plugin version
 productVersion=2020.2
+# Revision for plugin version, appended to productVersion, e.g. 2020.2.2
+# Used for published version, plus retrieving correct changelog notes
+# TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
+maintenanceVersion=2
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long


### PR DESCRIPTION
Fixes two issues:

- [x] Changelog notes in `plugin.xml` and ReSharper's `.nuspec` do not pick up latest revision, using the 2020.2 release only. This PR adds a new gradle property to specify the revision, so we can publish the correct release notes. This also affects the published version (e.g. 2020.2.2.{build}). The gradle property must currently be incremented manually, but can be overridden from TC at a later date
- [x] Fix the formatting of changelog notes in the ReSharper plugin package, which was adding an extra newline to each item.