### PR TITLE
Improvements of old MetaFileTracker

### DIFF
--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -143,14 +143,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool IsAssetOrPackage(ProjectItemChange change)
             {
                 var rootFolder = GetRootFolder(change.OldParentFolder);
+                var solution = change.GetSolution();
+                if (solution == null)
+                    return false;
                 if (rootFolder == null)
                     return false;
-                if (string.Compare(rootFolder.Name, ProjectExtensions.AssetsFolder, StringComparison.OrdinalIgnoreCase) == 0)
+                if (rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.AssetsFolder)))
                     return true;
-                if (string.Compare(rootFolder.Name, ProjectExtensions.PackagesFolder, StringComparison.OrdinalIgnoreCase) == 0)
-                    return true;
-                var project = change.ProjectItem.GetProject();
-                return project != null && project.HasSubItems(rootFolder.Name);
+                return rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))
+                       && !change.OldParentFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder)); // exclude direct children of PackagesFolder
             }
 
             private static IProjectFolder GetRootFolder(IProjectItem item)

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -150,8 +150,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                     return false;
                 if (rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.AssetsFolder)))
                     return true;
-                return rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))
-                       && !change.OldParentFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder)); // exclude direct children of PackagesFolder
+                if (rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))
+                       && !change.OldParentFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))) // exclude direct children of PackagesFolder
+                    return true;
+                return change.OldParentFolder.IsLinked; // support local package linked by relative path 
             }
 
             private static IProjectFolder GetRootFolder(IProjectItem item)


### PR DESCRIPTION
1. avoid meta files in direct children of Packanges folder
2. support local package linked by relative path