### PR TITLE
Use Unity entity kind in element descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Add inspection for correct constraint on type parameter of `SharedStatic` for Burst context ([#1852](https://github.com/JetBrains/resharper-unity/pull/1852))
 - Add inspections for correct usage of `SharedStatic` in Burst code ([#1852](https://github.com/JetBrains/resharper-unity/pull/1852))
 - Add option to disable Burst analysis ([#1852](https://github.com/JetBrains/resharper-unity/pull/1852))
+- Use Unity terminology to describe event functions and serialised fields in identifier tooltips and inspections ([#1914](https://github.com/JetBrains/resharper-unity/pull/1914))
 - Rider: Highlight methods from a Burst compiled context with line marker and Code Vision links ([#1852](https://github.com/JetBrains/resharper-unity/pull/1852))
 - Rider: Execute both edit and play mode tests in the same run ([#1894](https://github.com/JetBrains/resharper-unity/pull/1894))
 - Rider: Run Unity menu item handlers via gutter icon ([RIDER-35911](https://youtrack.jetbrains.com/issue/RIDER-35911), [#1857](https://github.com/JetBrains/resharper-unity/pull/1857))

--- a/resharper/resharper-unity/src/CSharp/Psi/UnityCSharpDeclaredElementPresenter.cs
+++ b/resharper/resharper-unity/src/CSharp/Psi/UnityCSharpDeclaredElementPresenter.cs
@@ -1,0 +1,26 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp.Impl;
+
+namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi
+{
+    [PsiSharedComponent]
+    public class UnityCSharpDeclaredElementPresenter : CSharpDeclaredElementPresenter
+    {
+        public override string GetEntityKind(IDeclaredElement declaredElement)
+        {
+            if (declaredElement.IsFromUnityProject())
+            {
+                var unityApi = declaredElement.GetSolution().GetComponent<UnityApi>();
+                switch (declaredElement)
+                {
+                    case IMethod method when unityApi.IsEventFunction(method):
+                        return "event function";
+                    case IField field when unityApi.IsSerialisedField(field):
+                        return "serialised field";
+                }
+            }
+            return base.GetEntityKind(declaredElement);
+        }
+    }
+}

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction01.gold
@@ -1,3 +1,3 @@
-﻿(method) void A.OnDestroy()
+﻿(event function) void A.OnDestroy()
 
 Destroying the attached Behaviour will result in the game or Scene receiving OnDestroy.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction01.richText.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction01.richText.gold
@@ -1,3 +1,3 @@
-﻿(method) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnDestroy(ReSharper C# Method Identifier)|()
+﻿(event function) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnDestroy(ReSharper C# Method Identifier)|()
 
 Destroying the attached Behaviour will result in the game or Scene receiving OnDestroy.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction02.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction02.gold
@@ -1,4 +1,4 @@
-﻿(method) void A.OnMouseExit()
+﻿(event function) void A.OnMouseExit()
 
 Called when the mouse is not any longer over the Collider.
 This function can be a coroutine.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction02.richText.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunction02.richText.gold
@@ -1,4 +1,4 @@
-﻿(method) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnMouseExit(ReSharper C# Method Identifier)|()
+﻿(event function) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnMouseExit(ReSharper C# Method Identifier)|()
 
 Called when the mouse is not any longer over the Collider.
 This function can be a coroutine.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon01.gold
@@ -1,4 +1,4 @@
-﻿(method) void A.OnDestroy()
+﻿(event function) void A.OnDestroy()
 
 Destroying the attached Behaviour will result in the game or Scene receiving OnDestroy.
 Unity event function

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon01.richText.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon01.richText.gold
@@ -1,4 +1,4 @@
-﻿(method) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnDestroy(ReSharper C# Method Identifier)|()
+﻿(event function) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnDestroy(ReSharper C# Method Identifier)|()
 
 Destroying the attached Behaviour will result in the game or Scene receiving OnDestroy.
 Unity event function

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon02.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon02.gold
@@ -1,4 +1,4 @@
-﻿(method) void A.OnMouseExit()
+﻿(event function) void A.OnMouseExit()
 
 Called when the mouse is not any longer over the Collider.
 This function can be a coroutine.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon02.richText.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/IdentifierTooltip/EventFunctionWithGutterIcon02.richText.gold
@@ -1,4 +1,4 @@
-﻿(method) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnMouseExit(ReSharper C# Method Identifier)|()
+﻿(event function) |void(ReSharper C# Keyword)| |A(ReSharper C# Class Identifier)|.|OnMouseExit(ReSharper C# Method Identifier)|()
 
 Called when the mouse is not any longer over the Collider.
 This function can be a coroutine.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/RedundantEventFunctionWarning.cs.gold
@@ -91,4 +91,4 @@ public class Derived : Base
 (0): ReSharper Dead Code: Redundant Unity event function
 (1): ReSharper Dead Code: Redundant Unity event function
 (2): ReSharper Dead Code: Redundant Unity event function
-(3): ReSharper Dead Code: Redundant method override
+(3): ReSharper Dead Code: Redundant event function override

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/resharper/HiddenEventFunctions.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/resharper/HiddenEventFunctions.cs.gold
@@ -83,18 +83,18 @@ If OnAudioFilterRead is implemented, Unity will insert a custom filter into the 
 (13): ReSharper Unity Implicitly Used Identifier: 
 (14): Unity Gutter Icon: Unity script
 (15): ReSharper Unity Implicitly Used Identifier: 
-(16): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(16): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (17): Unity Gutter Icon: Unity event function
 
 Start is called on the frame when a script is enabled just before any of the Update methods are called the first time.
 This function can be a coroutine.
 (18): ReSharper Unity Implicitly Used Identifier: 
-(19): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(19): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (20): Unity Gutter Icon: Unity event function
 
 This function is called when the object becomes enabled and active.
 (21): ReSharper Unity Implicitly Used Identifier: 
-(22): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(22): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (23): Unity Gutter Icon: Unity event function
 
 Destroying the attached Behaviour will result in the game or Scene receiving OnDestroy.

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/rider/HiddenEventFunctions.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/Stages/Analysis/rider/HiddenEventFunctions.cs.gold
@@ -73,13 +73,13 @@ public class ||Derived|(13)|(14) : Base
 (14): UnityCodeInsights: 
 (15): ReSharper Unity Implicitly Used Identifier: 
 (16): UnityCodeInsights: 
-(17): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(17): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (18): ReSharper Unity Implicitly Used Identifier: 
 (19): UnityCodeInsights: 
-(20): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(20): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (21): ReSharper Unity Implicitly Used Identifier: 
 (22): UnityCodeInsights: 
-(23): ReSharper Hides: Hides method from class 'Base' (Click to go)
+(23): ReSharper Hides: Hides event function from class 'Base' (Click to go)
 (24): ReSharper Unity Implicitly Used Identifier: 
 (25): UnityCodeInsights: 
 (26): ReSharper Hides: Hides Unity event function from class 'Base' (Click to go)

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourFields01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourFields01.gold
@@ -31,10 +31,10 @@ public class A : MonoBehaviour
 }
 
 ---------------------------------------------------------
-(0): ReSharper Dead Code: Field 'implicitlyAssignedField' is assigned but its value is never used
-(1): ReSharper Dead Code: Field 'implicitlyAssignedMultiField1' is assigned but its value is never used
-(2): ReSharper Dead Code: Field 'implicitlyAssignedMultiField2' is assigned but its value is never used
-(3): ReSharper Dead Code: Field 'implicitlyAssignedPrivateField' is assigned but its value is never used
+(0): ReSharper Dead Code: Serialised field 'implicitlyAssignedField' is assigned but its value is never used
+(1): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField1' is assigned but its value is never used
+(2): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField2' is assigned but its value is never used
+(3): ReSharper Dead Code: Serialised field 'implicitlyAssignedPrivateField' is assigned but its value is never used
 (4): ReSharper Dead Code: Field 'UnusedAction' is never used
 (5): ReSharper Dead Code: Constant 'UnusedConst' is never used
 (6): ReSharper Dead Code: Constant 'UnusedPrivateConst' is never used

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/MonoBehaviourMethods01.gold
@@ -66,11 +66,11 @@ public class A : MonoBehaviour
 
 ---------------------------------------------------------
 (0): ReSharper Dead Code: Method 'UnusedPrivateMethod' is never used
-(1): ReSharper Dead Code: Method 'OnAudioFilterRead' is never used
+(1): ReSharper Dead Code: Event function 'OnAudioFilterRead' is never used
 (2): ReSharper Warning: Incorrect method parameters. Expected '(float[] data, int channels)'
 (3): ReSharper Warning: Incorrect return type. Expected 'void'
-(4): ReSharper Dead Code: Method 'FixedUpdate' is never used
+(4): ReSharper Dead Code: Event function 'FixedUpdate' is never used
 (5): ReSharper Warning: Incorrect static modifier
-(6): ReSharper Dead Code: Method 'LateUpdate' is never used
+(6): ReSharper Dead Code: Event function 'LateUpdate' is never used
 (7): ReSharper Dead Code: Parameter 'collisionInfo' is never used
 

--- a/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/SerializableClassFields01.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Daemon/UsageChecking/SerializableClassFields01.gold
@@ -88,10 +88,10 @@ public class |NotSerializable|(38)
 }
 
 ---------------------------------------------------------
-(0): ReSharper Dead Code: Field 'implicitlyAssignedField' is assigned but its value is never used
-(1): ReSharper Dead Code: Field 'implicitlyAssignedMultiField1' is assigned but its value is never used
-(2): ReSharper Dead Code: Field 'implicitlyAssignedMultiField2' is assigned but its value is never used
-(3): ReSharper Dead Code: Field 'implicitlyAssignedPrivateField' is assigned but its value is never used
+(0): ReSharper Dead Code: Serialised field 'implicitlyAssignedField' is assigned but its value is never used
+(1): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField1' is assigned but its value is never used
+(2): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField2' is assigned but its value is never used
+(3): ReSharper Dead Code: Serialised field 'implicitlyAssignedPrivateField' is assigned but its value is never used
 (4): ReSharper Dead Code: Constant 'UnusedConst' is never used
 (5): ReSharper Dead Code: Constant 'UnusedPrivateConst' is never used
 (6): ReSharper Dead Code: Redundant 'SerializeField' attribute
@@ -107,10 +107,10 @@ public class |NotSerializable|(38)
 (16): ReSharper Dead Code: Field 'UnusedStaticField' is never used
 (17): ReSharper Dead Code: Redundant 'SerializeField' attribute
 (18): ReSharper Dead Code: Field 'ourUnusedPrivateStaticField' is never used
-(19): ReSharper Dead Code: Field 'implicitlyAssignedField' is assigned but its value is never used
-(20): ReSharper Dead Code: Field 'implicitlyAssignedMultiField1' is assigned but its value is never used
-(21): ReSharper Dead Code: Field 'implicitlyAssignedMultiField2' is assigned but its value is never used
-(22): ReSharper Dead Code: Field 'implicitlyAssignedPrivateField' is assigned but its value is never used
+(19): ReSharper Dead Code: Serialised field 'implicitlyAssignedField' is assigned but its value is never used
+(20): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField1' is assigned but its value is never used
+(21): ReSharper Dead Code: Serialised field 'implicitlyAssignedMultiField2' is assigned but its value is never used
+(22): ReSharper Dead Code: Serialised field 'implicitlyAssignedPrivateField' is assigned but its value is never used
 (23): ReSharper Dead Code: Constant 'UnusedConst' is never used
 (24): ReSharper Dead Code: Constant 'UnusedPrivateConst' is never used
 (25): ReSharper Dead Code: Redundant 'SerializeField' attribute

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_000.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_000.cs.gold
@@ -13,10 +13,10 @@ QUICKFIXES:
 Remove unused directives in file
 --Remove unused directives in project
 --Remove unused directives in solution
-1: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+1: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 2: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_010.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_010.cs.gold
@@ -13,10 +13,10 @@ QUICKFIXES:
 Remove unused directives in file
 --Remove unused directives in project
 --Remove unused directives in solution
-1: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+1: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 2: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_011.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_011.cs.gold
@@ -13,10 +13,10 @@ QUICKFIXES:
 Remove unused directives in file
 --Remove unused directives in project
 --Remove unused directives in solution
-1: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+1: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 2: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_100.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_100.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_101.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_101.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_110.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/AddMissingParameterThreeParameters_110.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_132.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_132.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_213.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_213.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_231.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_231.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_312.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_312.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:

--- a/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_321.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Intentions/QuickFixes/InvalidSignature/Availability/ReorderParametersThreeParameters_321.cs.gold
@@ -8,10 +8,10 @@ public class FooProcessor : AssetPostprocessor
     }
 }
 ------------------------------------------------
-0: Method 'OnPostprocessGameObjectWithUserProperties' is never used
+0: Event function 'OnPostprocessGameObjectWithUserProperties' is never used
 QUICKFIXES:
-Remove unused method
---Comment unused method
+Remove unused event function
+--Comment unused event function
 Used implicitly
 1: Incorrect method parameters. Expected '(GameObject go, string[] propNames, object[] values)'
 QUICKFIXES:


### PR DESCRIPTION
Use Unity terminology in tooltip and other descriptions for serialised fields and event functions. This will also use "serialised field" and "event function" in descriptions for code analysis and quick fixes, such as "Event function is not used" and "Remove unused event function".

<img width="852" alt="Screenshot 2020-10-27 at 9 41 19 am" src="https://user-images.githubusercontent.com/222659/97626558-eef1d080-1a21-11eb-8db9-c98f10167bc7.png">

<img width="852" alt="Screenshot 2020-10-27 at 9 41 30 am" src="https://user-images.githubusercontent.com/222659/97626561-ef8a6700-1a21-11eb-9845-d8e4b4cfc1bf.png">

