### PR TITLE
Fix issues with USB debugging + debug dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0-rtm-2021.1.1...net211)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/46?closed=1)
 
+### Changed
+
+- Rider: Add link to troubleshooting document to the "Attach to Unity Process" debug dialog ([#2072](https://github.com/JetBrains/resharper-unity/pull/2067))
+
 ### Fixed
 
 - Fix missing implicit include of UnityGC.cginc in non-surface shaders ([RIDER-60508](https://youtrack.jetbrains.com/issue/RIDER-60508), [#2069](https://github.com/JetBrains/resharper-unity/pull/2069))
 - Fix exception breaking highlighting in Unity.Mathematics generated files ([RIDER-61025](https://youtrack.jetbrains.com/issue/RIDER-61025), [#2067](https://github.com/JetBrains/resharper-unity/pull/2067))
+- Rider: Fix USB iOS debugging ([#2072](https://github.com/JetBrains/resharper-unity/pull/2072))
+- Rider: Fix grouping issue in "Attach to Unity Process" dialog ([#2059](https://github.com/JetBrains/resharper-unity/issues/2059), [#2072](https://github.com/JetBrains/resharper-unity/pull/2072))
+- Rider: Fix minor rendering issue in "Attach to Unity Process" dialog ([#2072](https://github.com/JetBrains/resharper-unity/pull/2072))
 - Rider: Gracefully handle Unity API exceptions in debugger extensions - `UnityException`, `MissingComponentException`, `MissingReferenceException`, `UnassignedReferenceException` ([RIDER-60794](https://youtrack.jetbrains.com/issue/RIDER-60794), [RIDER-60795](https://youtrack.jetbrains.com/issue/RIDER-60795), [DEXP-585430](https://youtrack.jetbrains.com/issue/DEXP-585430), [DEXP-534612](https://youtrack.jetbrains.com/issue/DEXP-534612), [DEXP-558487](https://youtrack.jetbrains.com/issue/DEXP-558487), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
 - Rider: Fix incorrect reporting of `EvaluatorAbortedException` control flow exception ([DEXP-570625](https://youtrack.jetbrains.com/issue/DEXP-570265), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))
 - Rider: Fix exceptions thrown when by Unity debugger extensions when implicit evaluation is disabled ([RIDER-60798](https://youtrack.jetbrains.com/issue/RIDER-60798), [#2057](https://github.com/JetBrains/resharper-unity/pull/2057))

--- a/debugger/ios-list-usb-devices/src/runtimeconfig.template.json
+++ b/debugger/ios-list-usb-devices/src/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Major"
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityPlayerListener.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityPlayerListener.kt
@@ -48,7 +48,7 @@ class UnityPlayerListener(private val onPlayerAdded: (UnityProcess) -> Unit,
 \s\[Id]\s(?<id>[^:]+)(:(?<debuggerPort>\d+))?
 \s\[Debug]\s(?<debug>\d+)
 (\s\[PackageName]\s(?<packageName>.*?)
-  (\s\[ProjectName]\s(?<projectName>.*)?)
+  (\s\[ProjectName]\s(?<projectName>.*))
 )?
 """, Pattern.COMMENTS)
     }
@@ -183,7 +183,10 @@ class UnityPlayerListener(private val onPlayerAdded: (UnityProcess) -> Unit,
 
                         val channel = key.channel() as DatagramChannel
                         val hostAddress = channel.receive(buffer) as InetSocketAddress
-                        val descriptor = String(buffer.array(), 0, buffer.position() - 1)
+
+                        // The UDP message may or may not be already null terminated. Unity players seem to all include
+                        // it, but the support script doesn't. We shouldn't rely on it being there.
+                        val descriptor = String(buffer.array(), 0, buffer.position()).trimEnd('\u0000')
 
                         if (logger.isTraceEnabled) {
                             logger.trace("Got heartbeat on ${channel.remoteAddress} from $hostAddress: $descriptor")

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
@@ -79,9 +79,10 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
             row {
                 button("Add player address manually...", actionListener = { enterCustomIp() })
             }
-            commentRow("Please ensure both the <i>Development Build</i> and <i>Script Debugging</i> options are checked in Unity's <i>Build Settings</i> dialog. " +
+            commentRow("<p>Please ensure both the <i>Development Build</i> and <i>Script Debugging</i> options are checked in Unity's <i>Build Settings</i> dialog. " +
                 "Device players must be visible to the current network and firewall rules need to allow incoming UDP messages for the current process. " +
-                "Apple USB devices require iTunes or the Apple Mobile Device service to be installed.")
+                "Apple USB devices require iTunes or the Apple Mobile Device service to be installed.</p> " +
+                "<p>See the <a href=\"https://jb.gg/unity-troubleshoot-debug\">troubleshooting guide</a> for more details.</p>")
         }.apply { preferredSize = Dimension(650, 450) }
 
         isOKActionEnabled = false
@@ -133,7 +134,7 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
             row("Port:") { portField() }
         }
 
-        val dialog = dialog(
+        @Suppress("DialogTitleCapitalization") val dialog = dialog(
                 title = "Add Unity process",
                 panel = panel,
                 project = project,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
@@ -352,8 +352,17 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
 
         private fun isFirstItem(node: UnityProcessTreeNode) = node.previousSibling == null
         private fun isChildProcess(node: UnityProcessTreeNode) = node.parent is UnityProcessTreeNode
-        private fun getPreviousSiblingProjectName(node: UnityProcessTreeNode) =
-            (node.previousSibling as? UnityProcessTreeNode)?.process?.projectName ?: UNKNOWN_PROJECTS
+
+        private fun getPreviousSiblingProjectName(node: UnityProcessTreeNode): String {
+            return (node.previousSibling as? UnityProcessTreeNode)?.let {
+                if (it.process is UnityIosUsbProcess) {
+                    USB_DEVICES
+                }
+                else {
+                    it.process.projectName
+                }
+            } ?: UNKNOWN_PROJECTS
+        }
 
         /**
          * When the item is selected then we use default tree's selection foreground.

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/UnityProcessPickerDialog.kt
@@ -19,6 +19,7 @@ import java.awt.Insets
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
 import javax.swing.*
+import javax.swing.border.EmptyBorder
 import javax.swing.tree.*
 
 class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(project) {
@@ -52,6 +53,12 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
                     isOKActionEnabled = !it.debuggerAttached && it.process.allowDebugging
                 }
             }
+
+            // Make sure the current theme doesn't add a border/insets to the contents of the tree. This can affect the
+            // separator, which is drawn as content, and non-opaque. If it's shifted, then we'll see the item background
+            // around it, which is very obvious when the item is selected. This is not a problem with Rider's default
+            // themes, but is with IntelliJ Light and Darcula.
+            border = EmptyBorder(0, 0, 0, 0)
 
             registerKeyboardAction(okAction, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), JComponent.WHEN_FOCUSED)
 
@@ -275,11 +282,14 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
         }
     }
 
+    // This cell renderer contains several components:
+    // * GroupedElementsRenderer.MyComponent (myRendererComponent) - root component
+    //   * SeparatorWithText (mySeparatorComponent)
+    //   * SimpleColoredComponent (myComponent) - item component defined in this derived class
+    // * ErrorLabel (myTextLabel) - looks like it's a text label for accessibility
+    // The root myRendererComponent is drawn in the correct selected/unselected tree background
     private class GroupedProcessTreeCellRenderer : GroupedElementsRenderer.Tree() {
         override fun getTreeCellRendererComponent(tree: JTree, value: Any?, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean): Component {
-
-            // Reset the state from the last render. The tree will set background colour on the renderer panel component
-            setDeselected(myRendererComponent)
 
             val itemComponent = myComponent as SimpleColoredComponent
             itemComponent.clear()
@@ -291,8 +301,11 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
 
             val projectName = unityProcess.projectName ?: if (unityProcess is UnityIosUsbProcess) USB_DEVICES else UNKNOWN_PROJECTS
             val hasSeparator = !isChildProcess(node) && (isFirstItem(node) || getPreviousSiblingProjectName(node) != projectName)
-            // TODO: Is there anything more useful we could show in the tooltip?
+
+            // Set up visibility and selected status. This does not (re)set the selected status of the returned
+            // myRendererComponent, which has its background set directly by the tree
             val component = configureComponent("", "", null, null, selected, hasSeparator, projectName, -1)
+            setDeselected(component)
 
             val focused = tree.hasFocus()
             if (unityProcess is UnityEditorHelper && unityProcess.roleName.isNotEmpty()) {
@@ -319,8 +332,7 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
         }
 
         override fun createSeparator(): SeparatorWithText {
-            // The DefaultTreeUI will set the background colour of the myRendererComponent and SeparatorWithText is not
-            // painted opaque, so we'll see the selected background colour. Force painting the background
+            // The separator is not painted opaque by default but looks bad painted over a selected background
             return object: SeparatorWithText() {
                 override fun paint(g: Graphics?) {
                     g?.color = background
@@ -331,10 +343,11 @@ class UnityProcessPickerDialog(private val project: Project) : DialogWrapper(pro
         }
 
         override fun createItemComponent(): JComponent {
-            myTextLabel = ErrorLabel() // dummy component required by base class
-            return SimpleColoredComponent().apply {
-                isOpaque = false
-            }
+            myTextLabel = ErrorLabel() // dummy component required by base class for accessibility
+
+            // Don't paint the background for the item component because we don't have a way of setting the unfocused
+            // selected colour. If we paint as non-opaque, we get myRendererComponent's background
+            return SimpleColoredComponent().apply { isOpaque = false }
         }
 
         private fun isFirstItem(node: UnityProcessTreeNode) = node.previousSibling == null


### PR DESCRIPTION
This PR fixes several issues with the "Attach to Unity Process" debug dialog:

- [x] iOS USB debugging is broken on Mac and Linux in 211 RTM, as the helper process is a .net core 3.0.1 app and Rider 211 ships 5.0.5. This PR adds runtime config to allow rolling forward to the next major version of .net core, so it runs again on 5.0.5
- [x] Adds extra logging for the USB helper process which would have allowed diagnosing this much quicker
- [x] Add a link to a [troubleshooting wiki document](https://jb.gg/unity-troubleshoot-debug) that includes details on macOS firewalls (yes, firewalls. The Mac has two firewalls, only one of which is controlled by system prefs)
- [x] Fix a grouping issue in the dialog, where players that do not match the current project are grouped with the USB devices (#2059)
- [x] Fix a minor rendering issue in the dialog with the Darcula and IntelliJ Light themes that would show the selected item background around the edges of the project separator