### PR TITLE
Disable ShowMarkerOnStaticMethods for Unity projects

### DIFF
--- a/resharper/resharper-unity/src/Settings/Rider/ShowMarkerOnStaticMethodSettings.cs
+++ b/resharper/resharper-unity/src/Settings/Rider/ShowMarkerOnStaticMethodSettings.cs
@@ -1,24 +1,30 @@
 using JetBrains.Application.Settings;
+using JetBrains.Application.Settings.Implementation;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Host.Features.RunMarkers;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Settings
 {
     [SolutionComponent]
     public class ShowMarkerOnStaticMethodSettings : IUnityProjectSettingsProvider
     {
-        private readonly ISettingsStore mySettingsStore;
+        private readonly SettingsSchema mySettingsSchema;
+        private readonly ILogger myLogger;
 
-        public ShowMarkerOnStaticMethodSettings(ISettingsStore settingsStore)
+        public ShowMarkerOnStaticMethodSettings(SettingsSchema settingsSchema, ILogger logger)
         {
-            mySettingsStore = settingsStore;
+            mySettingsSchema = settingsSchema;
+            myLogger = logger;
         }
 
         public void InitialiseProjectSettings(Lifetime projectLifetime, IProject project, ISettingsStorageMountPoint mountPoint)
         {
-            var store = mySettingsStore.BindToMountPoints(new[] {mountPoint});
-            store.SetValue<RunMarkerSettings, bool>(s => s.ShowMarkerOnStaticMethods, false);
+            // hide, because for Unity projects this wouldn't work.
+            // for Unity we have `UnityRunMarkerProvider` instead.
+            var entry = mySettingsSchema.GetScalarEntry((RunMarkerSettings o) => o.ShowMarkerOnStaticMethods);
+            ScalarSettingsStoreAccess.SetValue(mountPoint, entry, null, false, true, null, myLogger);
         }
     }
 }

--- a/resharper/resharper-unity/src/Settings/Rider/ShowMarkerOnStaticMethodSettings.cs
+++ b/resharper/resharper-unity/src/Settings/Rider/ShowMarkerOnStaticMethodSettings.cs
@@ -1,0 +1,24 @@
+using JetBrains.Application.Settings;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Host.Features.RunMarkers;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Settings
+{
+    [SolutionComponent]
+    public class ShowMarkerOnStaticMethodSettings : IUnityProjectSettingsProvider
+    {
+        private readonly ISettingsStore mySettingsStore;
+
+        public ShowMarkerOnStaticMethodSettings(ISettingsStore settingsStore)
+        {
+            mySettingsStore = settingsStore;
+        }
+
+        public void InitialiseProjectSettings(Lifetime projectLifetime, IProject project, ISettingsStorageMountPoint mountPoint)
+        {
+            var store = mySettingsStore.BindToMountPoints(new[] {mountPoint});
+            store.SetValue<RunMarkerSettings, bool>(s => s.ShowMarkerOnStaticMethods, false);
+        }
+    }
+}


### PR DESCRIPTION
Hide run-markers, because for Unity projects this wouldn't work.
For Unity we have `UnityRunMarkerProvider` instead.

https://youtrack.jetbrains.com/issue/RIDER-55734