### PR TITLE
Fix exception when saving AsmDef file template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 - Fix missing implicit include of UnityGC.cginc in non-surface shaders ([RIDER-60508](https://youtrack.jetbrains.com/issue/RIDER-60508), [#2069](https://github.com/JetBrains/resharper-unity/pull/2069))
 - Fix exception breaking highlighting in Unity.Mathematics generated files ([RIDER-61025](https://youtrack.jetbrains.com/issue/RIDER-61025), [#2067](https://github.com/JetBrains/resharper-unity/pull/2067))
+- Fix exception that prevented macros being saved with the AsmDef file template ([RIDER-61376](https://youtrack.jetbrains.com/issue/RIDER-61376), [#2073](https://github.com/JetBrains/resharper-unity/pull/2073))
 - Rider: Fix USB iOS debugging ([#2072](https://github.com/JetBrains/resharper-unity/pull/2072))
 - Rider: Fix grouping issue in "Attach to Unity Process" dialog ([#2059](https://github.com/JetBrains/resharper-unity/issues/2059), [#2072](https://github.com/JetBrains/resharper-unity/pull/2072))
 - Rider: Fix minor rendering issue in "Attach to Unity Process" dialog ([#2072](https://github.com/JetBrains/resharper-unity/pull/2072))

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/MustBeInProjectWithUnityVersion.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/MustBeInProjectWithUnityVersion.cs
@@ -44,7 +44,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplate
 
         public override IEnumerable<Pair<string, string>> EnumerateCustomProperties()
         {
-            yield return new Pair<string, string>(VersionProperty, myActualVersion.ToString(3));
+            yield return new Pair<string, string>(VersionProperty, myActualVersion.ToString());
         }
 
         public override string ToString()


### PR DESCRIPTION
The AsmDef file template uses the `MustBeInProjectWithUnityVersion` scope point that is parameterised with a Unity version. The default value is `2017.3`, because that's the first version that supported `.asmdef` files. Unfortunately, saving the template tries to save the scope point with the version serialised in 3 parts (`major.minor.build`) and if there are only 2 parts (`2017.3`) then it will throw an exception and the macros aren't saved.

This is a problem if the file template is modified to add a macro - the text content is saved, but the macro isn't. When evaluating, the macro placeholder is left in place. See [RIDER-61376](https://youtrack.jetbrains.com/issue/RIDER-61376)