### PR TITLE
Fix debug message complaining about accessing old setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,31 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
 
+## 2020.3.1
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net203-rtm-2020.3.0...net203-rtm-2020.3.1)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/43?closed=1)
+
+# Changed
+
+- Disable performance and Burst context with comment ([#1948](https://github.com/JetBrains/resharper-unity/pull/1948))
+
+# Fixed
+
+- Fix performance context and Burst actions not showing if caret was on first character of method declaration ([#1948](https://github.com/JetBrains/resharper-unity/pull/1948))
+- Rider: Fix showing incorrect Code Vision link for expensive code ([#1948](https://github.com/JetBrains/resharper-unity/pull/1948))
+- Rider: Fix automatically refreshing assets before running unit tests ([RIDER-54359](https://youtrack.jetbrains.com/issue/RIDER-54359), [#1960](https://github.com/JetBrains/resharper-unity/pull/1960))
+- Rider: Fix missing trace scenario in Diagnostic Tools dialog ([#1962](https://github.com/JetBrains/resharper-unity/pull/1962))
+- Unity editor: Fix log message on incorrect access of deprecated settings ([RIDER-55362](https://youtrack.jetbrains.com/issue/RIDER-55362), [#1967](https://github.com/JetBrains/resharper-unity/pull/1967))
+
+
+
 ## 2020.3.0
+* Released: [2020-12-14](https://blog.jetbrains.com/dotnet/2020/12/14/rider-2020-3-release/)
+* Build: 2020.3.0.5061
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net202...net203-rtm-2020.3.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/41?closed=1)
+* [GitHub release](https://github.com/JetBrains/resharper-unity/releases/tag/net203-rtm-2020.3.0)
+* [ReSharper release](https://resharper-plugins.jetbrains.com/packages/JetBrains.Unity/2020.3.0.125)
 
 ### Added
 

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -12,7 +12,7 @@ productVersion=2020.3
 # Revision for plugin version, appended to productVersion, e.g. 2020.2.2
 # Used for published version, plus retrieving correct changelog notes
 # TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
-maintenanceVersion=0
+maintenanceVersion=1
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long

--- a/unity/EditorPlugin/EditorPrefsWrapper.cs
+++ b/unity/EditorPlugin/EditorPrefsWrapper.cs
@@ -18,8 +18,8 @@ namespace JetBrains.Rider.Unity.Editor
     }
 
     // This is an internal Unity setting. Introduced in 2018.2 (moved in 2018.3). The enum is internal, so we can only
-    // use the int value, which matches ScriptCompilationDuringPlay, which is a protocol type, and we can't rely on the
-    // int mapping.
+    // use the int value, which matches our ScriptCompilationDuringPlay, which is a protocol type. Don't rely on casting
+    // Unity's value to our value - use the helpers.
     // https://github.com/Unity-Technologies/UnityCsReference/blob/2018.2/Editor/Mono/PreferencesWindow/PreferencesWindow.cs#L1154
     // https://github.com/Unity-Technologies/UnityCsReference/blob/2018.3/Editor/Mono/PreferencesWindow/PreferencesSettingsProviders.cs#L1074
     public static ScriptCompilationDuringPlay ScriptCompilationDuringPlay

--- a/unity/EditorPlugin/PluginEntryPoint.cs
+++ b/unity/EditorPlugin/PluginEntryPoint.cs
@@ -292,6 +292,10 @@ namespace JetBrains.Rider.Unity.Editor
 
     private static void SetupAssemblyReloadEvents()
     {
+      // Unity supports recompile/reload settings natively for Unity 2018.2+
+      if (UnityUtils.UnityVersion >= new Version(2018, 2))
+        return;
+
       // playmodeStateChanged was marked obsolete in 2017.1. Still working in 2018.3
 #pragma warning disable 618
       EditorApplication.playmodeStateChanged += () =>
@@ -369,10 +373,7 @@ namespace JetBrains.Rider.Unity.Editor
               paths[0], paths[1],
               Process.GetCurrentProcess().Id));
 
-          var scriptCompilationDuringPlay = UnityUtils.UnityVersion >= new Version(2018, 2)
-              ? EditorPrefsWrapper.ScriptCompilationDuringPlay
-              : PluginSettings.AssemblyReloadSettings;
-          model.UnityApplicationSettings.ScriptCompilationDuringPlay.Set(scriptCompilationDuringPlay);
+          model.UnityApplicationSettings.ScriptCompilationDuringPlay.Set(UnityUtils.SafeScriptCompilationDuringPlay);
 
           model.UnityProjectSettings.ScriptingRuntime.SetValue(UnityUtils.ScriptingRuntime);
 

--- a/unity/EditorPlugin/PluginSettings.cs
+++ b/unity/EditorPlugin/PluginSettings.cs
@@ -282,6 +282,7 @@ namespace JetBrains.Rider.Unity.Editor
 
       EditorGUILayout.HelpBox(loggingMsg, MessageType.None);
 
+      // This setting is natively supported in Unity 2018.2+
       if (UnityUtils.UnityVersion < new Version(2018, 2))
       {
         EditorGUI.BeginChangeCheck();

--- a/unity/EditorPlugin/UnityUtils.cs
+++ b/unity/EditorPlugin/UnityUtils.cs
@@ -67,6 +67,11 @@ namespace JetBrains.Rider.Unity.Editor
       }
     }
 
+    internal static ScriptCompilationDuringPlay SafeScriptCompilationDuringPlay =>
+        UnityVersion >= new Version(2018, 2)
+            ? EditorPrefsWrapper.ScriptCompilationDuringPlay
+            : PluginSettings.AssemblyReloadSettings;
+
     internal static ScriptCompilationDuringPlay ToScriptCompilationDuringPlay(int value)
     {
       switch (value)


### PR DESCRIPTION
Stops subscribing to handle locking assemblies during play mode for Unity 2018.2+ where it's handled natively. This has the side effect of not accessing a legacy editor setting, which outputs a log message ([RIDER-55362](https://youtrack.jetbrains.com/issue/RIDER-55362)). The change stops subscribing to the `EditorApplication.playmodeStateChanged` event for Unity 2018.2+ as the functionality is now redundant - `PluginSettings.AssemblyReloadSettings` always returns `RecompileAndContinuePlaying` in this case.