### PR TITLE
Fix completion when replacing entire method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Fixed
 
+- Fix broken code generation when replacing the entire name of an existing event function ([#2040](https://github.com/JetBrains/resharper-unity/pull/2040))
 - Fix missing entries from ReSharper's Unity specific dictionary ([#1737](https://github.com/JetBrains/resharper-unity/issues/1737), [#1809](https://github.com/JetBrains/resharper-unity/issues/1809), [#2008](https://github.com/JetBrains/resharper-unity/pull/2008))
 - Fix creation of `.meta` files in the root of the `Packages` folder, and in `file:` based packages ([#2000](https://github.com/JetBrains/resharper-unity/pull/2000))
 - Fix suggested name collision when creating a field to cache a property index ([RIDER-55185](https://youtrack.jetbrains.com/issue/RIDER-55185), [#2002](https://github.com/JetBrains/resharper-unity/pull/2002))

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod01.cs
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod01.cs
@@ -1,0 +1,10 @@
+// ${COMPLETE_ITEM:LateUpdate() { ... \}}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  public void {caret}()
+  {
+    // Existing code
+  }
+}

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod01.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod01.cs.gold
@@ -1,0 +1,10 @@
+﻿// ${COMPLETE_ITEM:LateUpdate() { ... \}}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  public void LateUpdate{caret}()
+  {
+    // Existing code
+  }
+}

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod02.cs
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod02.cs
@@ -1,0 +1,10 @@
+// ${COMPLETE_ITEM:OnApplicationPause(bool) { ... \}}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  public void {caret}(bool hasFocus)
+  {
+    // Existing code
+  }
+}

--- a/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod02.cs.gold
+++ b/resharper/resharper-unity/test/data/CSharp/CodeCompletion/Action/RetypeFullNameOnExistingMethod02.cs.gold
@@ -1,0 +1,10 @@
+﻿// ${COMPLETE_ITEM:OnApplicationPause(bool) { ... \}}
+using UnityEngine;
+
+public class A : MonoBehaviour
+{
+  public void OnApplicationPause{caret}(bool hasFocus)
+  {
+    // Existing code
+  }
+}

--- a/resharper/resharper-unity/test/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionCompletionActionTest.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Feature/Services/CodeCompletion/UnityEventFunctionCompletionActionTest.cs
@@ -51,6 +51,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Feature.Services.CodeCo
 
         [Test] public void GeneratedCodeResolvesNamespaceGlobally() { DoNamedTest(); }
         [Test] public void RetypeNameOnExistingMethod() { DoNamedTest(); }
+        [Test] public void RetypeFullNameOnExistingMethod01() { DoNamedTest(); }
+        [Test] public void RetypeFullNameOnExistingMethod02() { DoNamedTest(); }
         [Test] public void RetypeNameOnExistingBrokenMethod() { DoNamedTest(); }
         [Test] public void DoNotRenameNextDeclaration() { DoNamedTest(); }
         [Test] public void EmptyPrefix() { DoNamedTest(); }


### PR DESCRIPTION
When editing the name of a function in a Unity class, if the name is being completely replaced, e.g. changing `Awake` to `Start` then the auto-completion for event functions will generate incorrect code. It will generate a new body for the event function, while the existing body is still there, resulting in something like:

```
public void Awake()
{
}

()
{
  // Existing code
}
```
