### PR TITLE
Fix meta files not being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix creation of `.meta` files in the root of the `Packages` folder, and in `file:` based packages ([#2000](https://github.com/JetBrains/resharper-unity/pull/2000))
 - Fix suggested name collision when creating a field to cache a property index ([RIDER-55185](https://youtrack.jetbrains.com/issue/RIDER-55185), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Fix stored asset file names to be relative to solution directory ([RIDER-54695](https://youtrack.jetbrains.com/issue/RIDER-54695), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
+- Fix meta files not being updated correctly if solution name doesn't match folder name exactly ([#2027](https://github.com/JetBrains/resharper-unity/issues/2027), [#2030](https://github.com/JetBrains/resharper-unity/pull/2030))
 - Rider: Fix location of context menu shown when clicking Unity Code Vision links ([RIDER-49573](https://youtrack.jetbrains.com/issue/RIDER-49573), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Rider: Fix missing error indicator for `.asmdef` files ([#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Rider: Fix issue launching Unity when debugging and editor isn't running ([RIDER-52498](https://youtrack.jetbrains.com/issue/RIDER-52498), [#1920](https://github.com/JetBrains/resharper-unity/pull/1920))

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -21,9 +21,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
         private readonly ILogger myLogger;
         private IProjectItem myLastAddedItem;
 
-        public MetaFileTracker(Lifetime lifetime, ChangeManager changeManager, ISolution solution, ILogger logger, 
-            ISolutionLoadTasksScheduler solutionLoadTasksScheduler,
-            UnitySolutionTracker unitySolutionTracker)
+        public MetaFileTracker(Lifetime lifetime, ChangeManager changeManager, ISolution solution, ILogger logger,
+                               ISolutionLoadTasksScheduler solutionLoadTasksScheduler,
+                               UnitySolutionTracker unitySolutionTracker)
         {
             mySolution = solution;
             myLogger = logger;
@@ -31,9 +31,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             solutionLoadTasksScheduler.EnqueueTask(new SolutionLoadTask("AdviseForChanges", SolutionLoadTaskKinds.AfterDone,
                 () =>
                 {
-                    if (!unitySolutionTracker.IsUnityGeneratedProject.Value)
+                    if (!unitySolutionTracker.IsUnityProjectFolder.Value)
                         return;
-                    
+
                     changeManager.RegisterChangeProvider(lifetime, this);
                     changeManager.AddDependency(lifetime, this, solution);
                 }));
@@ -91,7 +91,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                 // never do this, and b) you can't delete a project from Visual Studio/Rider, only remove it
                 if (projectChange.IsRemoved)
                     return;
-                
+
                 // Don't recurse if this project isn't a Unity project. Note that we don't do this
                 // for the IsRemoved case above, as the project doesn't have a solution at that point,
                 // and IsUnityProject will throw
@@ -153,7 +153,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                 if (rootFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))
                        && !change.OldParentFolder.Location.Equals(solution.SolutionDirectory.Combine(ProjectExtensions.PackagesFolder))) // exclude direct children of PackagesFolder
                     return true;
-                return change.OldParentFolder.IsLinked; // support local package linked by relative path 
+                return change.OldParentFolder.IsLinked; // support local package linked by relative path
             }
 
             private static IProjectFolder GetRootFolder(IProjectItem item)


### PR DESCRIPTION
This PR fixes two issues, mostly related to `.meta` file tracking and updating:

- [x] A solution is recognised as generated if the name is the same, but the case is different. Unity should generate the name correctly, but some other tooling might not. Also, if the case is different in the recent solutions list, Rider uses the incorrect case. If we don't recognise a solution as generated, meta files aren't updated, which is bad. Fixes #2027
- [x] Change meta file tracker to work with any solution inside a Unity project - generated or manual. If we're moving things inside `Assets` or `Packages`, we should update the `.meta` files.