### PR TITLE
Stop creating meta files for hidden assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix suggested name collision when creating a field to cache a property index ([RIDER-55185](https://youtrack.jetbrains.com/issue/RIDER-55185), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Fix stored asset file names to be relative to solution directory ([RIDER-54695](https://youtrack.jetbrains.com/issue/RIDER-54695), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Fix meta files not being updated correctly if solution name doesn't match folder name exactly ([#2027](https://github.com/JetBrains/resharper-unity/issues/2027), [#2030](https://github.com/JetBrains/resharper-unity/pull/2030))
+- Fix meta files being created for hidden assets ([#2035](https://github.com/JetBrains/resharper-unity/pull/2035))
 - Rider: Fix location of context menu shown when clicking Unity Code Vision links ([RIDER-49573](https://youtrack.jetbrains.com/issue/RIDER-49573), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Rider: Fix missing error indicator for `.asmdef` files ([#2002](https://github.com/JetBrains/resharper-unity/pull/2002))
 - Rider: Fix issue launching Unity when debugging and editor isn't running ([RIDER-52498](https://youtrack.jetbrains.com/issue/RIDER-52498), [#1920](https://github.com/JetBrains/resharper-unity/pull/1920))

--- a/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
+++ b/resharper/resharper-unity/src/ProjectModel/MetaFileTracker.cs
@@ -137,7 +137,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool ShouldHandleChange(ProjectItemChange change)
             {
                 // String comparisons, treat as expensive if we're doing this very frequently
-                return IsAssetOrPackage(change) && !IsItemMetaFile(change);
+                return IsAssetOrPackage(change) && !IsItemMetaFile(change) && !IsHiddenAsset(change);
             }
 
             private static bool IsAssetOrPackage(ProjectItemChange change)
@@ -166,6 +166,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             private static bool IsItemMetaFile(ProjectItemChange change)
             {
                 return change.ProjectItem.Name.EndsWith(".meta", StringComparison.OrdinalIgnoreCase);
+            }
+
+            private static bool IsHiddenAsset(ProjectItemChange change)
+            {
+                // See "Hidden Assets" on this page: https://docs.unity3d.com/Manual/SpecialFolders.html
+                return change.ProjectItem.Name.EndsWith("~", StringComparison.Ordinal)
+                    || change.ProjectItem.Name.StartsWith(".", StringComparison.Ordinal)
+                    || (change.ProjectItem as IProjectFile)?.Name.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase) == true
+                    || change.ProjectItem.Name.Equals("cvs");
             }
 
             private bool OnItemRenamed(ProjectItemChange change)


### PR DESCRIPTION
Hidden assets, such as those ending with `~` or starting with `.` are not imported into the asset database, and should not have a `.meta` file created. See the list of "Hidden Assets" on this page for [special folder names](https://docs.unity3d.com/Manual/SpecialFolders.html).