### PR TITLE
Update settings store usage

### DIFF
--- a/resharper/resharper-unity.sln.DotSettings
+++ b/resharper/resharper-unity.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ECS/@EntryIndexedValue">ECS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HSV/@EntryIndexedValue">HSV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LDR/@EntryIndexedValue">LDR</s:String>
@@ -32,6 +33,7 @@
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fgb/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fgb/Words/=Higlighting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=asmdef/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autopopup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Delegator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmcs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Highlightings/@EntryIndexedValue">True</s:Boolean>

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/FieldDetector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
@@ -9,18 +8,21 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.CallGraph;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util.Collections;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders
 {
-
     [SolutionComponent]
     public class FieldDetector : UnityDeclarationHighlightingProviderBase
     {
         private readonly UnityApi myUnityApi;
 
-        public FieldDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, SettingsStore settingsStore, PerformanceCriticalCodeCallGraphMarksProvider marksProvider, UnityApi unityApi, IElementIdProvider provider)
-            : base(solution, callGraphSwaExtensionProvider, settingsStore, marksProvider, provider)
+        public FieldDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                             IApplicationWideContextBoundSettingStore settingsStore,
+                             PerformanceCriticalCodeCallGraphMarksProvider marksProvider, UnityApi unityApi,
+                             IElementIdProvider provider)
+            : base(solution, settingsStore, callGraphSwaExtensionProvider, marksProvider, provider)
         {
             myUnityApi = unityApi;
         }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/IUnityDeclarationHighlightingProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/IUnityDeclarationHighlightingProvider.cs
@@ -1,6 +1,4 @@
 using JetBrains.ReSharper.Feature.Services.Daemon;
-using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/InitialiseOnLoadCctorDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/InitialiseOnLoadCctorDetector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
@@ -9,6 +8,7 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCritical
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util.Collections;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders
@@ -16,17 +16,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
     [SolutionComponent]
     public class InitialiseOnLoadCctorDetector : UnityDeclarationHighlightingProviderBase
     {
-        public InitialiseOnLoadCctorDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, SettingsStore settingsStore, 
-            PerformanceCriticalCodeCallGraphMarksProvider marksProvider, IElementIdProvider provider)
-            : base(solution, callGraphSwaExtensionProvider, settingsStore, marksProvider, provider)
+        public InitialiseOnLoadCctorDetector(ISolution solution,
+                                             CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                                             IApplicationWideContextBoundSettingStore settingsStore,
+                                             PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
+                                             IElementIdProvider provider)
+            : base(solution, settingsStore, callGraphSwaExtensionProvider, marksProvider, provider)
         {
         }
-        
+
         public override bool AddDeclarationHighlighting(IDeclaration node, IHighlightingConsumer consumer, DaemonProcessKind kind)
         {
             if (!(node is IConstructorDeclaration element))
                 return false;
-            
+
             if (!element.IsStatic)
                 return false;
 
@@ -34,7 +37,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             if (containingType != null &&
                 containingType.HasAttributeInstance(KnownTypes.InitializeOnLoadAttribute, false))
             {
-                AddHighlighting(consumer, element, "Used implicitly", 
+                AddHighlighting(consumer, element, "Used implicitly",
                     "Called when Unity first launches the editor, the player, or recompiles scripts", kind);
                 return true;
             }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Anchors;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.ProjectModel;
@@ -12,6 +11,7 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCritical
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.ReSharper.Resources.Resources.Icons;
 using JetBrains.TextControl;
 
@@ -22,9 +22,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
     {
         private readonly UnityApi myUnityApi;
 
-        public TypeDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, SettingsStore settingsStore, UnityApi unityApi,
-            PerformanceCriticalCodeCallGraphMarksProvider marksProvider, IElementIdProvider provider)
-            : base(solution, callGraphSwaExtensionProvider, settingsStore, marksProvider, provider)
+        public TypeDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                            IApplicationWideContextBoundSettingStore settingsStore, UnityApi unityApi,
+                            PerformanceCriticalCodeCallGraphMarksProvider marksProvider, IElementIdProvider provider)
+            : base(solution, settingsStore, callGraphSwaExtensionProvider, marksProvider, provider)
         {
             myUnityApi = unityApi;
         }
@@ -39,15 +40,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             {
                 if (typeElement.DerivesFromMonoBehaviour())
                 {
-                    AddMonoBehaviourHiglighting(consumer, element, "Script", "Unity script", kind);
+                    AddMonoBehaviourHighlighting(consumer, element, "Script", "Unity script", kind);
                 }
                 else if (typeElement.DerivesFrom(KnownTypes.Editor) || typeElement.DerivesFrom(KnownTypes.EditorWindow))
                 {
-                    AddEditorHiglighting(consumer, element, "Editor", "Custom Unity Editor", kind);
+                    AddEditorHighlighting(consumer, element, "Editor", "Custom Unity Editor", kind);
                 }
                 else if (typeElement.DerivesFromScriptableObject())
                 {
-                    AddMonoBehaviourHiglighting(consumer, element, "Scriptable object", "Scriptable Object", kind);
+                    AddMonoBehaviourHighlighting(consumer, element, "Scriptable object", "Scriptable Object", kind);
                 }
                 else if (myUnityApi.IsUnityType(typeElement))
                 {
@@ -65,12 +66,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             return false;
         }
 
-        protected virtual void AddMonoBehaviourHiglighting(IHighlightingConsumer consumer, IClassLikeDeclaration declaration, string text, string tooltip, DaemonProcessKind kind)
+        protected virtual void AddMonoBehaviourHighlighting(IHighlightingConsumer consumer, IClassLikeDeclaration declaration, string text, string tooltip, DaemonProcessKind kind)
         {
             AddHighlighting(consumer, declaration, text, tooltip, kind);
         }
 
-        protected virtual void AddEditorHiglighting(IHighlightingConsumer consumer, IClassLikeDeclaration declaration, string text, string tooltip, DaemonProcessKind kind)
+        protected virtual void AddEditorHighlighting(IHighlightingConsumer consumer, IClassLikeDeclaration declaration, string text, string tooltip, DaemonProcessKind kind)
         {
             AddHighlighting(consumer, declaration, text, tooltip, kind);
         }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Application.Progress;
-using JetBrains.Application.Settings;
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Anchors;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Application.UI.Help;
 using JetBrains.Application.UI.Icons.CommonThemedIcons;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Feature.Services.Bulbs;
@@ -20,6 +17,7 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCritical
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.TextControl;
 using JetBrains.Util.Collections;
 
@@ -28,23 +26,24 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
     [SolutionComponent]
     public class UnityCommonIconProvider
     {
-        protected readonly ISolution Solution;
         protected readonly CallGraphSwaExtensionProvider CallGraphSwaExtensionProvider;
         protected readonly PerformanceCriticalCodeCallGraphMarksProvider MarksProvider;
+        protected readonly IApplicationWideContextBoundSettingStore SettingsStore;
         protected readonly UnityApi UnityApi;
-        protected readonly IContextBoundSettingsStore Settings;
+        private readonly ISolution mySolution;
         private readonly IElementIdProvider myProvider;
 
-        public UnityCommonIconProvider(ISolution solution,
-            CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
-            SettingsStore settingsStore, PerformanceCriticalCodeCallGraphMarksProvider marksProvider, UnityApi unityApi,
-            IElementIdProvider provider)
+        public UnityCommonIconProvider(ISolution solution, UnityApi unityApi,
+                                       CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                                       IApplicationWideContextBoundSettingStore settingsStore,
+                                       PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
+                                       IElementIdProvider provider)
         {
-            Solution = solution;
+            mySolution = solution;
             CallGraphSwaExtensionProvider = callGraphSwaExtensionProvider;
             MarksProvider = marksProvider;
             UnityApi = unityApi;
-            Settings = settingsStore.BindToContextTransient(ContextRange.Smart(solution.ToDataContext()));
+            SettingsStore = settingsStore;
             myProvider = provider;
         }
 
@@ -57,7 +56,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 {
                     consumer.AddImplicitConfigurableHighlighting(cSharpDeclaration);
                     consumer.AddHotHighlighting(CallGraphSwaExtensionProvider, cSharpDeclaration, MarksProvider,
-                        Settings, text,
+                        SettingsStore.BoundSettingsStore, text,
                         GetEventFunctionTooltip(eventFunction), kind, GetEventFunctionActions(cSharpDeclaration),
                         myProvider);
                 }
@@ -68,8 +67,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             ICSharpDeclaration declaration,
             string text, string tooltip, DaemonProcessKind kind)
         {
-            consumer.AddHotHighlighting(CallGraphSwaExtensionProvider, declaration, MarksProvider, Settings, text,
-                tooltip, kind, EnumerableCollection<BulbMenuItem>.Empty, myProvider, true);
+            consumer.AddHotHighlighting(CallGraphSwaExtensionProvider, declaration, MarksProvider,
+                SettingsStore.BoundSettingsStore, text, tooltip, kind, EnumerableCollection<BulbMenuItem>.Empty,
+                myProvider, true);
         }
 
         protected IEnumerable<BulbMenuItem> GetEventFunctionActions(ICSharpDeclaration declaration)
@@ -78,7 +78,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             if (declaration is IMethodDeclaration methodDeclaration)
             {
                 var declaredElement = methodDeclaration.DeclaredElement;
-                var textControl = Solution.GetComponent<ITextControlManager>().LastFocusedTextControl.Value;
+                var textControl = mySolution.GetComponent<ITextControlManager>().LastFocusedTextControl.Value;
 
                 if (textControl != null && declaredElement != null)
                 {
@@ -92,7 +92,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                             bulbAction = new ConvertToCoroutineBulbAction(methodDeclaration);
 
                         result.Add(new BulbMenuItem(
-                            new IntentionAction.MyExecutableProxi(bulbAction, Solution, textControl),
+                            new IntentionAction.MyExecutableProxi(bulbAction, mySolution, textControl),
                             bulbAction.Text, BulbThemedIcons.ContextAction.Id,
                             BulbMenuAnchors.FirstClassContextItems));
                     }
@@ -100,9 +100,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                     if (UnityApi.IsEventFunction(declaredElement))
                     {
                         var documentationNavigationAction = new DocumentationNavigationAction(
-                            Solution.GetComponent<ShowUnityHelp>(), declaredElement, UnityApi);
+                            mySolution.GetComponent<ShowUnityHelp>(), declaredElement, UnityApi);
                         result.Add(new BulbMenuItem(
-                            new IntentionAction.MyExecutableProxi(documentationNavigationAction, Solution,
+                            new IntentionAction.MyExecutableProxi(documentationNavigationAction, mySolution,
                                 textControl), documentationNavigationAction.Text, CommonThemedIcons.Question.Id,
                             BulbMenuAnchors.FirstClassContextItems));
                     }

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityDeclarationHighlightingProviderBase.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityDeclarationHighlightingProviderBase.cs
@@ -1,15 +1,13 @@
 using System.Collections.Generic;
-using JetBrains.Application.Settings;
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.CallGraph;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders
 {
@@ -18,27 +16,31 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         protected readonly ISolution Solution;
         protected readonly CallGraphSwaExtensionProvider CallGraphSwaExtensionProvider;
         protected readonly PerformanceCriticalCodeCallGraphMarksProvider MarksProvider;
-        protected readonly IContextBoundSettingsStore Settings;
-        private readonly IElementIdProvider myProvider;
+        protected readonly IApplicationWideContextBoundSettingStore SettingsStore;
+        protected readonly IElementIdProvider ElementIdProvider;
 
-        public UnityDeclarationHighlightingProviderBase(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, 
-            SettingsStore settingsStore, PerformanceCriticalCodeCallGraphMarksProvider marksProvider, IElementIdProvider provider)
+        protected UnityDeclarationHighlightingProviderBase(ISolution solution,
+                                                           IApplicationWideContextBoundSettingStore settingsStore,
+                                                           CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                                                           PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
+                                                           IElementIdProvider provider)
         {
             Solution = solution;
             CallGraphSwaExtensionProvider = callGraphSwaExtensionProvider;
             MarksProvider = marksProvider;
-            Settings = settingsStore.BindToContextTransient(ContextRange.Smart(solution.ToDataContext()));
-            myProvider = provider;
+            SettingsStore = settingsStore;
+            ElementIdProvider = provider;
         }
-        
+
         public abstract bool AddDeclarationHighlighting(IDeclaration treeNode, IHighlightingConsumer consumer,
-            DaemonProcessKind kind);
-        
+                                                        DaemonProcessKind kind);
+
         protected virtual void AddHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text,
             string tooltip, DaemonProcessKind kind)
         {
             consumer.AddImplicitConfigurableHighlighting(element);
-            consumer.AddHotHighlighting(CallGraphSwaExtensionProvider, element, MarksProvider, Settings, text, tooltip, kind, GetActions(element), myProvider);
+            consumer.AddHotHighlighting(CallGraphSwaExtensionProvider, element, MarksProvider,
+                SettingsStore.BoundSettingsStore, text, tooltip, kind, GetActions(element), ElementIdProvider);
         }
 
 

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityHighlightingUtils.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityHighlightingUtils.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using JetBrains.Application.Settings;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Feature.Services.Daemon;
@@ -33,7 +32,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
 
             return declaredElement.HasHotIcon(callGraphSwaExtensionProvider, settingsStore, marksProvider, kind, provider);
         }
-        
+
         public static bool HasHotIcon(this IDeclaredElement element,
             CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, IContextBoundSettingsStore settingsStore,
             PerformanceCriticalCodeCallGraphMarksProvider marksProvider, DaemonProcessKind kind, IElementIdProvider provider)
@@ -48,19 +47,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             if (!id.HasValue)
                 return false;
 
-            return callGraphSwaExtensionProvider.IsMarkedByCallGraphRootMarksProvider(marksProvider.Id, 
+            return callGraphSwaExtensionProvider.IsMarkedByCallGraphRootMarksProvider(marksProvider.Id,
                 kind == DaemonProcessKind.GLOBAL_WARNINGS, id.Value);
         }
 
         public static void AddHotHighlighting(this IHighlightingConsumer consumer,
-            CallGraphSwaExtensionProvider swaExtensionProvider, ICSharpDeclaration element, PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
-            IContextBoundSettingsStore settings, string text,
-            string tooltip, DaemonProcessKind kind, IEnumerable<BulbMenuItem> items, IElementIdProvider provider, bool onlyHot = false)
+                                              CallGraphSwaExtensionProvider swaExtensionProvider,
+                                              ICSharpDeclaration element,
+                                              PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
+                                              IContextBoundSettingsStore settings, string text,
+                                              string tooltip, DaemonProcessKind kind, IEnumerable<BulbMenuItem> items,
+                                              IElementIdProvider provider, bool onlyHot = false)
         {
             var isIconHot = element.HasHotIcon(swaExtensionProvider, settings, marksProvider, kind, provider);
             if (onlyHot && !isIconHot)
                 return;
-            
+
             var highlighting = isIconHot
                 ? new UnityHotGutterMarkInfo(items, element, tooltip)
                 : (IHighlighting) new UnityGutterMarkInfo(items, element, tooltip);

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Analyzers/PerformanceLineMarkerAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Analyzers/PerformanceLineMarkerAnalyzer.cs
@@ -2,11 +2,11 @@ using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.Highlightings;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.Analyzers
 {
@@ -14,14 +14,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
     public class PerformanceLineMarkerAnalyzer : PerformanceProblemAnalyzerBase<IFunctionDeclaration>
     {
         protected readonly IProperty<PerformanceHighlightingMode> LineMarkerStatus;
-        public PerformanceLineMarkerAnalyzer(Lifetime lifetime, ISolution solution, ISettingsStore store)
+
+        public PerformanceLineMarkerAnalyzer(Lifetime lifetime, ISolution solution,
+                                             IApplicationWideContextBoundSettingStore settingsStore)
         {
-            LineMarkerStatus = store.BindToContextLive(lifetime, ContextRange.Smart(solution.ToDataContext()))
+            LineMarkerStatus = settingsStore.BoundSettingsStore
                 .GetValueProperty(lifetime, (UnitySettings key) => key.PerformanceHighlightingMode);
         }
-        
+
         protected override void Analyze(IFunctionDeclaration t, IDaemonProcess daemonProcess, DaemonProcessKind kind,
-            IHighlightingConsumer consumer)
+                                        IHighlightingConsumer consumer)
         {
             if (LineMarkerStatus.Value == PerformanceHighlightingMode.Always)
             {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/VisualStudio/VSPerformanceLineMarkerAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/VisualStudio/VSPerformanceLineMarkerAnalyzer.cs
@@ -1,4 +1,3 @@
-using JetBrains.Application.Settings;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
@@ -6,19 +5,21 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCritical
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.Highlightings;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.VisualStudio
 {
     [SolutionComponent]
     public class VSPerformanceLineMarkerAnalyzer : PerformanceLineMarkerAnalyzer
     {
-        public VSPerformanceLineMarkerAnalyzer(Lifetime lifetime, ISolution solution, ISettingsStore store)
+        public VSPerformanceLineMarkerAnalyzer(Lifetime lifetime, ISolution solution,
+                                               IApplicationWideContextBoundSettingStore store)
             : base(lifetime, solution, store)
         {
         }
-        
+
         protected override void Analyze(IFunctionDeclaration t, IDaemonProcess daemonProcess, DaemonProcessKind kind,
-            IHighlightingConsumer consumer)
+                                        IHighlightingConsumer consumer)
         {
             if (LineMarkerStatus.Value == PerformanceHighlightingMode.Always)
             {

--- a/resharper/resharper-unity/src/Feature/Services/Pencils/UnityPencilsFilter.cs
+++ b/resharper/resharper-unity/src/Feature/Services/Pencils/UnityPencilsFilter.cs
@@ -11,10 +11,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.Pencils
 {
     public class UnityPencilsFilter : PencilsFilterSettingsBase<UnitySettings>
     {
-        public UnityPencilsFilter(Lifetime lifetime, UnitySolutionTracker solutionTracker, UnityReferencesTracker referencesTracker, ISettingsStore store)
-            : base("Unity", "Plugins", "Unity", "", solutionTracker.IsUnityProject.HasTrueValue(), store, s => s.EnablePerformanceCriticalCodeHighlighting)
+        public UnityPencilsFilter(Lifetime lifetime, UnitySolutionTracker solutionTracker,
+                                  UnityReferencesTracker referencesTracker, ISettingsStore store)
+            : base("Unity", "Plugins", "Unity", "", solutionTracker.IsUnityProject.HasTrueValue(), store,
+                s => s.EnablePerformanceCriticalCodeHighlighting)
         {
-            referencesTracker.HasUnityReference.Advise(lifetime, b => IsVisible.Value = solutionTracker.IsUnityProject.HasTrueValue() || b);
+            referencesTracker.HasUnityReference.Advise(lifetime,
+                b => IsVisible.Value = solutionTracker.IsUnityProject.HasTrueValue() || b);
         }
 
         public override string Kind => PencilsGroupKind.UnityPerformanceKind;
@@ -23,9 +26,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.Pencils
     [SolutionComponent]
     public class UnityPencilsFilterProvider : IPencilsFiltersProvider
     {
+        private readonly UnitySolutionTracker mySolutionTracker;
+        private readonly UnityReferencesTracker myReferencesTracker;
+
+        public UnityPencilsFilterProvider(UnitySolutionTracker solutionTracker, UnityReferencesTracker referencesTracker)
+        {
+            mySolutionTracker = solutionTracker;
+            myReferencesTracker = referencesTracker;
+        }
+
         public IEnumerable<IPencilsFilter> GetFilters(Lifetime lifetime, ISolution solution, ISettingsStore store)
         {
-            return new IPencilsFilter[] {new UnityPencilsFilter(lifetime, solution.GetComponent<UnitySolutionTracker>(), solution.GetComponent<UnityReferencesTracker>(), store)};
+            return new IPencilsFilter[] {new UnityPencilsFilter(lifetime, mySolutionTracker, myReferencesTracker, store)};
         }
     }
 }

--- a/resharper/resharper-unity/src/HlslSupport/Daemon/UnityHlslAllErrorsPredicate.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Daemon/UnityHlslAllErrorsPredicate.cs
@@ -1,9 +1,7 @@
 using JetBrains.Application.Settings;
 using JetBrains.Collections.Viewable;
-using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.ReSharper.Psi.Cpp.Tree;
@@ -13,32 +11,29 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Daemon
     [SolutionComponent]
     public class UnityHlslAllErrorsPredicate : IHlslUnresolvedUnqualifiedNamesErrorsPredicate {
         private readonly UnitySolutionTracker myUnitySolutionTracker;
-        private readonly IProperty<bool> mySuppressShaderErrors;
-        private readonly IProperty<bool> mySuppressShaderErrorsInRenderPipeline;
 
-        public UnityHlslAllErrorsPredicate(Lifetime lifetime, ISolution solution, UnitySolutionTracker unitySolutionTracker, ISettingsStore settingsStore)
+        public UnityHlslAllErrorsPredicate(Lifetime lifetime, ISolution solution,
+                                           UnitySolutionTracker unitySolutionTracker)
         {
             myUnitySolutionTracker = unitySolutionTracker;
-            mySuppressShaderErrors = settingsStore.BindToContextLive(lifetime, ContextRange.Smart(solution.ToDataContext()))
-                .GetValueProperty(lifetime, (UnitySettings key) => key.SuppressShaderErrorHighlighting);
-            mySuppressShaderErrorsInRenderPipeline = settingsStore.BindToContextLive(lifetime, ContextRange.Smart(solution.ToDataContext()))
-                .GetValueProperty(lifetime, (UnitySettings key) => key.SuppressShaderErrorHighlightingInRenderPipelinePackages);
         }
-        
+
         public bool SuppressUnresolvedErrors(CppFile cppFile, IContextBoundSettingsStore settingsStore)
         {
             if (!myUnitySolutionTracker.IsUnityProject.HasTrueValue())
                 return false;
-            
-            if (mySuppressShaderErrorsInRenderPipeline.Value)
+
+            if (settingsStore.GetValue((UnitySettings key) =>
+                key.SuppressShaderErrorHighlightingInRenderPipelinePackages))
             {
                 var location = cppFile.File;
                 if (location.FullPath.Contains(".render-pipelines"))
                     return true;
             }
-            return mySuppressShaderErrors.Value;
+
+            return settingsStore.GetValue((UnitySettings key) => key.SuppressShaderErrorHighlighting);
         }
-        
+
         public bool SuppressUnresolvedUnqualifiedErrors(CppFile cppFile, IContextBoundSettingsStore settingsStore)
         {
             return SuppressUnresolvedErrors(cppFile, settingsStore);

--- a/resharper/resharper-unity/src/HlslSupport/Daemon/UnityHlslAllErrorsPredicate.cs
+++ b/resharper/resharper-unity/src/HlslSupport/Daemon/UnityHlslAllErrorsPredicate.cs
@@ -1,21 +1,32 @@
 using JetBrains.Application.Settings;
 using JetBrains.Collections.Viewable;
+using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
 using JetBrains.ReSharper.Psi.Cpp.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Daemon
 {
     [SolutionComponent]
     public class UnityHlslAllErrorsPredicate : IHlslUnresolvedUnqualifiedNamesErrorsPredicate {
         private readonly UnitySolutionTracker myUnitySolutionTracker;
+        private readonly IProperty<bool> mySuppressShaderErrors;
+        private readonly IProperty<bool> mySuppressShaderErrorsInRenderPipeline;
 
         public UnityHlslAllErrorsPredicate(Lifetime lifetime, ISolution solution,
-                                           UnitySolutionTracker unitySolutionTracker)
+                                           UnitySolutionTracker unitySolutionTracker,
+                                           IApplicationWideContextBoundSettingStore settingsStore)
         {
             myUnitySolutionTracker = unitySolutionTracker;
+
+            // Cache the suppression settings for performance
+            mySuppressShaderErrors = settingsStore.BoundSettingsStore
+                .GetValueProperty(lifetime, (UnitySettings key) => key.SuppressShaderErrorHighlighting);
+            mySuppressShaderErrorsInRenderPipeline = settingsStore.BoundSettingsStore
+                .GetValueProperty(lifetime, (UnitySettings key) => key.SuppressShaderErrorHighlightingInRenderPipelinePackages);
         }
 
         public bool SuppressUnresolvedErrors(CppFile cppFile, IContextBoundSettingsStore settingsStore)
@@ -23,15 +34,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Daemon
             if (!myUnitySolutionTracker.IsUnityProject.HasTrueValue())
                 return false;
 
-            if (settingsStore.GetValue((UnitySettings key) =>
-                key.SuppressShaderErrorHighlightingInRenderPipelinePackages))
+            if (mySuppressShaderErrorsInRenderPipeline.Value)
             {
                 var location = cppFile.File;
                 if (location.FullPath.Contains(".render-pipelines"))
                     return true;
             }
 
-            return settingsStore.GetValue((UnitySettings key) => key.SuppressShaderErrorHighlighting);
+            return mySuppressShaderErrors.Value;
         }
 
         public bool SuppressUnresolvedUnqualifiedErrors(CppFile cppFile, IContextBoundSettingsStore settingsStore)

--- a/resharper/resharper-unity/src/JsonNew/Feature/CodeCompletion/JsonNewAutopopupCodeCompletionStrategy.cs
+++ b/resharper/resharper-unity/src/JsonNew/Feature/CodeCompletion/JsonNewAutopopupCodeCompletionStrategy.cs
@@ -16,7 +16,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.JsonNew.Feature.CodeCompletion
     {
         private readonly JsonNewIntellisenseManager myJsonIntellisenseManager;
 
-        public JsonNewAutopopupCodeCompletionStrategy(JsonNewIntellisenseManager jsonNewIntellisenseManager, ISettingsStore settingsStore)
+        public JsonNewAutopopupCodeCompletionStrategy(JsonNewIntellisenseManager jsonNewIntellisenseManager)
         {
             myJsonIntellisenseManager = jsonNewIntellisenseManager;
         }
@@ -34,24 +34,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.JsonNew.Feature.CodeCompletion
             return true;
         }
 
-        public bool ForceHideCompletion
-        {
-            get { return false; }
-        }
+        public bool ForceHideCompletion => false;
 
-        public PsiLanguageType Language
-        {
-            get { return JsonNewLanguage.Instance; }
-        }
+        // ReSharper disable once AssignNullToNotNullAttribute
+        public PsiLanguageType Language => JsonNewLanguage.Instance;
 
         public AutopopupType IsEnabledInSettings(IContextBoundSettingsStore settingsStore, ITextControl textControl)
         {
             return AutopopupType.HardAutopopup;
         }
 
-        public bool ProcessSubsequentTyping(char c, ITextControl textControl)
-        {
-            return true;
-        }
+        public bool ProcessSubsequentTyping(char c, ITextControl textControl) => true;
     }
 }

--- a/resharper/resharper-unity/src/Rider/Highlightings/IconsProviders/RiderInitialiseOnLoadCctorDetector.cs
+++ b/resharper/resharper-unity/src/Rider/Highlightings/IconsProviders/RiderInitialiseOnLoadCctorDetector.cs
@@ -1,4 +1,3 @@
-using JetBrains.Application.Settings.Implementation;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
 using JetBrains.ReSharper.Daemon.UsageChecking;
@@ -10,10 +9,10 @@ using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Resources.Icons;
 using JetBrains.ReSharper.Plugins.Unity.Rider.CodeInsights;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Highlightings.IconsProviders
 {
-    
     [SolutionComponent]
     public class RiderInitialiseOnLoadCctorDetector : InitialiseOnLoadCctorDetector
     {
@@ -21,29 +20,31 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Highlightings.IconsProviders
         private readonly UnitySolutionTracker mySolutionTracker;
         private readonly ConnectionTracker myConnectionTracker;
         private readonly IconHost myIconHost;
-        private readonly IElementIdProvider myProvider;
 
-        public RiderInitialiseOnLoadCctorDetector(ISolution solution, CallGraphSwaExtensionProvider callGraphSwaExtensionProvider, 
-            SettingsStore settingsStore, PerformanceCriticalCodeCallGraphMarksProvider marksProvider, UnityCodeInsightFieldUsageProvider fieldUsageProvider,
-            UnitySolutionTracker solutionTracker, ConnectionTracker connectionTracker,
-            IconHost iconHost, IElementIdProvider provider)
-            : base(solution, callGraphSwaExtensionProvider, settingsStore, marksProvider, provider)
+        public RiderInitialiseOnLoadCctorDetector(ISolution solution,
+                                                  CallGraphSwaExtensionProvider callGraphSwaExtensionProvider,
+                                                  IApplicationWideContextBoundSettingStore settingsStore,
+                                                  PerformanceCriticalCodeCallGraphMarksProvider marksProvider,
+                                                  UnityCodeInsightFieldUsageProvider fieldUsageProvider,
+                                                  UnitySolutionTracker solutionTracker,
+                                                  ConnectionTracker connectionTracker,
+                                                  IconHost iconHost, IElementIdProvider elementIdProvider)
+            : base(solution, callGraphSwaExtensionProvider, settingsStore, marksProvider, elementIdProvider)
         {
             myFieldUsageProvider = fieldUsageProvider;
             mySolutionTracker = solutionTracker;
             myConnectionTracker = connectionTracker;
             myIconHost = iconHost;
-            myProvider = provider;
         }
 
         protected override void AddHighlighting(IHighlightingConsumer consumer, ICSharpDeclaration element, string text, string tooltip,
-            DaemonProcessKind kind)
+                                                DaemonProcessKind kind)
         {
-            var iconId = element.HasHotIcon(CallGraphSwaExtensionProvider, Settings, MarksProvider, kind, myProvider)
+            var iconId = element.HasHotIcon(CallGraphSwaExtensionProvider, SettingsStore.BoundSettingsStore, MarksProvider, kind, ElementIdProvider)
                 ? InsightUnityIcons.InsightHot.Id
                 : InsightUnityIcons.InsightUnity.Id;
-            
-            if (RiderIconProviderUtil.IsCodeVisionEnabled(Settings, myFieldUsageProvider.ProviderId,
+
+            if (RiderIconProviderUtil.IsCodeVisionEnabled(SettingsStore.BoundSettingsStore, myFieldUsageProvider.ProviderId,
                 () => { base.AddHighlighting(consumer, element, text, tooltip, kind); }, out var useFallback))
             {
                 if (!useFallback)

--- a/resharper/resharper-unity/src/Rider/UnityEditorProtocol.cs
+++ b/resharper/resharper-unity/src/Rider/UnityEditorProtocol.cs
@@ -14,7 +14,6 @@ using JetBrains.IDE;
 using JetBrains.Lifetimes;
 using JetBrains.Platform.Unity.EditorPluginModel;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.Rd;
 using JetBrains.Rd.Base;
 using JetBrains.Rd.Impl;
@@ -22,6 +21,7 @@ using JetBrains.Rd.Tasks;
 using JetBrains.ReSharper.Host.Features;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Rider.Model;
 using JetBrains.Rider.Model.Notifications;
 using JetBrains.TextControl;
@@ -55,19 +55,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
 
         [NotNull]
         public readonly ViewableProperty<EditorPluginModel> UnityModel = new ViewableProperty<EditorPluginModel>(null);
-        
+
         [NotNull]
         public readonly ViewableProperty<SocketWire.Base> UnityWire = new ViewableProperty<SocketWire.Base>(null);
 
         public UnityEditorProtocol(Lifetime lifetime, ILogger logger, UnityHost host,
-            IScheduler dispatcher, IShellLocks locks, ISolution solution,
-            ISettingsStore settingsStore, JetBrains.Application.ActivityTrackingNew.UsageStatistics usageStatistics,
-            UnitySolutionTracker unitySolutionTracker, IThreading threading,
-            UnityVersion unityVersion, NotificationsModel notificationsModel,
-            IHostProductInfo hostProductInfo, IFileSystemTracker fileSystemTracker)
+                                   IScheduler dispatcher, IShellLocks locks, ISolution solution,
+                                   IApplicationWideContextBoundSettingStore settingsStore,
+                                   JetBrains.Application.ActivityTrackingNew.UsageStatistics usageStatistics,
+                                   UnitySolutionTracker unitySolutionTracker, IThreading threading,
+                                   UnityVersion unityVersion, NotificationsModel notificationsModel,
+                                   IHostProductInfo hostProductInfo, IFileSystemTracker fileSystemTracker)
         {
             myPluginInstallations = new JetHashSet<FileSystemPath>();
-            
+
             myComponentLifetime = lifetime;
             myLogger = logger;
             myDispatcher = dispatcher;
@@ -79,7 +80,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
             myNotificationsModel = notificationsModel;
             myHostProductInfo = hostProductInfo;
             myHost = host;
-            myBoundSettingsStore = settingsStore.BindToContextLive(lifetime, ContextRange.Smart(solution.ToDataContext()));
+            myBoundSettingsStore = settingsStore.BoundSettingsStore;
             mySessionLifetimes = new SequentialLifetimes(lifetime);
 
             if (solution.GetData(ProjectModelExtensions.ProtocolSolutionKey) == null)
@@ -99,7 +100,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                 CreateProtocols(protocolInstancePath);
             });
         }
-        
+
         private void OnChangeAction(FileSystemChangeDelta delta)
         {
             // connect on reload of server
@@ -147,19 +148,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                 var wire = new SocketWire.Client(lifetime, myDispatcher, protocolInstance.Port, "UnityClient");
                 UnityWire.Value = wire;
                 wire.BackwardsCompatibleWireFormat = true;
-                    
-                var protocol = new Protocol("UnityEditorPlugin", new Serializers(),
-                    new Identities(IdKind.Client), myDispatcher, wire, lifetime);
 
-                protocol.ThrowErrorOnOutOfSyncModels = false;
+                var protocol = new Protocol("UnityEditorPlugin", new Serializers(),
+                    new Identities(IdKind.Client), myDispatcher, wire, lifetime) {ThrowErrorOnOutOfSyncModels = false};
 
                 protocol.OutOfSyncModels.AdviseOnce(lifetime, e =>
                 {
                     if (myPluginInstallations.Contains(mySolution.SolutionFilePath))
                         return;
-                        
+
                     myPluginInstallations.Add(mySolution.SolutionFilePath); // avoid displaying Notification multiple times on each AppDomain.Reload in Unity
-                        
+
                     var appVersion = myUnityVersion.ActualVersionForSolution.Value;
                     if (appVersion < new Version(2019, 2))
                     {
@@ -172,13 +171,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                     }
                     else
                     {
-                        var notification = new NotificationModel("Advanced Unity integration is unavailable", 
+                        var notification = new NotificationModel("Advanced Unity integration is unavailable",
                             $"Please update External Editor to {myHostProductInfo.VersionMarketingString} in Unity Preferences.",
                             true, RdNotificationEntryType.WARN);
                         mySolution.Locks.ExecuteOrQueue(lifetime, "OutOfSyncModels.Notify", () => myNotificationsModel.Notification(notification));
                     }
                 });
-                
+
                 wire.Connected.WhenTrue(lifetime, lf =>
                 {
                     myLogger.Info("WireConnected.");
@@ -226,7 +225,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                     editor.UnityApplicationData.Advise(lifetime,
                         s => myHost.PerformModelAction(a =>
                         {
-                            var version = UnityVersion.Parse(s.ApplicationVersion); 
+                            var version = UnityVersion.Parse(s.ApplicationVersion);
                             a.UnityApplicationData.SetValue(new UnityApplicationData(s.ApplicationPath,
                                     s.ApplicationContentsPath, s.ApplicationVersion, UnityVersion.RequiresRiderPackage(version)));
                         }));
@@ -238,16 +237,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
                         rd.GenerateUIElementsSchema.Set((l, u) =>
                             editor.GenerateUIElementsSchema.Start(l, u).ToRdTask(l));
                     });
-                    
+
                     editor.BuildLocation.Advise(lf, b => myHost.PerformModelAction(rd => rd.BuildLocation.SetValue(b)));
-                    
+
                     myHost.PerformModelAction(rd =>
                     {
                         rd.RunMethodInUnity.Set((l, data) =>
                         {
                             var editorRdTask = editor.RunMethodInUnity.Start(l, new RunMethodData(data.AssemblyName, data.TypeName, data.MethodName)).ToRdTask(l);
                             var frontendRes = new RdTask<JetBrains.Rider.Model.RunMethodResult>();
-                            
+
                             editorRdTask.Result.Advise(l, r =>
                             {
                                 frontendRes.Set(new JetBrains.Rider.Model.RunMethodResult(r.Result.Success, r.Result.Message, r.Result.StackTrace));
@@ -289,7 +288,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
         }
 
         private void TrackActivity(EditorPluginModel editor, Lifetime lf)
-        { 
+        {
             editor.UnityApplicationData.AdviseOnce(lf, data => { myUsageStatistics.TrackActivity("UnityVersion", data.ApplicationVersion); });
             editor.ScriptingRuntime.AdviseOnce(lf, runtime => { myUsageStatistics.TrackActivity("ScriptingRuntime", runtime.ToString()); });
         }

--- a/resharper/resharper-unity/src/Rider/UnitySettingsSynchronizer.cs
+++ b/resharper/resharper-unity/src/Rider/UnitySettingsSynchronizer.cs
@@ -1,10 +1,9 @@
-﻿using JetBrains.Application.Settings;
-using JetBrains.Application.Threading;
+﻿using JetBrains.Application.Threading;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider
 {
@@ -12,9 +11,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider
     public class UnitySettingsSynchronizer
     {
         public UnitySettingsSynchronizer(Lifetime lifetime, ISolution solution, UnityHost host,
-                                         ISettingsStore settingsStore)
+                                         IApplicationWideContextBoundSettingStore settingsStore)
         {
-            var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.Smart(solution.ToDataContext()));
+            var boundStore = settingsStore.BoundSettingsStore;
             var entry = boundStore.Schema.GetScalarEntry((UnitySettings s) => s.EnableShaderLabHippieCompletion);
             boundStore.GetValueProperty<bool>(lifetime, entry, null).Change.Advise_HasNew(lifetime, args =>
             {

--- a/resharper/resharper-unity/src/Settings/CgSupportSettings.cs
+++ b/resharper/resharper-unity/src/Settings/CgSupportSettings.cs
@@ -1,14 +1,14 @@
-﻿using JetBrains.Application;
-using JetBrains.Application.Environment;
+﻿using JetBrains.Application.Environment;
 using JetBrains.Application.Environment.Helpers;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
-    [ShellComponent]
+    [SolutionComponent]
     public class CgSupportSettings
     {
         public IProperty<bool> IsErrorHighlightingEnabled { get; }

--- a/resharper/resharper-unity/src/Settings/CgSupportSettings.cs
+++ b/resharper/resharper-unity/src/Settings/CgSupportSettings.cs
@@ -4,6 +4,7 @@ using JetBrains.Application.Environment.Helpers;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
@@ -12,10 +13,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
     {
         public IProperty<bool> IsErrorHighlightingEnabled { get; }
 
-        public CgSupportSettings(Lifetime lifetime, ISettingsStore settingsStore, RunsProducts.ProductConfigurations productConfigurations)
+        public CgSupportSettings(Lifetime lifetime, IApplicationWideContextBoundSettingStore settingsStore,
+                                 RunsProducts.ProductConfigurations productConfigurations)
         {
-            var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ApplicationWide);
-            IsErrorHighlightingEnabled = boundStore.GetValueProperty(lifetime, (UnitySettings s) => s.EnableCgErrorHighlighting);
+            IsErrorHighlightingEnabled = settingsStore.BoundSettingsStore
+                .GetValueProperty(lifetime, (UnitySettings s) => s.EnableCgErrorHighlighting);
 
             if (!productConfigurations.IsInternalMode())
             {

--- a/resharper/resharper-unity/src/Settings/ShaderLabSupport.cs
+++ b/resharper/resharper-unity/src/Settings/ShaderLabSupport.cs
@@ -2,7 +2,6 @@ using JetBrains.Application;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
-using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
@@ -11,10 +10,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
     {
         public IProperty<bool> IsParsingEnabled { get; }
 
-        public ShaderLabSupport(Lifetime lifetime, IApplicationWideContextBoundSettingStore settingsStore)
+        public ShaderLabSupport(Lifetime lifetime, ISettingsStore settingsStore)
         {
-            IsParsingEnabled = settingsStore.BoundSettingsStore.
-                GetValueProperty(lifetime, (UnitySettings s) => s.EnableShaderLabParsing);
+            // We can't use IApplicationWideContextBoundSettingsStore here because this a ShellComponent, because it's used
+            // in ShaderLabProjectFileLanguageService
+            // Keep a live context so that we'll get new mount points, e.g. Solution
+            IsParsingEnabled = settingsStore.BindToContextLive(lifetime, ContextRange.ApplicationWide)
+                .GetValueProperty(lifetime, (UnitySettings s) => s.EnableShaderLabParsing);
         }
     }
 }

--- a/resharper/resharper-unity/src/Settings/ShaderLabSupport.cs
+++ b/resharper/resharper-unity/src/Settings/ShaderLabSupport.cs
@@ -2,6 +2,7 @@ using JetBrains.Application;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
@@ -10,10 +11,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Settings
     {
         public IProperty<bool> IsParsingEnabled { get; }
 
-        public ShaderLabSupport(Lifetime lifetime, ISettingsStore settingsStore)
+        public ShaderLabSupport(Lifetime lifetime, IApplicationWideContextBoundSettingStore settingsStore)
         {
-            var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ApplicationWide);
-            IsParsingEnabled = boundStore.GetValueProperty(lifetime, (UnitySettings s) => s.EnableShaderLabParsing);
+            IsParsingEnabled = settingsStore.BoundSettingsStore.
+                GetValueProperty(lifetime, (UnitySettings s) => s.EnableShaderLabParsing);
         }
     }
 }

--- a/resharper/resharper-unity/src/ShaderLab/Feature/Services/Formatting/ShaderLabFormattingStylePage.cs
+++ b/resharper/resharper-unity/src/ShaderLab/Feature/Services/Formatting/ShaderLabFormattingStylePage.cs
@@ -1,77 +1,70 @@
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using JetBrains.Application.Components;
+using JetBrains.Application.Settings;
 using JetBrains.Application.UI.Components;
 using JetBrains.Application.UI.Options;
 using JetBrains.Lifetimes;
 using JetBrains.ReSharper.Feature.Services.OptionPages;
 using JetBrains.ReSharper.Feature.Services.OptionPages.CodeEditing;
 using JetBrains.ReSharper.Feature.Services.OptionPages.CodeStyle;
-using JetBrains.ReSharper.Feature.Services.OptionPages.CodeStyle.ViewModels;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Formatting;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.EditorConfig;
 using JetBrains.ReSharper.Resources.Resources.Icons;
-using IContextBoundSettingsStoreLive = JetBrains.Application.Settings.IContextBoundSettingsStoreLive;
 
 namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Feature.Services.Formatting
 {
-  [OptionsPage(
-     PID,
-     "ShaderLab Formatting Style",
-     typeof(PsiFeaturesUnsortedOptionsThemedIcons.Indent),
-     ParentId = CodeEditingPage.PID,
-     Sequence = 0,
-     FilterTags = new[] { ConfigFileUtils.EditorConfigName })]
-  public class ShaderLabFormattingStylePage : CodeStylePage
-  {
-    public const string PID = "ShaderLabFormattingStylePage";
-
-    protected override bool ShowAutoDetectAndConfigureFormattingTip => true;
-
-    public override string Id => PID;
-
-    public ShaderLabFormattingStylePage(
-      [NotNull] Lifetime lifetime,
-      [NotNull] OptionsSettingsSmartContext smartContext,
-      [NotNull] IUIApplication environment,
-      [NotNull] ShaderLabFormattingStylePageSchema schema,
-      [NotNull] CodeStylePreview preview, IComponentContainer container)
-      : base(lifetime, smartContext, environment, schema, preview, container)
+    [OptionsPage(
+        PID,
+        "ShaderLab Formatting Style",
+        typeof(PsiFeaturesUnsortedOptionsThemedIcons.Indent),
+        ParentId = CodeEditingPage.PID,
+        Sequence = 0,
+        FilterTags = new[] {ConfigFileUtils.EditorConfigName})]
+    public class ShaderLabFormattingStylePage : CodeStylePage
     {
-    }
-  }
+        public const string PID = "ShaderLabFormattingStylePage";
 
-  [FormattingSettingsPresentationComponent]
-  public class ShaderLabFormattingStylePageSchema : IndentStylePageSchema<ShaderLabFormatSettingsKey, ShaderLabCodeStylePreview>
-  {
-    public ShaderLabFormattingStylePageSchema([NotNull] Lifetime lifetime, [NotNull] IContextBoundSettingsStoreLive smartContext, [NotNull] IValueEditorViewModelFactory itemViewModelFactory, IComponentContainer container, ISettingsToHide settingsToHide)
-      : base(lifetime, smartContext, itemViewModelFactory, container, settingsToHide)
-    {
+        protected override bool ShowAutoDetectAndConfigureFormattingTip => true;
+
+        public override string Id => PID;
+
+        public ShaderLabFormattingStylePage(Lifetime lifetime,
+                                            [NotNull] OptionsSettingsSmartContext smartContext,
+                                            [NotNull] IUIApplication environment,
+                                            [NotNull] ShaderLabFormattingStylePageSchema schema,
+                                            [NotNull] CodeStylePreview preview, IComponentContainer container)
+            : base(lifetime, smartContext, environment, schema, preview, container)
+        {
+        }
     }
 
-    protected override void Describe(SchemaBuilder builder)
+    [FormattingSettingsPresentationComponent]
+    public class ShaderLabFormattingStylePageSchema : IndentStylePageSchema<ShaderLabFormatSettingsKey, ShaderLabCodeStylePreview>
     {
-      base.Describe(builder);
+        public ShaderLabFormattingStylePageSchema(Lifetime lifetime,
+                                                  [NotNull] IContextBoundSettingsStoreLive smartContext,
+                                                  [NotNull] IValueEditorViewModelFactory itemViewModelFactory,
+                                                  IComponentContainer container, ISettingsToHide settingsToHide)
+            : base(lifetime, smartContext, itemViewModelFactory, container, settingsToHide)
+        {
+        }
 
-      builder
-        .Category("Brace rules")
+        protected override void Describe(SchemaBuilder builder)
+        {
+            base.Describe(builder);
 
-        .ItemFor(
-          key => key.BraceStyle,
-          "Shader \"Unlit/NewUnlitShader\"\n{\n    Properties\n    {\n        _MainTex (\"Texture\", 2D) = \"white\" {}\n    }\n    SubShader\n    {\n        Tags { \"RenderType\"=\"Opaque\" }\n        LOD 100\n\n        Pass\n        {\n\n        }\n    }\n}",
-          PreviewType.Code, PreviewParseType.File).EndCategory();
+            builder
+                .Category("Brace rules")
+
+                .ItemFor(
+                    key => key.BraceStyle,
+                    "Shader \"Unlit/NewUnlitShader\"\n{\n    Properties\n    {\n        _MainTex (\"Texture\", 2D) = \"white\" {}\n    }\n    SubShader\n    {\n        Tags { \"RenderType\"=\"Opaque\" }\n        LOD 100\n\n        Pass\n        {\n\n        }\n    }\n}")
+                .EndCategory();
+        }
+
+        public override KnownLanguage Language => ShaderLabLanguage.Instance;
+        public override string PageName => "ShaderLab Formatting Style";
     }
-
-    public override KnownLanguage Language
-    {
-      get { return ShaderLabLanguage.Instance; }
-    }
-
-    public override string PageName
-    {
-      get { return "ShaderLab Formatting Style"; }
-    }
-  }
 }

--- a/resharper/resharper-unity/src/Utils/SolutionWideWritableContextBoundSettingsStore.cs
+++ b/resharper/resharper-unity/src/Utils/SolutionWideWritableContextBoundSettingsStore.cs
@@ -1,0 +1,21 @@
+using JetBrains.Application.Settings;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.DataContext;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Utils
+{
+    // Amortise the cost of BindToContextLive across any component that wants to write purely to the Solution layer
+    [SolutionComponent]
+    public class SolutionWideWritableContextBoundSettingsStore
+    {
+        public SolutionWideWritableContextBoundSettingsStore(Lifetime lifetime, ISolution solution,
+                                                             ISettingsStore settingsStore)
+        {
+            BoundSettingsStore = settingsStore.BindToContextLive(lifetime,
+                ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
+        }
+
+        public IContextBoundSettingsStoreLive BoundSettingsStore { get; }
+    }
+}

--- a/resharper/resharper-unity/src/Yaml/AssetIndexingSupport.cs
+++ b/resharper/resharper-unity/src/Yaml/AssetIndexingSupport.cs
@@ -3,8 +3,8 @@ using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Caches;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
+using JetBrains.ReSharper.Plugins.Unity.Utils;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
 using JetBrains.ReSharper.Plugins.Yaml.Settings;
 
@@ -15,11 +15,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
     {
         public readonly IProperty<bool> IsEnabled;
 
-        public AssetIndexingSupport(Lifetime lifetime, YamlSupport yamlSupport, SolutionCaches solutionCaches, ISolution solution, ISettingsStore settingsStore)
+        public AssetIndexingSupport(Lifetime lifetime, YamlSupport yamlSupport, SolutionCaches solutionCaches,
+                                    ISolution solution, SolutionWideWritableContextBoundSettingsStore settingsStore)
         {
-            var settings = settingsStore.BindToContextLive(lifetime,
-                ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
-            IsEnabled = settings.GetValueProperty(lifetime, (UnitySettings key) => key.IsAssetIndexingEnabled);
+            IsEnabled = settingsStore.BoundSettingsStore.GetValueProperty(lifetime,
+                (UnitySettings key) => key.IsAssetIndexingEnabled);
 
             if (!yamlSupport.IsParsingEnabled.Value)
                 IsEnabled.Value = false;
@@ -31,7 +31,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml
                     yamlSupport.IsParsingEnabled.Value = true;
                     if (v.HasOld)
                     {
-                        solutionCaches.PersistentProperties[UnityYamlDisableStrategy.SolutionCachesId] = false.ToString();
+                        solutionCaches.PersistentProperties[UnityYamlDisableStrategy.SolutionCachesId] =
+                            false.ToString();
                     }
                 }
             });

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityYamlDisableStrategy.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 using JetBrains.Application.Settings;
-using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Caches;
-using JetBrains.ProjectModel.DataContext;
 using JetBrains.ReSharper.Plugins.Unity.Settings;
+using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
@@ -24,16 +22,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
         private readonly bool myAllowRunHeuristic;
         private ulong myTotalSize;
 
-        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore, AssetIndexingSupport assetIndexingSupport)
+        public UnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches,
+                                        IApplicationWideContextBoundSettingStore settingsStore, AssetIndexingSupport assetIndexingSupport)
         {
             mySolutionCaches = solutionCaches;
             myAssetIndexingSupport = assetIndexingSupport;
-            var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ManuallyRestrictWritesToOneContext(solution.ToDataContext()));
-            myAllowRunHeuristic = boundStore.GetValue((UnitySettings s) => s.EnableAssetIndexingPerformanceHeuristic);
+            myAllowRunHeuristic = settingsStore.BoundSettingsStore
+                .GetValue((UnitySettings s) => s.EnableAssetIndexingPerformanceHeuristic);
 
             if (solutionCaches.PersistentProperties.TryGetValue(SolutionCachesId, out var result))
             {
-                myShouldRunHeuristic = Boolean.Parse(result);
+                myShouldRunHeuristic = bool.Parse(result);
             }
             else
             {

--- a/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/Rider/Psi/Modules/RiderUnityYamlDisableStrategy.cs
@@ -1,8 +1,8 @@
-using JetBrains.Application.Settings;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Caches;
 using JetBrains.ReSharper.Plugins.Unity.Rider;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 {
@@ -11,7 +11,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
     {
         private readonly UnityHost myUnityHost;
 
-        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore,
+        public RiderUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches,
+                                             IApplicationWideContextBoundSettingStore settingsStore,
                                              AssetIndexingSupport assetIndexingSupport, UnityHost unityHost)
             : base(lifetime, solution, solutionCaches, settingsStore, assetIndexingSupport)
         {

--- a/resharper/resharper-unity/src/Yaml/VisualStudio/Psi/Modules/ReSharperUnityYamlDisableStrategy.cs
+++ b/resharper/resharper-unity/src/Yaml/VisualStudio/Psi/Modules/ReSharperUnityYamlDisableStrategy.cs
@@ -1,9 +1,9 @@
 using JetBrains.Application.Notifications;
-using JetBrains.Application.Settings;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Caches;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.VisualStudio.Psi.Modules
 {
@@ -13,8 +13,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.VisualStudio.Psi.Modules
         private readonly Lifetime myLifetime;
         private readonly UserNotifications myNotifications;
 
-        public ReSharperUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches, ISettingsStore settingsStore,
-                                                 AssetIndexingSupport assetIndexingSupport, UserNotifications notifications)
+        public ReSharperUnityYamlDisableStrategy(Lifetime lifetime, ISolution solution, SolutionCaches solutionCaches,
+                                                 IApplicationWideContextBoundSettingStore settingsStore,
+                                                 AssetIndexingSupport assetIndexingSupport,
+                                                 UserNotifications notifications)
             : base(lifetime, solution, solutionCaches, settingsStore, assetIndexingSupport)
         {
             myLifetime = lifetime;

--- a/resharper/resharper-unity/test/src/CSharp/Feature/Services/Descriptions/IdentifierTooltipTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Feature/Services/Descriptions/IdentifierTooltipTest.cs
@@ -5,29 +5,23 @@ using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Feature.Services.Descriptions
 {
-    // TODO: WHY DOES TESTSETTING NOT WORK!??!
     [TestUnity]
     // The tests include tooltips from all highlighters at the caret position, which will include gutter icons for
     // ReSharper, but not Rider as we prefer Code Vision. Force gutter icons on to avoid splitting the test per product.
-    // TODO: Include tests for this setting always on, and always off
-    // ReSharper currently ignores this option, and I can't get [TestSetting] to work correctly...
-    // [TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.Always)]
+    [TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.Always)]
     public class IdentifierTooltipTest : IdentifierTooltipTestBase
     {
         protected override string RelativeTestDataPath => @"CSharp\Daemon\IdentifierTooltip";
 
-        // TODO: TestSetting is ignored if set again. It's called, but the component doesn't see the changed value
-        // [Test, TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.None)]
-        // public void EventFunction01() { DoNamedTest(); }
-        // [Test, TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.None)]
-        // public void EventFunction02() { DoNamedTest(); }
+        // TODO: ReSharper currently ignores this setting, and always shows gutter icons
 #if RIDER
-        [Test] public void EventFunction01() { DoNamedTest(); }
-        [Test] public void EventFunction02() { DoNamedTest(); }
-#else
+        [Test, TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.None)]
+        public void EventFunction01() { DoNamedTest(); }
+        [Test, TestSetting(typeof(UnitySettings), nameof(UnitySettings.GutterIconMode), GutterIconMode.None)]
+        public void EventFunction02() { DoNamedTest(); }
+#endif
         [Test] public void EventFunctionWithGutterIcon01() { DoNamedTest(); }
         [Test] public void EventFunctionWithGutterIcon02() { DoNamedTest(); }
-#endif
         [Test] public void EventFunctionParameter01() { DoNamedTest(); }
         [Test] public void EventFunctionParameter02() { DoNamedTest(); }
     }

--- a/resharper/resharper-yaml/src/Settings/YamlSupport.cs
+++ b/resharper/resharper-yaml/src/Settings/YamlSupport.cs
@@ -2,6 +2,7 @@ using JetBrains.Application;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
+using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Yaml.Settings
 {
@@ -10,10 +11,10 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Settings
   {
     public IProperty<bool> IsParsingEnabled { get; }
 
-    public YamlSupport(Lifetime lifetime, ISettingsStore settingsStore)
+    public YamlSupport(Lifetime lifetime, IApplicationWideContextBoundSettingStore settingsStore)
     {
-      var boundStore = settingsStore.BindToContextLive(lifetime, ContextRange.ApplicationWide);
-      IsParsingEnabled = boundStore.GetValueProperty(lifetime, (YamlSettings s) => s.EnableYamlParsing2);
+      IsParsingEnabled = settingsStore.BoundSettingsStore
+        .GetValueProperty(lifetime, (YamlSettings s) => s.EnableYamlParsing2);
     }
   }
 }

--- a/resharper/resharper-yaml/src/Settings/YamlSupport.cs
+++ b/resharper/resharper-yaml/src/Settings/YamlSupport.cs
@@ -2,7 +2,6 @@ using JetBrains.Application;
 using JetBrains.Application.Settings;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
-using JetBrains.ReSharper.Psi.Util;
 
 namespace JetBrains.ReSharper.Plugins.Yaml.Settings
 {
@@ -11,9 +10,12 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Settings
   {
     public IProperty<bool> IsParsingEnabled { get; }
 
-    public YamlSupport(Lifetime lifetime, IApplicationWideContextBoundSettingStore settingsStore)
+    public YamlSupport(Lifetime lifetime, ISettingsStore settingsStore)
     {
-      IsParsingEnabled = settingsStore.BoundSettingsStore
+      // We can't use IApplicationWideContextBoundSettingsStore here because this a ShellComponent, because it's used
+      // in UnityYamlProjectFileLanguageService
+      // Keep a live context so that we'll get new mount points, e.g. Solution
+      IsParsingEnabled = settingsStore.BindToContextLive(lifetime, ContextRange.ApplicationWide)
         .GetValueProperty(lifetime, (YamlSettings s) => s.EnableYamlParsing2);
     }
   }


### PR DESCRIPTION
Update the way we're using `ISettingsStore` and bound stores. A transient bound store is fairly cheap, but doesn't get updated when new settings layers are added (which can cause problems e.g. for tests that want to temporarily change settings). A live bound store fixes this, but is quite expensive. We should inject `IApplicationWideContextBoundSettingStore` and use the common bound store here.

This PR goes through all usages of `ISettingsStore` and bound settings stores to make sure we're using the correct stores. It also introduces `SolutionWideWritableContextBoundSettingsStore` that maintains a single live bound store that has writes restricted to the solution context. This can be shared by all components that need settings to be saved a the solution level, rather than global/smart.