### PR TITLE
Ensure Packages folder is indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ## 2021.1.0
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net203...net211)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/42?closed=1)
+
+### Fixed
+
+- Rider: Fix files in `Packages` folder showing the non-project dialog when being modified ([#1997](https://github.com/JetBrains/resharper-unity/pull/1997))
+
+
 
 ## 2020.3.1
 * Released: [2020-12-24](https://blog.jetbrains.com/dotnet/2020/12/24/resharper-rider-2020-3-1/)

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ContentModelUpdater.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ContentModelUpdater.kt
@@ -40,15 +40,16 @@ class ContentModelUpdater : ProjectManagerListener {
         // It's common practice to have extra folders in the root project folder, e.g. a backup copy of Library for
         // a different version of Unity, or target, which can be renamed instead of having to do a time consuming
         // reimport. Also, folders containing builds for targets such as iOS.
-        // Exclude all folders apart from Assets, ProjectSettings and Packages
+        // Exclude all folders apart from Assets, ProjectSettings and Packages. Make sure to explicitly include these
+        // three folders. Without the explicit include, Assets + ProjectSettings are indexed, but Packages aren't.
         for (child in project.projectDir.children) {
-            if (child != null && isRootFolder(project, child) && !isInProject(project, child)) {
+            if (child != null && isRootFolder(project, child)) {
                 val file = VfsUtil.virtualToIoFile(child)
 
                 if (shouldInclude(child.name)) {
                     newIncludedFolders.add(file)
                 }
-                else {
+                else if (!isInProject(project, child)){
                     newExcludedFolders.add(file)
                 }
             }
@@ -89,7 +90,6 @@ class ContentModelUpdater : ProjectManagerListener {
             application.invokeLater {
                 contentModel.update()
             }
-
         }
     }
 
@@ -103,8 +103,8 @@ class ContentModelUpdater : ProjectManagerListener {
 
     private fun shouldInclude(name: String): Boolean {
         return name.equals("Assets", true)
-                || name.equals("ProjectSettings", true)
-                || name.equals("Packages", true)
+            || name.equals("Packages", true)
+            || name.equals("ProjectSettings", true)
     }
 
     private inner class Listener(private val project: Project, private val alarm: SingleAlarm) : AsyncFileListener, PackageManagerListener {


### PR DESCRIPTION
If the `Packages` folder contains any project code, it wasn't being explicitly indexed, so `Packages/manifest.json` wasn't added to the content model, and would show the "non-project file" dialog when trying to modify. If the `Packages` folder doesn't contain any project, it was being explicitly added, so the dialog wasn't shown. I don't know why `Packages` wasn't being indexed, because with the same code, `Assets` was indexed.

Note that this code will be rewritten soon, when the new project model is merged. It's still worth fixing now, to make sure that the rewritten version also correctly indexes both `Assets` and `Packages`.