### PR TITLE
Add zone marker to fix exceptions in inspectcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Fixed
 
+- Fix exception and missing namespace suppression when running plugin in `inspectcode` ([#2003](https://github.com/JetBrains/resharper-unity/pull/2003))
 - Rider: Allow disabling Burst context Code Vision ([#1985](https://github.com/JetBrains/resharper-unity/pull/1985))
 
 

--- a/resharper/resharper-unity/src/Feature/Services/ExternalSources/ZoneMarker.cs
+++ b/resharper/resharper-unity/src/Feature/Services/ExternalSources/ZoneMarker.cs
@@ -1,0 +1,10 @@
+using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.ReSharper.Feature.Services.ExternalSources;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Feature.Services.ExternalSources
+{
+    [ZoneMarker]
+    public class ZoneMarker : IRequire<ExternalSourcesZone>
+    {
+    }
+}

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -12,7 +12,7 @@ productVersion=2020.3
 # Revision for plugin version, appended to productVersion, e.g. 2020.2.2
 # Used for published version, plus retrieving correct changelog notes
 # TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
-maintenanceVersion=2
+maintenanceVersion=3
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long


### PR DESCRIPTION
When running with the Unity plugin, `inspectcode` throws an exception because a schema setting entry isn't loaded, as its owning zone (`ExternalSourcesZone`) is not enabled for the command line runner.