### PR TITLE
Update API information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 
 ## 2020.3.0
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net202...net203)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net202...net203-rtm-2020.3.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/41?closed=1)
 
 ### Added
@@ -30,6 +30,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Change defaults for implicit conversion hints to always show instead of push-to-hint ([#1923](https://github.com/JetBrains/resharper-unity/pull/1923))
 - Use Unity terminology to describe event functions and serialised fields in identifier tooltips and inspections ([#1914](https://github.com/JetBrains/resharper-unity/pull/1914))
 - Add annotation for `[NativeSetThreadIndex]` to mean implicit usage ([#1619](https://github.com/JetBrains/resharper-unity/issues/1619), [#1923](https://github.com/JetBrains/resharper-unity/pull/1923))
+- Update API information to 2019.4.15f1, 2020.1.14f1 and 2020.2.0b12. Adds missing `EditorWindow.CreateGUI` message ([1937](https://github.com/JetBrains/resharper-unity/pull/1937))
 - Rider: Highlight methods from a Burst compiled context with line marker and Code Vision links ([#1852](https://github.com/JetBrains/resharper-unity/pull/1852))
 - Rider: Execute both edit and play mode tests in the same run ([#1894](https://github.com/JetBrains/resharper-unity/pull/1894))
 - Rider: Run Unity menu item handlers via gutter icon ([RIDER-35911](https://youtrack.jetbrains.com/issue/RIDER-35911), [#1857](https://github.com/JetBrains/resharper-unity/pull/1857))

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -369,7 +369,7 @@
     <message name="Awake" static="False" minimumVersion="5.5" description="Called as the new window is opened." path="Documentation/en/ScriptReference/EditorWindow.Awake.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="CreateGUI" static="False" minimumVersion="2019.4" maximumVersion="2019.4" description="CreateGUI is called when the EditorWindow's rootVisualElement is ready to be populated." path="Documentation/en/ScriptReference/EditorWindow.CreateGUI.html">
+    <message name="CreateGUI" static="False" minimumVersion="2019.4" maximumVersion="2020.1" description="CreateGUI is called when the EditorWindow's rootVisualElement is ready to be populated." path="Documentation/en/ScriptReference/EditorWindow.CreateGUI.html">
       <returns type="System.Void" array="False" />
     </message>
     <message name="OnDestroy" static="False" description="OnDestroy is called to close the EditorWindow window." path="Documentation/en/ScriptReference/EditorWindow.OnDestroy.html">

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -369,6 +369,9 @@
     <message name="Awake" static="False" minimumVersion="5.5" description="Called as the new window is opened." path="Documentation/en/ScriptReference/EditorWindow.Awake.html">
       <returns type="System.Void" array="False" />
     </message>
+    <message name="CreateGUI" static="False" minimumVersion="2019.4" maximumVersion="2019.4" description="CreateGUI is called when the EditorWindow's rootVisualElement is ready to be populated." path="Documentation/en/ScriptReference/EditorWindow.CreateGUI.html">
+      <returns type="System.Void" array="False" />
+    </message>
     <message name="OnDestroy" static="False" description="OnDestroy is called to close the EditorWindow window." path="Documentation/en/ScriptReference/EditorWindow.OnDestroy.html">
       <returns type="System.Void" array="False" />
     </message>
@@ -485,7 +488,7 @@
       </parameters>
       <returns type="System.Void" array="False" />
     </message>
-    <message name="OnApplicationQuit" static="False" description="Sent to all game objects before the application quits." path="Documentation/en/ScriptReference/MonoBehaviour.OnApplicationQuit.html">
+    <message name="OnApplicationQuit" static="False" description="Sent to all GameObjects before the application quits." path="Documentation/en/ScriptReference/MonoBehaviour.OnApplicationQuit.html">
       <returns type="System.Void" array="False" />
     </message>
     <message name="OnAudioFilterRead" static="False" description="If OnAudioFilterRead is implemented, Unity will insert a custom filter into the audio DSP chain." path="Documentation/en/ScriptReference/MonoBehaviour.OnAudioFilterRead.html">

--- a/resharper/resharper-unity/src/api.xml
+++ b/resharper/resharper-unity/src/api.xml
@@ -369,7 +369,7 @@
     <message name="Awake" static="False" minimumVersion="5.5" description="Called as the new window is opened." path="Documentation/en/ScriptReference/EditorWindow.Awake.html">
       <returns type="System.Void" array="False" />
     </message>
-    <message name="CreateGUI" static="False" minimumVersion="2019.4" maximumVersion="2020.1" description="CreateGUI is called when the EditorWindow's rootVisualElement is ready to be populated." path="Documentation/en/ScriptReference/EditorWindow.CreateGUI.html">
+    <message name="CreateGUI" static="False" minimumVersion="2019.4" description="CreateGUI is called when the EditorWindow's rootVisualElement is ready to be populated." path="Documentation/en/ScriptReference/EditorWindow.CreateGUI.html">
       <returns type="System.Void" array="False" />
     </message>
     <message name="OnDestroy" static="False" description="OnDestroy is called to close the EditorWindow window." path="Documentation/en/ScriptReference/EditorWindow.OnDestroy.html">

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/List/EditorWindow01.cs.gold
@@ -1,6 +1,7 @@
-﻿# 1130 ITEMS #
+﻿# 1131 ITEMS #
 
 + private Awake() { ... }
+private CreateGUI() { ... }
 private OnDestroy() { ... }
 private OnDisable() { ... }
 private OnEnable() { ... }
@@ -1131,9 +1132,10 @@ public override GetExtraPaneTypes() { … }    IEnumerable<Type>
 public override GetHashCode() { … }    int
 public override ToString() { … }    string
 # AUTOMATIC #
-# 1130 ITEMS #
+# 1131 ITEMS #
 
 + private Awake() { ... }
+private CreateGUI() { ... }
 private OnDestroy() { ... }
 private OnDisable() { ... }
 private OnEnable() { ... }

--- a/resharper/resharper-unity/test/data/CSharp/Generate/HasExistingBaseFunctions.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Generate/HasExistingBaseFunctions.cs.gold
@@ -4,23 +4,24 @@
  2: Update():System.Void
  3: OnEnable():System.Void
  4: OnDisable():System.Void
- 5: ModifierKeysChanged():System.Void
- 6: OnAddedAsTab():System.Void
- 7: OnBecameInvisible():System.Void
- 8: OnBecameVisible():System.Void
- 9: OnDidOpenScene():System.Void
- 10: OnFocus():System.Void
- 11: OnHierarchyChange():System.Void
- 12: OnInspectorUpdate():System.Void
- 13: OnLostFocus():System.Void
- 14: OnProjectChange():System.Void
- 15: OnSelectionChange():System.Void
- 16: OnTabDetached():System.Void
- 17: OnValidate():System.Void
- 18: OnWizardCreate():System.Void
- 19: OnWizardOtherButton():System.Void
- 20: OnWizardUpdate():System.Void
- 21: ShowButton(UnityEngine.Rect):System.Void
+ 5: CreateGUI():System.Void
+ 6: ModifierKeysChanged():System.Void
+ 7: OnAddedAsTab():System.Void
+ 8: OnBecameInvisible():System.Void
+ 9: OnBecameVisible():System.Void
+ 10: OnDidOpenScene():System.Void
+ 11: OnFocus():System.Void
+ 12: OnHierarchyChange():System.Void
+ 13: OnInspectorUpdate():System.Void
+ 14: OnLostFocus():System.Void
+ 15: OnProjectChange():System.Void
+ 16: OnSelectionChange():System.Void
+ 17: OnTabDetached():System.Void
+ 18: OnValidate():System.Void
+ 19: OnWizardCreate():System.Void
+ 20: OnWizardOtherButton():System.Void
+ 21: OnWizardUpdate():System.Void
+ 22: ShowButton(UnityEngine.Rect):System.Void
 
 // ${KIND:Unity.EventFunctions}
 using UnityEditor;

--- a/resharper/resharper-unity/test/data/CSharp/Generate/ListElements09.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/Generate/ListElements09.cs.gold
@@ -6,20 +6,21 @@
  4: OnDisable():System.Void
  5: OnDestroy():System.Void
  6: OnGUI():System.Void
- 7: ModifierKeysChanged():System.Void
- 8: OnAddedAsTab():System.Void
- 9: OnBecameInvisible():System.Void
- 10: OnBecameVisible():System.Void
- 11: OnDidOpenScene():System.Void
- 12: OnFocus():System.Void
- 13: OnHierarchyChange():System.Void
- 14: OnInspectorUpdate():System.Void
- 15: OnLostFocus():System.Void
- 16: OnProjectChange():System.Void
- 17: OnSelectionChange():System.Void
- 18: OnTabDetached():System.Void
- 19: OnValidate():System.Void
- 20: ShowButton(UnityEngine.Rect):System.Void
+ 7: CreateGUI():System.Void
+ 8: ModifierKeysChanged():System.Void
+ 9: OnAddedAsTab():System.Void
+ 10: OnBecameInvisible():System.Void
+ 11: OnBecameVisible():System.Void
+ 12: OnDidOpenScene():System.Void
+ 13: OnFocus():System.Void
+ 14: OnHierarchyChange():System.Void
+ 15: OnInspectorUpdate():System.Void
+ 16: OnLostFocus():System.Void
+ 17: OnProjectChange():System.Void
+ 18: OnSelectionChange():System.Void
+ 19: OnTabDetached():System.Void
+ 20: OnValidate():System.Void
+ 21: ShowButton(UnityEngine.Rect):System.Void
 
 // ${KIND:Unity.EventFunctions}
 using UnityEditor;


### PR DESCRIPTION
Updates the API information to 2020.2.0b12. Also reruns the update for 2019.4.15f1 and 2020.1.14f1.

Adds the `EditorWindow.CreateGUI` message that was introduced in 2019.4. We did run the update on the docs from 2019.4.4f1, but for some reason, this message wasn't included. I have no idea why - rerun the update on 2019.4.4f1 and there it is! Go figure.