### PR TITLE
For generated meta files use LineEndings similar to files in Solution

### DIFF
--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -259,10 +259,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
                 try
                 {
                     var guid = Guid.NewGuid();
-                                        var timestamp = (long)(DateTime.UtcNow - ourUnixTime).TotalSeconds;
-                                        var le = myDocumentLineEndingsDetector.DetectLineEnding(mySolution, null, null);
-                                        DoUnderTransaction("Unity::CreateMetaFile", () => path.WriteAllText($"fileFormatVersion: 2{le}guid: {guid:N}{le}timeCreated: {timestamp}"));
-                                        myLogger.Info("*** resharper-unity: Meta added {0}", path);
+                    var timestamp = (long) (DateTime.UtcNow - ourUnixTime).TotalSeconds;
+                    var le = myDocumentLineEndingsDetector.DetectLineEnding(mySolution, null, null);
+                    DoUnderTransaction("Unity::CreateMetaFile", () => path.WriteAllText($"fileFormatVersion: 2{le}guid: {guid:N}{le}timeCreated: {timestamp}"));
+                    myLogger.Info("*** resharper-unity: Meta added {0}", path);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
https://github.com/JetBrains/resharper-unity/issues/2001

It feels like we need to provide some better api in Rider/Re# first.

This is postponed, given that MetaFileTracker has a good chance to be moved to frontend soon.