### PR TITLE
Update plugin testing on Mac/Linux

### DIFF
--- a/resharper/resharper-unity/src/HlslSupport/ZoneMarker.cs
+++ b/resharper/resharper-unity/src/HlslSupport/ZoneMarker.cs
@@ -4,8 +4,13 @@
 namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport
 {
   [ZoneMarker]
-  public class ZoneMarker :
-    IRequire<ILanguageCppZone>
+  public class ZoneMarker : IRequire<ILanguageHlslSupportZone>
+  {
+  }
+
+  // By inheriting from ILanguageCppZone, activation is also inherited
+  [ZoneDefinition]
+  public interface ILanguageHlslSupportZone : ILanguageCppZone
   {
   }
 }

--- a/resharper/resharper-unity/src/Rider/Shaders/ZoneMarker.cs
+++ b/resharper/resharper-unity/src/Rider/Shaders/ZoneMarker.cs
@@ -1,0 +1,10 @@
+using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.ReSharper.Plugins.Unity.HlslSupport;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.Shaders
+{
+    [ZoneMarker]
+    public class ZoneMarker : IRequire<ILanguageHlslSupportZone>
+    {
+    }
+}

--- a/resharper/resharper-unity/src/app.config
+++ b/resharper/resharper-unity/src/app.config
@@ -31,5 +31,16 @@
         <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
+
+    <!-- As of 212, something is causing 5.0.0.0 to get referenced. MSBuild reckons it's JetBrains.Platform.Core, but
+         this is definitely referencing 4.0.4.1. The SDK is referencing the 4.5.3 package which is 4.0.4.1 file version.
+         This forces us to stick with 4.0.4.1 when compiling. At runtime, we use whatever is in the product.
+         This affected the tests in 211, but not affects resharper-unity. Weirdly, it doesn't affect rider-unity -->
+    <assemblyBnding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBnding>
   </runtime>
 </configuration>

--- a/resharper/resharper-unity/src/rider-unity.csproj
+++ b/resharper/resharper-unity/src/rider-unity.csproj
@@ -85,7 +85,7 @@
     <PsiLanguageNames Include="ShaderLab">
       <Visible>False</Visible>
     </PsiLanguageNames>
-    <CsLex Include="ShaderLab\Psi\Parsing\ShaderLab.lex" References="ShaderLab\Psi\Parsing\Chars.lex"/>
+    <CsLex Include="ShaderLab\Psi\Parsing\ShaderLab.lex" References="ShaderLab\Psi\Parsing\Chars.lex" />
     <TokenGenerator Include="ShaderLab\Psi\Parsing\ShaderLabTokenType.Tokens.xml">
       <OutputFile>ShaderLab\Psi\Parsing\ShaderLabTokenType.Tokens.generated.cs</OutputFile>
     </TokenGenerator>
@@ -107,7 +107,7 @@
     <PsiLanguageNames Include="JsonNew">
       <Visible>False</Visible>
     </PsiLanguageNames>
-    <CsLex Include="JsonNew\Psi\Parsing\JsonNew.lex" References="JsonNew\Psi\Parsing\Chars.lex"/>
+    <CsLex Include="JsonNew\Psi\Parsing\JsonNew.lex" References="JsonNew\Psi\Parsing\Chars.lex" />
     <TokenGenerator Include="JsonNew\Psi\Parsing\TokenNodeTypes\JsonNewTokenNodeTypes.Tokens.xml">
       <OutputFile>JsonNew\Psi\Parsing\TokenNodeTypes\JsonNewTokenNodeTypes.Tokens.generated.cs</OutputFile>
     </TokenGenerator>

--- a/resharper/resharper-unity/test/src/CSharp/Psi/CodeStyle/FileLayoutTests.cs
+++ b/resharper/resharper-unity/test/src/CSharp/Psi/CodeStyle/FileLayoutTests.cs
@@ -1,4 +1,5 @@
 using JetBrains.ReSharper.FeaturesTestFramework.CodeCleanup;
+using JetBrains.Util;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.CodeStyle
@@ -12,6 +13,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.CSharp.Psi.CodeStyle
     {
         protected override string RelativeTestDataPath => @"CSharp\Psi\CodeStyle";
 
-        [Test] public void TestFileLayout01() { DoNamedTest2(); }
+        [Test]
+        public void TestFileLayout01()
+        {
+            // This test does not currently run on Mono, because the System.Xaml.dll that ships with system Mono (that
+            // runs tests) expects a single mapping between CLR and XAML namespaces in [assembly: XmlnsDefinition(...)],
+            // and ReSharper has two attributes to map a XAML namespaces to the JetBrains.Application.Src.UI.Icons CLR
+            // namespace. The System.Xaml shipping with Rider uses a dictionary indexer instead of the Add method,
+            // so it works, although last write wins
+            if (PlatformUtil.IsRunningOnMono)
+                Assert.Ignore("Test not supported on Mono");
+            DoNamedTest2();
+        }
     }
 }

--- a/resharper/resharper-unity/test/src/RequireHlslSupportAttribute.cs
+++ b/resharper/resharper-unity/test/src/RequireHlslSupportAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using JetBrains.Application.Environment;
+using JetBrains.ReSharper.Plugins.Unity.HlslSupport;
+using JetBrains.ReSharper.Resources.Shell;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Tests
+{
+    // HLSL requires Psi.Cpp, which doesn't work on Mono. This attribute will ignore any test if
+    // ILanguageHlslSupportZone is not active
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false)]
+    public class RequireHlslSupportAttribute : TestActionAttribute
+    {
+        public override void BeforeTest(ITest test)
+        {
+            if (test.RunState == RunState.NotRunnable)
+                return;
+
+            var productConfigurations = Shell.Instance.GetComponent<RunsProducts.ProductConfigurations>();
+            if (productConfigurations.RunningZones.All(p =>
+                p.ZoneInterfaceType.FullName != typeof(ILanguageHlslSupportZone).FullName))
+            {
+                Assert.Ignore("HLSL zone is not available");
+            }
+        }
+    }
+}

--- a/resharper/resharper-unity/test/src/ShaderLab/Daemon/Hlsl/HlslCodeAnalysisTest.cs
+++ b/resharper/resharper-unity/test/src/ShaderLab/Daemon/Hlsl/HlslCodeAnalysisTest.cs
@@ -3,11 +3,12 @@ using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Daemon.Hlsl
 {
+    [RequireHlslSupport]
     public class HlslCodeAnalysisTest : ShaderLabHighlightingTestBase<CppHighlightingBase>
     {
         protected override string RelativeTestDataPath => @"ShaderLab\Daemon\Hlsl\Analysis";
 
-        // it is ok that fixed4 and other macroses are not resolved, because we do not have UnityCg folder
+        // it is ok that fixed4 and other macros are not resolved, because we do not have UnityCg folder
         [Test] public void TestHlsl01() { DoNamedTest2(); }
         [Test] public void TestHlsl02() { DoNamedTest2(); }
         [Test] public void TestHlsl03() { DoNamedTest2(); }

--- a/resharper/resharper-unity/test/src/ShaderLab/Feature/Services/TypingAssist/ShaderLabTypingAssistTest.cs
+++ b/resharper/resharper-unity/test/src/ShaderLab/Feature/Services/TypingAssist/ShaderLabTypingAssistTest.cs
@@ -8,12 +8,13 @@ using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Feature.Services.TypingAssist
 {
+    [RequireHlslSupport]
     [TestFileExtension(ShaderLabProjectFileType.SHADERLAB_EXTENSION)]
     [TestSettingsKey(typeof(ShaderLabFormatSettingsKey))]
-     public class ShaderLabTypingAssistTest : TypingAssistTestBase
+    public class ShaderLabTypingAssistTest : TypingAssistTestBase
     {
         protected override string RelativeTestDataPath => @"ShaderLab\TypingAssist";
-        
+
         [Test] public void SmartEnter01() { DoNamedTest(); }
         [Test] public void SmartEnter02() { DoNamedTest(); }
         [Test] public void SmartEnter03() { DoNamedTest(); }
@@ -24,21 +25,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests.ShaderLab.Feature.Services.Typ
         [Test] public void SmartEnterHlsl01() { DoNamedTest(); }
         [Test] public void SmartEnterHlsl02() { DoNamedTest(); }
         [Test] public void SmartEnterHlsl03() { DoNamedTest(); }
-
         [Test] public void SmartBackspace01() { DoNamedTest(); }
         [Test] public void SmartBackspace02() { DoNamedTest(); }
         [Test] public void SmartBackspace03() { DoNamedTest(); }
-        
-        
+
         // There is no smart backspace in C++ now, that test should fail when cpp team will implement it
         // we should check how injects are affected
         [Test] public void SmartBackspaceCppIsNotWorking() { DoNamedTest(); }
-        
+
         protected override void DoTest(Lifetime lifetime)
         {
             var settingsStore = ChangeSettingsTemporarily(TestLifetime).BoundStore;
             settingsStore.SetValue((ShaderLabFormatSettingsKey key) => key.INDENT_SIZE, 4);
-            
+
             base.DoTest(lifetime);
         }
     }

--- a/resharper/resharper-unity/test/src/TestEnvironment.cs
+++ b/resharper/resharper-unity/test/src/TestEnvironment.cs
@@ -42,7 +42,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests
         {
             try
             {
-                SetupLogging();
+                ConfigureLoggingFolderPath();
+                // ConfigureStartupLogging();
                 SetJetTestPackagesDir();
                 HackTestDataInNugets.ApplyPatches();
 
@@ -59,18 +60,43 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests
             }
         }
 
-        // Default logging is verbose, but this is useful for debugging startup, before the tests get a chance to
-        // initialise properly
-        private static void SetupLogging()
+        // The default logger outputs to $TMPDIR/JetLogs/ReSharperTests/resharper.log, which is not very helpful when
+        // we're testing more than one assembly. This sets up an environment variable to output the log to
+        // /resharper/build/{project}/logs
+        private static void ConfigureLoggingFolderPath()
         {
-            var executingAssembly = Assembly.GetExecutingAssembly();
-            var url = new Uri(executingAssembly.CodeBase);
-            var assemblyPath = FileSystemPath.Parse(url.AbsolutePath);
-            var assemblyDir = assemblyPath.Directory;
-            var configFile = assemblyDir.CombineWithShortName(assemblyPath.NameWithoutExtension + "_log.xml");
-            var testsFolder = Logger.LogFolderPath / "ReSharperTests";
-            var logfile = testsFolder.CombineWithShortName(assemblyPath.NameWithoutExtension + "_log.log");
-            logfile.DeleteFile();
+            Environment.SetEnvironmentVariable(Logger.JETLOGS_DIRECTORY_ENV_VARIABLE, GetLogsFolder().FullPath);
+        }
+
+        private static FileSystemPath GetLogsFolder()
+        {
+            // /resharper/build/{project}/bin/Debug/net461
+            var assemblyPath = FileSystemPath.Parse(Assembly.GetExecutingAssembly().Location).Directory;
+            var buildRoot = assemblyPath.Parent.Parent.Parent;
+
+            // /resharper/build/{project}/logs
+            var logsPath = buildRoot.Combine("logs");
+            if (!logsPath.ExistsDirectory)
+                logsPath.CreateDirectory();
+            return logsPath;
+        }
+
+        // BaseTestNoShell.SetUp will set up all the logging we normally need. It sets up per-test and common logs to
+        // write at VERBOSE level to files in $TMPDIR/JetLogs/ReSharperTests.
+        // However, it only starts logging once configured, which is when SetUp is called before a test starts. Use this
+        // method to log during startup, to diagnose any kind of startup issues (e.g. running tests on a Mac). This is
+        // not normally useful, and can have a significant performance impact - a ~35 second run dropped to ~29 seconds
+        // on my MacBook. This is mostly due to adding a third VERBOSE logging file appender, lots of VERBOSE logging
+        // during startup, and the cost of creating FileLogEventListener from config (getting current process ID to
+        // substitute into the file path pattern can be surprisingly expensive on my Mac when called for each test).
+        // Note that TRACE logging can be enabled per-test by overriding BaseTestNoShell.TestCategories
+        private static void ConfigureStartupLogging()
+        {
+            var logsPath = GetLogsFolder();
+            var configFile = logsPath.Combine("resharper_startup_conf.xml");
+            var logfile = logsPath.Combine("resharper_startup.log");
+            if (logfile.ExistsFile)
+                logfile.DeleteFile();
 
             // Set to TRACE to get logging on basically everything (including component containers)
             // Set to VERBOSE for most useful logging, but beware perf impact

--- a/resharper/resharper-unity/test/src/TestEnvironment.cs
+++ b/resharper/resharper-unity/test/src/TestEnvironment.cs
@@ -2,8 +2,6 @@
 using System.IO;
 using System.Reflection;
 using JetBrains.Application.BuildScript.Application.Zones;
-using JetBrains.Application.Environment;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.TestFramework;
 using JetBrains.TestFramework;
 using JetBrains.TestFramework.Application.Zones;
@@ -30,22 +28,11 @@ using JetBrains.RdBackend.Common.Env;
 namespace JetBrains.ReSharper.Plugins.Unity.Tests
 {
     [ZoneDefinition]
-    public interface IUnityTestZone : ITestsEnvZone
-
-    {
-    }
-
-    [ZoneActivator]
-    class CppTestZoneActivator : IActivate<ILanguageCppZone>, IActivate<PsiFeatureTestZone>
+    public interface IUnityTestZone : ITestsEnvZone, IRequire<PsiFeatureTestZone>
 #if RIDER
-        , IActivate<IRiderPlatformZone>
+        , IRequire<IRiderPlatformZone>
 #endif
-    ,IRequire<IUnityTestZone>
     {
-        public bool ActivatorEnabled()
-        {
-            return true;
-        }
     }
 
     [SetUpFixture]
@@ -59,10 +46,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Tests
                 SetJetTestPackagesDir();
                 HackTestDataInNugets.ApplyPatches();
 
-                // Temp workaround for GacCacheController, which adds all Mono GAC paths into a dictionary without
-                // checking for duplicates
                 if (PlatformUtil.IsRunningOnMono)
+                {
+                    // Temp workaround for GacCacheController, which adds all Mono GAC paths into a dictionary without
+                    // checking for duplicates
                     Environment.SetEnvironmentVariable("MONO_GAC_PREFIX", "/foo");
+                }
             }
             catch (Exception e)
             {

--- a/resharper/resharper-unity/test/src/app.config
+++ b/resharper/resharper-unity/test/src/app.config
@@ -43,11 +43,12 @@
 
     <!-- As of 211, something is causing 4.0.6.0 to get referenced. MSBuild reckons it's JetBrains.Platform.Core, but
          this is definitely referencing 4.0.4.1. The SDK is referencing the 4.5.3 package which is 4.0.4.1 file version.
-         This forces us to stick with 4.0.4.1 -->
+         This forces us to stick with 4.0.4.1 when compiling. At runtime, we use whatever is in the product.
+         UPDATE: 212 build is complaining about 5.0.0.0 -->
     <assemblyBnding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.0.4.1" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.0.4.1" />
       </dependentAssembly>
     </assemblyBnding>
   </runtime>

--- a/resharper/resharper-unity/test/src/tests.resharper-unity.csproj
+++ b/resharper/resharper-unity/test/src/tests.resharper-unity.csproj
@@ -8,14 +8,15 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <JetTestProject>True</JetTestProject>
+    <!-- Force 32 bit x86 for Windows as we need to load a specific build of the Cpp assembly, and we have X86 defined
+         in the app.config. Use OS default for other platforms as Mono can't run Cpp. Mac only runs 64 bit processes -->
+    <PlatformTarget Condition="'$([MSBuild]::IsOsPlatform(Windows))' == 'True'">X86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RESHARPER;$(CommandLineConstants)</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RESHARPER;$(CommandLineConstants)</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\Rider\**" />

--- a/resharper/resharper-unity/test/src/tests.resharper-unity.csproj
+++ b/resharper/resharper-unity/test/src/tests.resharper-unity.csproj
@@ -11,6 +11,7 @@
     <!-- Force 32 bit x86 for Windows as we need to load a specific build of the Cpp assembly, and we have X86 defined
          in the app.config. Use OS default for other platforms as Mono can't run Cpp. Mac only runs 64 bit processes -->
     <PlatformTarget Condition="'$([MSBuild]::IsOsPlatform(Windows))' == 'True'">X86</PlatformTarget>
+    <PlatformTarget Condition="'$([MSBuild]::IsOsPlatform(Windows))' != 'True'">X64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RESHARPER;$(CommandLineConstants)</DefineConstants>

--- a/resharper/resharper-unity/test/src/tests.rider-unity.csproj
+++ b/resharper/resharper-unity/test/src/tests.rider-unity.csproj
@@ -8,14 +8,15 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <JetTestProject>True</JetTestProject>
+    <!-- Force 32 bit x86 for Windows as we need to load a specific build of the Cpp assembly, and we have X86 defined
+         in the app.config. Use OS default for other platforms as Mono can't run Cpp. Mac only runs 64 bit processes -->
+    <PlatformTarget Condition="'$([MSBuild]::IsOsPlatform(Windows))' == 'True'">X86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;JET_MODE_ASSERT;JET_MODE_REPORT_EXCEPTIONS;RIDER;$(CommandLineConstants)</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RIDER;$(CommandLineConstants)</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="AsmDef\**" />

--- a/resharper/resharper-yaml/test/src/HackTestDataInNugets.cs
+++ b/resharper/resharper-yaml/test/src/HackTestDataInNugets.cs
@@ -6,7 +6,6 @@ using System.IO.Packaging;
 using HarmonyLib;
 using JetBrains.Reflection;
 using JetBrains.Util;
-using NuGet;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedParameter.Local
@@ -33,26 +32,18 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Tests
             // 574 files, and this takes a loooong time to complete. It also calls into a native library to get the
             // stream compression option, and we don't care about either of these things, so don't waste time
             // calculating them.
-            var originalMethod = AccessTools.Method(typeof(System.IO.Packaging.ZipPackage), "LoadParts");
+            var originalMethod = AccessTools.Method(typeof(ZipPackage), "LoadParts");
             var prefixMethod = new HarmonyMethod(AccessTools.Method(typeof(HackTestDataInNugets), nameof(New_System_IO_Packaging_ZipPackage_LoadParts)));
             harmony.Patch(originalMethod, prefixMethod);
 
             // Reverse patch System.IO.Packaging.ZipPackage.CreatePartCore onto HackTestDataInNugets.NuGet_ZipPacakge_CreatePartCore
             // to save us doing a lot of private reflection from our reimplementation of System.IO.Packaging.ZipPackage.LoadParts
-            harmony.CreateReversePatcher(AccessTools.Method(typeof(System.IO.Packaging.ZipPackage), "CreatePartCore"),
+            harmony.CreateReversePatcher(AccessTools.Method(typeof(ZipPackage), "CreatePartCore"),
                 new HarmonyMethod(AccessTools.Method(typeof(HackTestDataInNugets), nameof(System_IO_Packaging_ZipPackage_CreatePartCore)))).Patch();
-
-            // NuGet.OptimizedZipPackage.EnsurePackageFiles would indirectly call System.IO.ZipPackage.LoadParts, which
-            // is slow. It would then iterate over the parts (files) and ensure that each file exists on disk. If it
-            // doesn't it would uncompress the file into memory and then write to disk. If it does exist, it will
-            // uncompress the file into memory to compare stream lengths, and rewrite if necessary.
-            originalMethod = AccessTools.Method(typeof(NuGet.OptimizedZipPackage), "EnsurePackageFiles");
-            prefixMethod = new HarmonyMethod(AccessTools.Method(typeof(HackTestDataInNugets), nameof(New_NuGet_OptimizedZipPackage_EnsurePackageFiles)));
-            harmony.Patch(originalMethod, prefixMethod);
         }
 
         // Replaces ZipPackage.LoadParts, which is naive and very, very slow, and used every time a package is opened.
-        private static bool New_System_IO_Packaging_ZipPackage_LoadParts(System.IO.Packaging.ZipPackage __instance, ref Dictionary<Uri, ZipPackagePart> ___parts)
+        private static bool New_System_IO_Packaging_ZipPackage_LoadParts(ZipPackage __instance, ref Dictionary<Uri, ZipPackagePart> ___parts)
         {
             ___parts = new Dictionary<Uri, ZipPackagePart>();
             var packageStream = __instance.GetFieldOrPropertyValue<Stream>("PackageStream");
@@ -73,57 +64,6 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Tests
         private static PackagePart System_IO_Packaging_ZipPackage_CreatePartCore(object instance, Uri partUri, string contentType, CompressionOption compressionOption)
         {
             throw new InvalidOperationException("Stub replaced at runtime");
-        }
-
-        // Use SharpCompress to get a list of files, and write to disk if not already there. If the files are corrupt,
-        // we don't care. Delete them and try again. Significantly faster.
-        private static bool New_NuGet_OptimizedZipPackage_EnsurePackageFiles(OptimizedZipPackage __instance,
-            ref Dictionary<string, PhysicalPackageFile> ____files, ref string ____expandedFolderPath,
-            IFileSystem ____expandedFileSystem)
-        {
-            if (____files != null)
-            {
-                return false;
-            }
-
-            ____files = new Dictionary<string, PhysicalPackageFile>();
-            ____expandedFolderPath = __instance.Id + "." + __instance.Version;
-            using (var stream = __instance.GetStream())
-            {
-                using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Read, true))
-                {
-                    foreach (var zipArchiveEntry in zipArchive.Entries)
-                    {
-                        var path = zipArchiveEntry.FullName;
-                        if (path.EndsWith(".nuspec") || path.EndsWith(".psmdcp") || path == "_rels/.rels" ||
-                            path == "[Content_Types].xml")
-                            continue;
-                        var localPath = Path.Combine(____expandedFolderPath, path);
-                        if (!____expandedFileSystem.FileExists(localPath))
-                        {
-                            using (var entryStream = zipArchiveEntry.Open())
-                            {
-                                try
-                                {
-                                    using (var file = ____expandedFileSystem.CreateFile(localPath))
-                                        entryStream.CopyTo(file);
-                                }
-                                catch (Exception)
-                                {
-                                }
-                            }
-                        }
-
-                        var physicalPackageFile = new PhysicalPackageFile
-                        {
-                            SourcePath = ____expandedFileSystem.GetFullPath(localPath), TargetPath = path
-                        };
-                        ____files[path] = physicalPackageFile;
-                    }
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/resharper/resharper-yaml/test/src/TestEnvironment.cs
+++ b/resharper/resharper-yaml/test/src/TestEnvironment.cs
@@ -7,6 +7,7 @@ using JetBrains.TestFramework;
 using JetBrains.TestFramework.Application.Zones;
 using JetBrains.TestFramework.Utils;
 using JetBrains.Util;
+using JetBrains.Util.Logging;
 using NUnit.Framework;
 
 [assembly: RequiresThread(System.Threading.ApartmentState.STA)]
@@ -37,14 +38,17 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Tests
         {
             try
             {
-                SetupLogging();
+                ConfigureLoggingFolderPath();
+                // ConfigureStartupLogging();
                 SetJetTestPackagesDir();
                 HackTestDataInNugets.ApplyPatches();
 
-                // Temp workaround for GacCacheController, which adds all Mono GAC paths into a dictionary without
-                // checking for duplicates
                 if (PlatformUtil.IsRunningOnMono)
+                {
+                    // Temp workaround for GacCacheController, which adds all Mono GAC paths into a dictionary without
+                    // checking for duplicates
                     Environment.SetEnvironmentVariable("MONO_GAC_PREFIX", "/foo");
+                }
             }
             catch (Exception e)
             {
@@ -52,20 +56,43 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Tests
             }
         }
 
-        // Default logging is verbose, but this is useful for debugging startup, before the tests get a chance to
-        // initialise properly
-        private static void SetupLogging()
+        // The default logger outputs to $TMPDIR/JetLogs/ReSharperTests/resharper.log, which is not very helpful when
+        // we're testing more than one assembly. This sets up an environment variable to output the log to
+        // /resharper/build/{project}/logs
+        private static void ConfigureLoggingFolderPath()
         {
-            var executingAssembly = Assembly.GetExecutingAssembly();
-            var url = new Uri(executingAssembly.CodeBase);
-            var assemblyPath = FileSystemPath.Parse(url.AbsolutePath);
-            var assemblyDir = assemblyPath.Directory;
-            var configFile = assemblyDir.CombineWithShortName(assemblyPath.NameWithoutExtension + "_log.xml");
+            Environment.SetEnvironmentVariable(Logger.JETLOGS_DIRECTORY_ENV_VARIABLE, GetLogsFolder().FullPath);
+        }
 
-            // /resharper/build/tests.rider/bin/Debug/net461/JetBrains.ReSharper.Plugins.Unity.Tests.Rider_log.log
-            // Note that the logger will delete all files with basename.*, e.g. Rider.dll !!!!??!?!
-            var logfile = assemblyDir.CombineWithShortName(assemblyPath.NameWithoutExtension + "_log.log");
-            logfile.DeleteFile();
+        private static FileSystemPath GetLogsFolder()
+        {
+            // /resharper/build/{project}/bin/Debug/net461
+            var assemblyPath = FileSystemPath.Parse(Assembly.GetExecutingAssembly().Location).Directory;
+            var buildRoot = assemblyPath.Parent.Parent.Parent;
+
+            // /resharper/build/{project}/logs
+            var logsPath = buildRoot.Combine("logs");
+            if (!logsPath.ExistsDirectory)
+                logsPath.CreateDirectory();
+            return logsPath;
+        }
+
+        // BaseTestNoShell.SetUp will set up all the logging we normally need. It sets up per-test and common logs to
+        // write at VERBOSE level to files in $TMPDIR/JetLogs/ReSharperTests.
+        // However, it only starts logging once configured, which is when SetUp is called before a test starts. Use this
+        // method to log during startup, to diagnose any kind of startup issues (e.g. running tests on a Mac). This is
+        // not normally useful, and can have a significant performance impact - a ~35 second run dropped to ~29 seconds
+        // on my MacBook. This is mostly due to adding a third VERBOSE logging file appender, lots of VERBOSE logging
+        // during startup, and the cost of creating FileLogEventListener from config (getting current process ID to
+        // substitute into the file path pattern can be surprisingly expensive on my Mac when called for each test).
+        // Note that TRACE logging can be enabled per-test by overriding BaseTestNoShell.TestCategories
+        private static void ConfigureStartupLogging()
+        {
+            var logsPath = GetLogsFolder();
+            var configFile = logsPath.Combine("resharper_startup_conf.xml");
+            var logfile = logsPath.Combine("resharper_startup.log");
+            if (logfile.ExistsFile)
+                logfile.DeleteFile();
 
             // Set to TRACE to get logging on basically everything (including component containers)
             // Set to VERBOSE for most useful logging, but beware perf impact

--- a/resharper/resharper-yaml/test/src/app.config
+++ b/resharper/resharper-yaml/test/src/app.config
@@ -9,11 +9,12 @@
 
     <!-- As of 211, something is causing 4.0.6.0 to get referenced. MSBuild reckons it's JetBrains.Platform.Core, but
          this is definitely referencing 4.0.4.1. The SDK is referencing the 4.5.3 package which is 4.0.4.1 file version.
-         This forces us to stick with 4.0.4.1 -->
+         This forces us to stick with 4.0.4.1 when compiling. At runtime, we use whatever is in the product.
+         UPDATE: 212 build is complaining about 5.0.0.0 -->
     <assemblyBnding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.0.4.1" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.0.4.1" />
       </dependentAssembly>
     </assemblyBnding>
   </runtime>


### PR DESCRIPTION
Fixes a number of issues to get testing working again on Mac/Linux:

- [x] Removes some redundant hacks working around severe performance problems with the implementation of `System.IO.Packaging` on Mono. The ReSharper SDK uses a newer version of NuGet which means we no longer need to patch Mono's `OptimizedZipPackage.EnsurePackageFiles`. However, there are still some usages of NuGet 2.x that call Mono's really bad implementation of `ZipPackage.LoadParts` and that can add about 5 seconds to a 30 second test run. So this hack remains, for now.
- [x] Add an `ILanguageHlslSupportZone` zone definition which is only available if the `ILanguageCppZone` is available. Mono can't load the Cpp PSI assembly, and since it's not loaded, the `ILanguageCppZone` is not loaded or activated, and so all HLSL support code is disabled for Mac tests. An additional `[RequireHlslSupport]` attribute is available for test classes and methods that will ignore the tests if the `ILanguageHlslSupportZone` is not available.
- [x] Force the test assemblies to be compiled as x86 on Windows only. We need to specify 32 or 64 bit in order to load the correct Cpp PSI assembly, but Mac only supports 64 bit processes, and Mono doesn't support the Cpp PSI assembly. Windows stays as 32 bit, Mac/Linux use the OS default, which is 64 bit for Mac.
- [x] Disables the verbose logging set up in the `TestEnvironment` classes. This has a measurable impact on performance (it's the third `VERBOSE` file logger, and the constructor that the config uses is costly when called for every test). On my Mac, it drops a ~35 second run to ~29 seconds. It was added to capture startup logging, to help diagnose issues running tests on Mac, and isn't needed for day-to-day running. The default logs already output per-test and per-test run logs at `VERBOSE`, it just doesn't include startup logging.
- [x] Move the location of the default logs. The per-test run logs are written to `$TMPDIR/JetLogs/ReSharperTests/resharper.log`, which means that the logs are not per-assembly. The same file should be reused if the timestamp isn't older than 3 hours, but now the logs are created in `{solution-root}/resharper/build/{project}/logs` which means we get separate logs for rider-unity, rider-yaml, resharper-unity and resharper-yaml.

I haven't tested on Linux, but it should have the same behaviour as Mono on Mac.