### PR TITLE
Use default identifier as base for ReSharper highlight

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/VisualStudio/UnityImplicitlyUsedIdentifierClassificationDefinition.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/Highlightings/VisualStudio/UnityImplicitlyUsedIdentifierClassificationDefinition.cs
@@ -26,7 +26,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.V
             IsBold = true;
         }
 
-        [Export, Name(Name), BaseDefinition("formal language")]
+        // DefaultIdentifierClassificationDefinition.Name is internal
+        [Export, Name(Name), BaseDefinition("ReSharper Default Identifier")]
         internal ClassificationTypeDefinition ClassificationTypeDefinition;
     }
 }


### PR DESCRIPTION
Doesn't make much difference. Just means that if someone changes the colours for "ReSharper all languages Default Identifier" in Visual Studio, then the "Unity Implicitly Used Identifier" will match. Previously, it would use the generic text colours.