### PR TITLE
Fix run/debug NUnit tests when they don't run/debug for Unity

### DIFF
--- a/resharper/resharper-unity/src/Rider/UnitTesting/UnityTaskRunnerHostController.cs
+++ b/resharper/resharper-unity/src/Rider/UnitTesting/UnityTaskRunnerHostController.cs
@@ -55,6 +55,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnitTesting
         {
             await myInnerHostController.PrepareForRun(run).ConfigureAwait(false);
 
+            if (!myUnityController.IsUnityEditorUnitTestRunStrategy(run.RunStrategy))
+                return;
+                
             var unityEditorProcessId = myUnityController.TryGetUnityProcessId();
             if (unityEditorProcessId.HasValue)
                 return;


### PR DESCRIPTION
Fix run/debug NUnit tests when they don't run/debug for Unity
Fix exception "Illegal scheduler for current action.." when calling "UnityModel.Value.ExitUnity.Start"
Increase ourUnityConnectionTimeout