### PR TITLE
Fix exceptions in debugger extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,21 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
+## 2021.1.1
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2011.1.0...net211)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/46?closed=1)
+
+### Fixed
+
+- Rider: Gracefully handle Unity API exceptions in debugger extensions - `UnityException`, `MissingComponentException`, `MissingReferenceException`, `UnassignedReferenceException` ([RIDER-60794](https://youtrack.jetbrains.com/issue/RIDER-60794), [RIDER-60795](https://youtrack.jetbrains.com/issue/RIDER-60795), [DEXP-585430](https://youtrack.jetbrains.com/issue/DEXP-585430), [DEXP-534612](https://youtrack.jetbrains.com/issue/DEXP-534612), [DEXP-558487](https://youtrack.jetbrains.com/issue/DEXP-558487), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
+- Rider: Fix incorrect reporting of `EvaluatorAbortedException` control flow exception ([DEXP-570625](https://youtrack.jetbrains.com/issue/DEXP-570265), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
+- Rider: Fix exceptions thrown when by Unity debugger extensions when implicit evaluation is disabled ([RIDER-60798](https://youtrack.jetbrains.com/issue/RIDER-60798), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
+- Rider: Fix some null reference exceptions when evaluating Unity debugger extensions ([DEXP-561412](https://youtrack.jetbrains.com/issue/DEXP-561412), [DEXP-577753](https://youtrack.jetbrains.com/issue/DEXP-577753), [#2507](https://github.com/JetBrains/resharper-unity/pull/2057))
+
+
+
 ## 2021.1.0
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net203...net211)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net203...net211-rtm-2021.1.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/42?closed=1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
-## 2021.1.1
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2011.1.0...net211)
+## 2021.1.2
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0-rtm-2021.1.1...net211)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/46?closed=1)
 
 ### Fixed
 
+- Fix exception breaking highlighting in Unity.Mathematics generated files ([RIDER-61025](https://youtrack.jetbrains.com/issue/RIDER-61025), [#2067](https://github.com/JetBrains/resharper-unity/pull/2067))
 - Rider: Gracefully handle Unity API exceptions in debugger extensions - `UnityException`, `MissingComponentException`, `MissingReferenceException`, `UnassignedReferenceException` ([RIDER-60794](https://youtrack.jetbrains.com/issue/RIDER-60794), [RIDER-60795](https://youtrack.jetbrains.com/issue/RIDER-60795), [DEXP-585430](https://youtrack.jetbrains.com/issue/DEXP-585430), [DEXP-534612](https://youtrack.jetbrains.com/issue/DEXP-534612), [DEXP-558487](https://youtrack.jetbrains.com/issue/DEXP-558487), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
 - Rider: Fix incorrect reporting of `EvaluatorAbortedException` control flow exception ([DEXP-570625](https://youtrack.jetbrains.com/issue/DEXP-570265), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
 - Rider: Fix exceptions thrown when by Unity debugger extensions when implicit evaluation is disabled ([RIDER-60798](https://youtrack.jetbrains.com/issue/RIDER-60798), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
@@ -21,9 +22,20 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 
 
+## 2021.1.1
+* Released: [2021-04-10](https://blog.jetbrains.com/dotnet/2021/04/10/rider-resharper-2021-1-1-released/)
+* Build: 2021.1.0.114
+* [No code changes](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0...net211-rtm-2021.1.0-rtm-2021.1.1)
+
+
+
 ## 2021.1.0
+* Released: [2021-04-08](https://blog.jetbrains.com/dotnet/2021/04/08/rider-2021-1-release/)
+* Build: 2021.1.0.113
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net203...net211-rtm-2021.1.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/42?closed=1)
+* [GitHub release](https://github.com/JetBrains/resharper-unity/releases/tag/net211-rtm-2021.1.0)
+* [ReSharper release](https://resharper-plugins.jetbrains.com/packages/JetBrains.Unity/2021.1.0.114)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Fixed
 
+- Fix missing implicit include of UnityGC.cginc in non-surface shaders ([RIDER-60508](https://youtrack.jetbrains.com/issue/RIDER-60508), [#2069](https://github.com/JetBrains/resharper-unity/pull/2069))
 - Fix exception breaking highlighting in Unity.Mathematics generated files ([RIDER-61025](https://youtrack.jetbrains.com/issue/RIDER-61025), [#2067](https://github.com/JetBrains/resharper-unity/pull/2067))
 - Rider: Gracefully handle Unity API exceptions in debugger extensions - `UnityException`, `MissingComponentException`, `MissingReferenceException`, `UnassignedReferenceException` ([RIDER-60794](https://youtrack.jetbrains.com/issue/RIDER-60794), [RIDER-60795](https://youtrack.jetbrains.com/issue/RIDER-60795), [DEXP-585430](https://youtrack.jetbrains.com/issue/DEXP-585430), [DEXP-534612](https://youtrack.jetbrains.com/issue/DEXP-534612), [DEXP-558487](https://youtrack.jetbrains.com/issue/DEXP-558487), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
 - Rider: Fix incorrect reporting of `EvaluatorAbortedException` control flow exception ([DEXP-570625](https://youtrack.jetbrains.com/issue/DEXP-570265), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))

--- a/debugger/debugger-worker/src/Evaluation/EvaluatorExceptionThrownExceptionHelper.cs
+++ b/debugger/debugger-worker/src/Evaluation/EvaluatorExceptionThrownExceptionHelper.cs
@@ -1,0 +1,38 @@
+using System;
+using JetBrains.Annotations;
+using JetBrains.Util;
+using Mono.Debugging.Backend.Values;
+using Mono.Debugging.Backend.Values.ValueReferences;
+using Mono.Debugging.Backend.Values.ValueRoles;
+using Mono.Debugging.Client.CallStacks;
+using Mono.Debugging.Client.Values.Render;
+using Mono.Debugging.Evaluation;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
+{
+    public static class EvaluatorExceptionThrownExceptionHelper
+    {
+        [CanBeNull]
+        public static string GetThrownExceptionMessage<TValue>(EvaluatorExceptionThrownException<TValue> exception,
+                                                               IStackFrame frame,
+                                                               IValueServicesFacade<TValue> valueServices,
+                                                               IValueFetchOptions valueFetchOptions,
+                                                               ILogger logger)
+            where TValue : class
+        {
+            try
+            {
+                var reference = new SimpleValueReference<TValue>(exception.Exception, frame, valueServices.RoleFactory);
+                return reference.AsObjectSafe(valueFetchOptions)
+                    ?.GetInstancePropertyReference("Message", true)
+                    ?.AsStringSafe(valueFetchOptions)?.GetString();
+            }
+            catch (Exception e)
+            {
+                // Argh! Exception thrown while trying to get information about a thrown exception!
+                logger.LogExceptionSilently(e);
+                return null;
+            }
+        }
+    }
+}

--- a/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
+++ b/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -39,7 +38,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
         protected UnityAdditionalValuesProvider(IDebuggerSession session, IValueServicesFacade<TValue> valueServices,
                                                 IUnityOptions unityOptions, ILogger logger)
         {
-            // We can't use EvaluationOptions here, it hasn't been set yet
             mySession = session;
             myValueServices = valueServices;
             myUnityOptions = unityOptions;
@@ -66,85 +64,77 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
         [CanBeNull]
         private IValueReference<TValue> GetActiveScene(IStackFrame frame)
         {
-            try
-            {
-                var sceneManagerType = myValueServices.GetReifiedType(frame,
-                                           "UnityEngine.SceneManagement.SceneManager, UnityEngine.CoreModule")
-                                       ?? myValueServices.GetReifiedType(frame,
-                                           "UnityEngine.SceneManagement.SceneManager, UnityEngine");
-                if (sceneManagerType == null)
+            return myLogger.CatchEvaluatorException<TValue, IValueReference<TValue>>(() =>
                 {
-                    myLogger.Warn("Unable to get typeof(SceneManager). Not a Unity project?");
-                    return null;
-                }
+                    var sceneManagerType = myValueServices.GetReifiedType(frame,
+                                               "UnityEngine.SceneManagement.SceneManager, UnityEngine.CoreModule")
+                                           ?? myValueServices.GetReifiedType(frame,
+                                               "UnityEngine.SceneManagement.SceneManager, UnityEngine");
+                    if (sceneManagerType == null)
+                    {
+                        myLogger.Warn("Unable to get typeof(SceneManager). Not a Unity project?");
+                        return null;
+                    }
 
-                var getActiveSceneMethod = sceneManagerType.MetadataType.GetMethods()
-                    .FirstOrDefault(m => m.IsStatic && m.Parameters.Length == 0 && m.Name == "GetActiveScene");
-                if (getActiveSceneMethod == null)
-                {
-                    myLogger.Warn("Unable to find SceneManager.GetActiveScene");
-                    return null;
-                }
+                    var getActiveSceneMethod = sceneManagerType.MetadataType.GetMethods()
+                        .FirstOrDefault(m => m.IsStatic && m.Parameters.Length == 0 && m.Name == "GetActiveScene");
+                    if (getActiveSceneMethod == null)
+                    {
+                        myLogger.Warn("Unable to find SceneManager.GetActiveScene");
+                        return null;
+                    }
 
-                var activeScene = sceneManagerType.CallStaticMethod(frame, mySession.EvaluationOptions, getActiveSceneMethod);
-                if (activeScene == null)
-                {
-                    myLogger.Warn("Unexpected response: SceneManager.GetActiveScene() == null");
-                    return null;
-                }
+                    // GetActiveScene can throw a UnityException if we call it from the wrong location, such as the
+                    // constructor of a MonoBehaviour
+                    var activeScene =
+                        sceneManagerType.CallStaticMethod(frame, mySession.EvaluationOptions, getActiveSceneMethod);
+                    if (activeScene == null)
+                    {
+                        myLogger.Warn("Unexpected response: SceneManager.GetActiveScene() == null");
+                        return null;
+                    }
 
-                // Don't show type presentation. We know it's a scene, the clue's in the name
-                return new SimpleValueReference<TValue>(activeScene, sceneManagerType.MetadataType,
-                    "Active scene", ValueOriginKind.Property,
-                    ValueFlags.None | ValueFlags.IsReadOnly | ValueFlags.IsDefaultTypePresentation, frame,
-                    myValueServices.RoleFactory);
-            }
-            catch (Exception e)
-            {
-                myLogger.LogException(e);
-                return null;
-            }
+                    // Don't show type presentation. We know it's a scene, the clue's in the name
+                    return new SimpleValueReference<TValue>(activeScene, sceneManagerType.MetadataType,
+                        "Active scene", ValueOriginKind.Property,
+                        ValueFlags.None | ValueFlags.IsReadOnly | ValueFlags.IsDefaultTypePresentation, frame,
+                        myValueServices.RoleFactory);
+                }, exception => myLogger.LogThrownUnityException(exception, frame, myValueServices, mySession.EvaluationOptions));
         }
 
         [CanBeNull]
         private IValueReference<TValue> GetThisGameObjectForMonoBehaviour(IStackFrame frame)
         {
-            try
+            return myLogger.CatchEvaluatorException<TValue, IValueReference<TValue>>(() =>
             {
                 var thisObj = frame.GetThis(mySession.EvaluationOptions);
-                if (thisObj?.DeclaredType?.FindTypeThroughHierarchy("UnityEngine.MonoBehaviour") != null)
+                if (thisObj?.DeclaredType?.FindTypeThroughHierarchy("UnityEngine.MonoBehaviour") == null)
+                    return null;
+
+                if (!(thisObj.GetPrimaryRole(mySession.EvaluationOptions) is IObjectValueRole<TValue> role))
                 {
-                    if (!(thisObj.GetPrimaryRole(mySession.EvaluationOptions) is IObjectValueRole<TValue> role))
-                    {
-                        myLogger.Warn("Unable to get 'this' as object value");
-                        return null;
-                    }
-
-                    var gameObjectReference = role.GetInstancePropertyReference("gameObject", true);
-                    if (gameObjectReference == null)
-                    {
-                        myLogger.Warn("Unable to get 'this.gameObject' as a property reference");
-                        return null;
-                    }
-
-                    var gameObject = gameObjectReference.GetValue(mySession.EvaluationOptions);
-                    var gameObjectType = gameObjectReference.GetValueType(mySession.EvaluationOptions,
-                        myValueServices.ValueMetadataProvider);
-
-                    // Don't show type for each child game object. It's always "GameObject", and we know they're game
-                    // objects from the synthetic group.
-                    return new SimpleValueReference<TValue>(gameObject, gameObjectType, "this.gameObject",
-                        ValueOriginKind.Property,
-                        ValueFlags.None | ValueFlags.IsDefaultTypePresentation | ValueFlags.IsReadOnly, frame,
-                        myValueServices.RoleFactory);
+                    myLogger.Warn("Unable to get 'this' as object value");
+                    return null;
                 }
-            }
-            catch (Exception ex)
-            {
-                myLogger.LogException(ex);
-            }
 
-            return null;
+                var gameObjectReference = role.GetInstancePropertyReference("gameObject", true);
+                if (gameObjectReference == null)
+                {
+                    myLogger.Warn("Unable to get 'this.gameObject' as a property reference");
+                    return null;
+                }
+
+                var gameObject = gameObjectReference.GetValue(mySession.EvaluationOptions);
+                var gameObjectType = gameObjectReference.GetValueType(mySession.EvaluationOptions,
+                    myValueServices.ValueMetadataProvider);
+
+                // Don't show type for each child game object. It's always "GameObject", and we know they're game
+                // objects from the synthetic group.
+                return new SimpleValueReference<TValue>(gameObject, gameObjectType, "this.gameObject",
+                    ValueOriginKind.Property,
+                    ValueFlags.None | ValueFlags.IsDefaultTypePresentation | ValueFlags.IsReadOnly, frame,
+                    myValueServices.RoleFactory);
+            }, exception => myLogger.LogThrownUnityException(exception, frame, myValueServices, mySession.EvaluationOptions));
         }
     }
 }

--- a/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
+++ b/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
@@ -113,7 +113,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
             return myLogger.CatchEvaluatorException<TValue, IValueReference<TValue>>(() =>
                 {
                     // Make sure we can evaluate. The debugger overrides this for GetChildren, we'll allow it here, too.
-                    // make Make sure we an can ate the Message perty, even if cit evaluation is // If the user wishes to stop this, they can disable specific settings in the Unity settings page
+                    // If the user wishes to stop this, they can disable specific settings in the Unity settings page
                     var newOptions = mySession.EvaluationOptions.WithOverridden(o => o.AllowTargetInvoke = true);
 
                     var thisObj = frame.GetThis(newOptions);

--- a/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
+++ b/debugger/debugger-worker/src/Evaluation/UnityAdditionalValuesProvider.cs
@@ -84,7 +84,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
                         .FirstOrDefault(m => m.IsStatic && m.Parameters.Length == 0 && m.Name == "GetActiveScene");
                     if (getActiveSceneMethod == null)
                     {
-                        myLogger.Warn("Unable to find SceneManager.GetActiveScene");
+                        myLogger.Warn("Unable to find SceneManager.GetActiveScene method");
                         return null;
                     }
 
@@ -129,10 +129,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation
                     var gameObjectReference = role.GetInstancePropertyReference("gameObject", true);
                     if (gameObjectReference == null)
                     {
-                        myLogger.Warn("Unable to get 'this.gameObject' as a property reference");
+                        myLogger.Warn("Unable to find 'this.gameObject' as a property reference");
                         return null;
                     }
 
+                    // There's a chance that `gameObject` will throw a UnityException because we're not allowed to call
+                    // it here (e.g. MonoBehaviour ctor), so invoke the method now rather than returning a decorated
+                    // version of the property value reference. We'll catch the exception and react gracefully. Note
+                    // that if the gameObject property returned null (it won't), we'd still get a valid value here.
                     var gameObject = gameObjectReference.GetValue(newOptions);
                     var gameObjectType = gameObjectReference.GetValueType(newOptions,
                         myValueServices.ValueMetadataProvider);

--- a/debugger/debugger-worker/src/LoggerHelper.cs
+++ b/debugger/debugger-worker/src/LoggerHelper.cs
@@ -1,0 +1,61 @@
+using System;
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Evaluation;
+using JetBrains.Util;
+using Mono.Debugging.Backend.Values;
+using Mono.Debugging.Client.CallStacks;
+using Mono.Debugging.Client.Values.Render;
+using Mono.Debugging.Evaluation;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger
+{
+    public static class LoggerHelper
+    {
+        [CanBeNull]
+        public static T CatchEvaluatorException<TValue, T>(this ILogger logger, [InstantHandle] Func<T> action,
+                                                           Action<EvaluatorExceptionThrownException<TValue>> onEvaluatorException)
+            where TValue : class
+        {
+            try
+            {
+                return action();
+            }
+            catch (EvaluatorExceptionThrownException<TValue> e)
+            {
+                // The code being evaluated threw an exception. This might be expected, might not
+                onEvaluatorException(e);
+            }
+            catch (Exception e)
+            {
+                // We're not expecting this exception, log it as an error so we can fix it
+                logger.LogException(e);
+            }
+
+            return default;
+        }
+
+        // Extract the message from the thrown exception and log it. If it's a UnityException, treat it as expected and
+        // log silently (it usually means Unity doesn't like us calling a method at the current location). If it's any
+        // other exception, log it as an error so we can fix it.
+        public static void LogThrownUnityException<TValue>(this ILogger logger,
+                                                           EvaluatorExceptionThrownException<TValue> exception,
+                                                           IStackFrame frame,
+                                                           IValueServicesFacade<TValue> valueServices,
+                                                           IValueFetchOptions valueFetchOptions)
+            where TValue : class
+        {
+            var message = EvaluatorExceptionThrownExceptionHelper.GetThrownExceptionMessage(exception, frame,
+                valueServices, valueFetchOptions, logger);
+            if (exception.ExceptionTypeName == "UnityEngine.UnityException")
+            {
+                // We're expecting this if we e.g. call GetActiveScene from a MonoBehaviour constructor. Log the
+                logger.Verbose(exception, comment: message);
+            }
+            else
+            {
+                // Not expecting this, log it as an error so we can fix it
+                logger.Error(exception, "Exception thrown by evaluated code: {0}", message);
+            }
+        }
+    }
+}

--- a/debugger/debugger-worker/src/LoggerHelper.cs
+++ b/debugger/debugger-worker/src/LoggerHelper.cs
@@ -20,6 +20,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger
             {
                 return action();
             }
+            catch (EvaluatorAbortedException e)
+            {
+                // Evaluation has been aborted, e.g. the user has continued before evaluation has completed
+                logger.LogExceptionSilently(e);
+            }
             catch (EvaluatorExceptionThrownException<TValue> e)
             {
                 // The code being evaluated threw an exception. This might be expected, might not

--- a/debugger/debugger-worker/src/LoggerHelper.cs
+++ b/debugger/debugger-worker/src/LoggerHelper.cs
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger
             where TValue : class
         {
             var message = EvaluatorExceptionThrownExceptionHelper.GetThrownExceptionMessage(exception, frame,
-                valueServices, valueFetchOptions, logger);
+                valueServices, valueFetchOptions.WithOverridden(o => o.AllowTargetInvoke = true), logger);
             if (exception.ExceptionTypeName == "UnityEngine.UnityException")
             {
                 // We're expecting this if we e.g. call GetActiveScene from a MonoBehaviour constructor. Log the

--- a/debugger/debugger-worker/src/Values/ChunkedValueGroupBase.cs
+++ b/debugger/debugger-worker/src/Values/ChunkedValueGroupBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using JetBrains.Annotations;
 using Mono.Debugging.Backend.Values.ValueRoles;
 using Mono.Debugging.Client.Values;
 using Mono.Debugging.Client.Values.Render;
@@ -71,6 +72,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values
             }
         }
 
+        [NotNull]
         protected abstract IValue GetElementValueAt(TRole collection, int index, IValueFetchOptions options);
     }
 }

--- a/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/FilteredObjectChildrenRendererBase.cs
+++ b/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/FilteredObjectChildrenRendererBase.cs
@@ -15,10 +15,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
     public abstract class FilteredObjectChildrenRendererBase<TValue> : ChildrenRendererBase<TValue, IObjectValueRole<TValue>>
         where TValue : class
     {
-        protected override IEnumerable<IValueEntity> GetChildren(IObjectValueRole<TValue> valueRole,
+        [NotNull]
+        protected override IEnumerable<IValueEntity> GetChildren([NotNull] IObjectValueRole<TValue> valueRole,
                                                                  IMetadataTypeLite instanceType,
                                                                  IPresentationOptions options,
-                                                                 IUserDataHolder dataHolder, CancellationToken token)
+                                                                 IUserDataHolder dataHolder,
+                                                                 CancellationToken token)
         {
             var references = EnumerateChildren(valueRole, options, token);
             references = FilterChildren(references);
@@ -26,7 +28,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
             return RenderChildren(valueRole, references, options, token);
         }
 
-        protected IEnumerable<IValueReference<TValue>> EnumerateChildren(IObjectValueRole<TValue> valueRole,
+        [NotNull]
+        protected IEnumerable<IValueReference<TValue>> EnumerateChildren([NotNull] IObjectValueRole<TValue> valueRole,
                                                                          IPresentationOptions options,
                                                                          CancellationToken token)
         {

--- a/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/GameObjectChildrenRenderer.cs
+++ b/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/GameObjectChildrenRenderer.cs
@@ -272,7 +272,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
                     var gameObject = childTransform?.GetInstancePropertyReference("gameObject", true)
                         ?.AsObjectSafe(options);
                     if (gameObject == null)
-                        return new ErrorValue("Game Object", "Unable to retrieve child game object");
+                        return new ErrorValue("Game Object", "Unable to find child gameObject, or value is null");
 
                     var name = gameObject.GetInstancePropertyReference("name", true)?.AsStringSafe(options)
                         ?.GetString() ?? "Game Object";

--- a/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/GameObjectChildrenRenderer.cs
+++ b/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/GameObjectChildrenRenderer.cs
@@ -14,6 +14,7 @@ using Mono.Debugging.Backend.Values.ValueRoles;
 using Mono.Debugging.Client.CallStacks;
 using Mono.Debugging.Client.Values;
 using Mono.Debugging.Client.Values.Render;
+using Mono.Debugging.Evaluation;
 using Mono.Debugging.Soft;
 using TypeSystem;
 
@@ -175,9 +176,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
                             return stringValueRole.GetString();
                         }
                     }
+                    catch (EvaluatorAbortedException e)
+                    {
+                        myLogger.LogExceptionSilently(e);
+                    }
                     catch (Exception e)
                     {
-                        myLogger.Error(e, "Unable to fetch object names for {0}", componentValue);
+                        myLogger.Warn(e, ExceptionOrigin.Algorithmic,
+                            $"Unable to fetch object names for {componentValue}");
                     }
                 }
 

--- a/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/ScenePathValueHelper.cs
+++ b/debugger/debugger-worker/src/Values/Render/ChildrenRenderers/ScenePathValueHelper.cs
@@ -49,15 +49,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.Childre
                     var targetTransformRole = targetTransformReference?.AsObjectSafe(options);
                     // Search in bases - transform might be a RectTransform or a Transform, and root is defined on Transform
                     var rootTransformReference = targetTransformRole?.GetInstancePropertyReference("root", true);
+                    var rootTransformRole = rootTransformReference?.AsObjectSafe(options);
 
-                    if (targetTransformReference == null || rootTransformReference == null)
+                    if (targetTransformRole == null || rootTransformRole == null)
                     {
-                        logger.Warn("Unable to evaluate gameObject.transform and/or gameObject.root. Unexpected.");
+                        logger.Warn("Unable to evaluate gameObject.transform and/or gameObject.transform.root or values are null.");
                         return null;
                     }
 
-                    var rootTransformName = rootTransformReference.AsObjectSafe(options)
-                        ?.GetInstancePropertyReference("name", true)
+                    var rootTransformName = rootTransformRole.GetInstancePropertyReference("name", true)
                         ?.AsStringSafe(options)?.GetString() ?? "";
 
                     var pathValue = animationUtilityType.CallStaticMethod(frame, options, method,

--- a/debugger/debugger-worker/src/Values/Render/ValuePresenters/ExternalDebuggerDisplayObjectPresenter.cs
+++ b/debugger/debugger-worker/src/Values/Render/ValuePresenters/ExternalDebuggerDisplayObjectPresenter.cs
@@ -47,7 +47,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.ValuePr
 
             // Default is ({x}, {y}, {z}, {w}) to F1 precision. Euler angles is more useful
             {"UnityEngine.Quaternion", "eulerAngles: {eulerAngles}"},
-            {"UnityEngine.MeshFilter", "vertex count: {sharedMesh.vertexCount}"},
+            {"UnityEngine.Mesh", "vertex count: {vertexCount}"},
+            {"UnityEngine.MeshFilter", "shared mesh: ({sharedMesh})"},
             {"UnityEngine.SceneManagement.Scene", "{name} ({path})"},
 
             // Local values, as shown in the Inspector

--- a/debugger/debugger-worker/src/Values/Render/ValuePresenters/ExternalDebuggerDisplayObjectPresenter.cs
+++ b/debugger/debugger-worker/src/Values/Render/ValuePresenters/ExternalDebuggerDisplayObjectPresenter.cs
@@ -131,7 +131,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.Render.ValuePr
                 // Log as warning, not error - there's nothing the user can do, and we're likely to encounter this with
                 // device builds
                 myLogger.Warn(ex,
-                    comment: $"Unable to evaluate debugger display string for type ${instanceType.GetGenericTypeDefinition().FullName}: ${debuggerDisplayString}. " +
+                    comment: $"Unable to evaluate debugger display string for type {instanceType.GetGenericTypeDefinition().FullName}: {debuggerDisplayString}. " +
                              "Expected behaviour on devices due to stripping");
                 return null;
             }

--- a/debugger/debugger-worker/src/Values/ValueGroupBase.cs
+++ b/debugger/debugger-worker/src/Values/ValueGroupBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
+using JetBrains.Annotations;
 using Mono.Debugging.Client.Values;
 using Mono.Debugging.Client.Values.Render;
 
@@ -19,18 +20,21 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values
         public string SimpleName { get; }
         public virtual bool IsTop => true;
 
+        [NotNull]
         public virtual IValueKeyPresentation GetKeyPresentation(IPresentationOptions options,
                                                                 CancellationToken token = new CancellationToken())
         {
             return new ValueKeyPresentation(SimpleName, ValueOriginKind.Group, ValueFlags.None);
         }
 
+        [NotNull]
         public virtual IValuePresentation GetValuePresentation(IPresentationOptions options,
                                                                CancellationToken token = new CancellationToken())
         {
             return SimplePresentation.EmptyPresentation;
         }
 
+        [NotNull]
         public abstract IEnumerable<IValueEntity> GetChildren(IPresentationOptions options,
                                                               CancellationToken token = new CancellationToken());
     }

--- a/debugger/debugger-worker/src/Values/ValueReferences/CalculatedValueReferenceDecorator.cs
+++ b/debugger/debugger-worker/src/Values/ValueReferences/CalculatedValueReferenceDecorator.cs
@@ -1,7 +1,6 @@
 using JetBrains.Annotations;
 using Mono.Debugging.Backend.Values.ValueReferences;
 using Mono.Debugging.Backend.Values.ValueRoles;
-using Mono.Debugging.Client.Values;
 using Mono.Debugging.Client.Values.Render;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.ValueReferences
@@ -32,9 +31,5 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.ValueReference
         // Calculated value, must be read only
         public override ValueOriginKind OriginKind => ValueOriginKind.Other;
         public override ValueFlags DefaultFlags => ValueFlags.None | ValueFlags.IsReadOnly;
-        public override bool IsWriteable => false;
-
-        public override void SetValue(TValue value, IValueFetchOptions options) =>
-            throw ValueErrors.ReadOnlyReference();
     }
 }

--- a/debugger/debugger-worker/src/Values/ValueReferences/ValueReferenceDecoratorBase.cs
+++ b/debugger/debugger-worker/src/Values/ValueReferences/ValueReferenceDecoratorBase.cs
@@ -3,6 +3,7 @@ using MetadataLite.API;
 using Mono.Debugging.Backend.Values.ValueReferences;
 using Mono.Debugging.Backend.Values.ValueRoles;
 using Mono.Debugging.Client.CallStacks;
+using Mono.Debugging.Client.Values;
 using Mono.Debugging.Client.Values.Render;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.ValueReferences
@@ -42,10 +43,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Values.ValueReference
 
         public virtual void SetValue(TValue value, IValueFetchOptions options)
         {
+            if ((DefaultFlags & ValueFlags.IsReadOnly) != 0)
+                throw ValueErrors.ReadOnlyReference();
             myValueReferenceImplementation.SetValue(value, options);
         }
 
-        public virtual bool IsWriteable => myValueReferenceImplementation.IsWriteable;
+        public virtual bool IsWriteable =>
+            (DefaultFlags & ValueFlags.IsReadOnly) == 0 && myValueReferenceImplementation.IsWriteable;
 
         public virtual ValueOriginKind OriginKind => myValueReferenceImplementation.OriginKind;
 

--- a/rider/frontend.gradle
+++ b/rider/frontend.gradle
@@ -89,7 +89,7 @@ patchPluginXml {
         <p>
         ${changelog.get(pluginVersion).toHTML()}
         </p>
-        <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net202/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
+        <p>See the <a href="https://github.com/JetBrains/resharper-unity/blob/net211/CHANGELOG.md">CHANGELOG</a> for more details and history.</p>
         </body>
     """.stripIndent()
 }

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -12,7 +12,7 @@ productVersion=2021.1
 # Revision for plugin version, appended to productVersion, e.g. 2020.2.2
 # Used for published version, plus retrieving correct changelog notes
 # TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
-maintenanceVersion=0
+maintenanceVersion=2
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long


### PR DESCRIPTION
This PR handles a number of exceptions generated while evaluating extra data such as "Active Scene", "this.gameObject", "Scene Path" and so on.

- [x] Catches exceptions thrown by evaluated code and recovers gracefully. Retrieves the messages of various expected exceptions and silently logs at verbose level. Unexpected exceptions are reported at error level, to allow reporting and fixing
- [x] Silently logs `EvaluatorAbortedException` rather than log as error. This is a process control exception and shouldn't be logged. Fixes [DEXP-570625](https://youtrack.jetbrains.com/issue/DEXP-570265)
- [x] Catches `UnityException` thrown when evaluating API calls at invalid moments, e.g. calling `GetActiveScene` in a `MonoBehaviour` constructor. This could break evaluation of an entire Unity `Object`. Exception is caught and silently logged at verbose. Fixes [RIDER-60794](https://youtrack.jetbrains.com/issue/RIDER-60794) and [RIDER-60795](https://youtrack.jetbrains.com/issue/RIDER-60795)
- [x] Catches `MissingComponentException` and silently logs. Thrown by "null" instances returned from `GetComponent` when there isn't a `Component` attached to the current `GameObject`. Fixes [DEXP-585430](https://youtrack.jetbrains.com/issue/DEXP-585430)
- [x] Catches `MissingReferenceException` and silently logs. Thrown by calling APIs from destroyed objects. Fixes [DEXP-534612](https://youtrack.jetbrains.com/issue/DEXP-534612)
- [x] Catches `UnassignedReferenceException` and silently logs. Thrown by "null" instance objects created for an unassigned serialised field. Fixes [DEXP-558487](https://youtrack.jetbrains.com/issue/DEXP-558487)
- [x] Prevent exceptions when implicit evaluation is disabled. Unity extensions are evaluated even if implicit eval is disabled, as there is a separate setting to disable them. Fixes [RIDER-60798](https://youtrack.jetbrains.com/issue/RIDER-60798)
- [x] Gracefully handle possible null references while retrieving "Scene Path". Fixes [DEXP-561412](https://youtrack.jetbrains.com/issue/DEXP-561412)
- [x] Handle null reference when showing debugger display string details for mesh components. Fixes [DEXP-577753](https://youtrack.jetbrains.com/issue/DEXP-577753)