### PR TITLE
Make doc search link version specific

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uxml/codeInsight/schema/UxmlSchemaProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ideaInterop/fileTypes/uxml/codeInsight/schema/UxmlSchemaProvider.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.xml.XmlFile
 import com.intellij.xml.XmlSchemaProvider
-import com.jetbrains.rdclient.util.idea.getOrCreateUserData
+import com.jetbrains.rd.platform.util.idea.getOrCreateUserData
 import com.jetbrains.rider.isUnityProject
 import com.jetbrains.rider.projectDir
 import java.nio.file.Paths

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/packageManager/PackageManager.kt
@@ -19,8 +19,8 @@ import com.intellij.util.concurrency.NonUrgentExecutor
 import com.intellij.util.io.inputStream
 import com.intellij.util.io.isDirectory
 import com.intellij.util.pooledThreadSingleAlarm
+import com.jetbrains.rd.platform.util.idea.getOrCreateUserData
 import com.jetbrains.rd.platform.util.lifetime
-import com.jetbrains.rdclient.util.idea.getOrCreateUserData
 import com.jetbrains.rider.debugger.util.isExistingFile
 import com.jetbrains.rider.model.unity.frontendBackend.frontendBackendModel
 import com.jetbrains.rider.plugins.unity.util.SemVer

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -42,7 +42,7 @@ class UnityDocumentationProvider : DocumentationProvider {
         val parsedVersion = SemVer.parse("$version.0") ?: return ""
         // Version before 2017.1 has different format of version:
         // https://docs.unity3d.com/560/Documentation/ScriptReference/MonoBehaviour.html
-        // lets return make url without version for old Unity, I don't like the UI on website, when older Unity version prefix is specified
+        // lets make url without specific version for old Unity, I don't like the UI on website, when older Unity version prefix is specified
         if (parsedVersion < SemVer.parse("2017.1.0")!!)
             return ""
         return "/$version/Documentation"

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -42,9 +42,8 @@ class UnityDocumentationProvider : DocumentationProvider {
         val parsedVersion = SemVer.parse("$version.0") ?: return ""
         // Version before 2017.1 has different format of version:
         // https://docs.unity3d.com/560/Documentation/ScriptReference/MonoBehaviour.html
-        // lets make url without specific version for old Unity, I don't like the UI on website, when older Unity version prefix is specified
         if (parsedVersion < SemVer.parse("2017.1.0")!!)
-            return ""
+            return "/${parsedVersion.major}${parsedVersion.minor}0/Documentation"
         return "/$version/Documentation"
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -28,13 +28,17 @@ class UnityDocumentationProvider() : DocumentationProvider {
     private fun getUrlForContext(context: String, project: Project): String {
         // We know context will be a fully qualified type or method name, starting
         // with either `UnityEngine.` or `UnityEditor.`
-        // TODO: Use the current version for the fallback online search
-        // E.g. https://docs.unity3d.com/2017.4/Documentation/ScriptReference/30_search.html?q=...
         val keyword = stripPrefix(context)
         val documentationRoot = getLocalDocumentationRoot(project)
         return getFileUri(documentationRoot, "ScriptReference/$keyword.html")
             ?: getFileUri(documentationRoot, "ScriptReference/${keyword.replace('.', '-')}.html")
-            ?: "https://docs.unity3d.com/ScriptReference/30_search.html?q=$keyword"
+            ?: "https://docs.unity3d.com${getVersionSpecificPieceOfUrl(project)}/ScriptReference/30_search.html?q=$keyword"
+    }
+
+    private fun getVersionSpecificPieceOfUrl(project:Project):String
+    {
+        val version = UnityInstallationFinder.getInstance(project).getApplicationVersion(2) ?: return ""
+        return "/$version/Documentation"
     }
 
     private fun stripPrefix(context: String): String {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -39,10 +39,11 @@ class UnityDocumentationProvider : DocumentationProvider {
     private fun getVersionSpecificPieceOfUrl(project:Project):String
     {
         val version = UnityInstallationFinder.getInstance(project).getApplicationVersion(2) ?: return ""
-        val parsedVersion = SemVer.parse(version) ?: return ""
+        val parsedVersion = SemVer.parse("$version.0") ?: return ""
         // Version before 2017.1 has different format of version:
         // https://docs.unity3d.com/560/Documentation/ScriptReference/MonoBehaviour.html
-        if (parsedVersion < SemVer.parse("2017.1")!!)
+        // lets return make url without version for old Unity, I don't like the UI on website, when older Unity version prefix is specified
+        if (parsedVersion < SemVer.parse("2017.1.0")!!)
             return ""
         return "/$version/Documentation"
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -42,7 +42,7 @@ class UnityDocumentationProvider : DocumentationProvider {
         val parsedVersion = SemVer.parse(version) ?: return ""
         // Version before 2017.1 has different format of version:
         // https://docs.unity3d.com/560/Documentation/ScriptReference/MonoBehaviour.html
-        if (parsedVersion <= SemVer.parse("2017.1")!!)
+        if (parsedVersion < SemVer.parse("2017.1")!!)
             return ""
         return "/$version/Documentation"
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/quickDoc/UnityDocumentationProvider.kt
@@ -6,11 +6,12 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.util.io.exists
 import com.jetbrains.rider.model.unity.frontendBackend.frontendBackendModel
+import com.jetbrains.rider.plugins.unity.util.SemVer
 import com.jetbrains.rider.plugins.unity.util.UnityInstallationFinder
 import com.jetbrains.rider.projectView.solution
 import java.nio.file.Path
 
-class UnityDocumentationProvider() : DocumentationProvider {
+class UnityDocumentationProvider : DocumentationProvider {
 
     override fun getUrlFor(p0: PsiElement?, p1: PsiElement?): MutableList<String>? {
         val project = p0?.project
@@ -38,6 +39,11 @@ class UnityDocumentationProvider() : DocumentationProvider {
     private fun getVersionSpecificPieceOfUrl(project:Project):String
     {
         val version = UnityInstallationFinder.getInstance(project).getApplicationVersion(2) ?: return ""
+        val parsedVersion = SemVer.parse(version) ?: return ""
+        // Version before 2017.1 has different format of version:
+        // https://docs.unity3d.com/560/Documentation/ScriptReference/MonoBehaviour.html
+        if (parsedVersion <= SemVer.parse("2017.1")!!)
+            return ""
         return "/$version/Documentation"
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityLocalAttachProcessDebuggerProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/attach/UnityLocalAttachProcessDebuggerProvider.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.xdebugger.attach.*
-import com.jetbrains.rdclient.util.idea.getOrCreateUserData
+import com.jetbrains.rd.platform.util.idea.getOrCreateUserData
 import com.jetbrains.rider.plugins.unity.run.UnityProcessInfo
 import com.jetbrains.rider.plugins.unity.run.UnityRunUtil
 


### PR DESCRIPTION
https://github.com/JetBrains/resharper-unity/issues/2005

requires some more testing.


https://docs.unity3d.com/2021.1/Documentation/ScriptReference/30_search.html?q=InitializeOnLoadAttribute
Version before 2017.1 has different format of version:
https://docs.unity3d.com/550/Documentation/ScriptReference/30_search.html?q=InitializeOnLoadAttribute

In the old version UI there is no goo way to change version. Clicking "current version" clears the seach term from the url.