### PR TITLE
Fixes for additional content roots in workspace model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 
 ## 2021.1.2
+* Released: [2021-04-23](https://blog.jetbrains.com/dotnet/2021/04/23/resharper_rider_2021_1_2/)
+* Build: 2021.1.2.127
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0-rtm-2021.1.1...net211-rtm-2021.1.2)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/46?closed=1)
+* [GitHub release](https://github.com/JetBrains/resharper-unity/releases/tag/net211-rtm-2021.1.2)
+* [ReSharper release](https://resharper-plugins.jetbrains.com/packages/JetBrains.Unity/2021.1.2.127)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,19 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
+## 2021.1.3
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.2...net211)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/47?closed=1)
+
+### Fixed
+
+- Rider: Only add Unity folders to index for Unity packages ([#2076](https://github.com/JetBrains/resharper-unity/pull/2076))
+- Rider: Clean up indexed folders added in previous versions ([#2076](https://github.com/JetBrains/resharper-unity/pull/2076))
+
+
+
 ## 2021.1.2
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0-rtm-2021.1.1...net211)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net211-rtm-2021.1.0-rtm-2021.1.1...net211-rtm-2021.1.2)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/46?closed=1)
 
 ### Changed

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -12,7 +12,7 @@ productVersion=2021.1
 # Revision for plugin version, appended to productVersion, e.g. 2020.2.2
 # Used for published version, plus retrieving correct changelog notes
 # TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
-maintenanceVersion=2
+maintenanceVersion=3
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long


### PR DESCRIPTION
This PR will:

- [x] Only add Unity specific folders to the content model for a Unity project. This is especially important for `<project-root>/Packages`
- [x] Reset the extra folders and includes/excludes in the content model stored in `indexLayout.xml` by previous versions. The upgrade flag is stored in global config, keyed with the hash of the `.idea` path