### PR TITLE
Minor build fixes

### DIFF
--- a/resharper/resharper-unity/test/src/app.config
+++ b/resharper/resharper-unity/test/src/app.config
@@ -40,5 +40,15 @@
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBnding>
+
+    <!-- As of 211, something is causing 4.0.6.0 to get referenced. MSBuild reckons it's JetBrains.Platform.Core, but
+         this is definitely referencing 4.0.4.1. The SDK is referencing the 4.5.3 package which is 4.0.4.1 file version.
+         This forces us to stick with 4.0.4.1 -->
+    <assemblyBnding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBnding>
   </runtime>
 </configuration>

--- a/resharper/resharper-unity/test/src/tests.rider-unity.csproj
+++ b/resharper/resharper-unity/test/src/tests.rider-unity.csproj
@@ -24,12 +24,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Lib.Harmony" Version="2.0.0.8" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Console" Version="3.10.0" />
-    <PackageReference Include="Lib.Harmony" Version="2.0.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\rider-unity.csproj" />

--- a/resharper/resharper-yaml/test/src/app.config
+++ b/resharper/resharper-yaml/test/src/app.config
@@ -6,5 +6,15 @@
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBnding>
+
+    <!-- As of 211, something is causing 4.0.6.0 to get referenced. MSBuild reckons it's JetBrains.Platform.Core, but
+         this is definitely referencing 4.0.4.1. The SDK is referencing the 4.5.3 package which is 4.0.4.1 file version.
+         This forces us to stick with 4.0.4.1 -->
+    <assemblyBnding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBnding>
   </runtime>
 </configuration>

--- a/resharper/resharper-yaml/test/src/tests.rider-yaml.csproj
+++ b/resharper/resharper-yaml/test/src/tests.rider-yaml.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Lib.Harmony" Version="2.0.0.8" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Lib.Harmony" Version="2.0.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\rider-yaml.csproj" />

--- a/rider/buildSrc/build.gradle.kts
+++ b/rider/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "0.6.4")
+    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "0.7.2")
 }
 
 plugins {


### PR DESCRIPTION
Updates gradle-intellij-plugin to 0.7.2 to fix downloading the JBR. The old version had the wrong URL. Also fixes compile time warnings for assembly version resolution.