### PR TITLE
Allow Editor templates for projects with UNITY_EDITOR define

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Application;
+using JetBrains.ProjectModel.Properties.Managed;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Context;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
 using JetBrains.ReSharper.Plugins.Unity.ProjectModel;
@@ -69,6 +70,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplate
                     else
                         yield return new InUnityCSharpRuntimeFolder();
                 }
+            }
+            
+            // For a project with UNITY_EDITOR define we have to allow Editor Templates 
+            if (project != null && project.ProjectProperties.ActiveConfigurations.Configurations.OfType<IManagedProjectConfiguration>()
+                .Select(configuration => configuration.DefineConstants)
+                .All(defines => defines.Contains("UNITY_EDITOR")))
+            {
+                yield return new InUnityCSharpEditorFolder();
             }
         }
 

--- a/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
@@ -71,13 +71,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplate
                         yield return new InUnityCSharpRuntimeFolder();
                 }
             }
-            
-            // For a project with UNITY_EDITOR define we have to allow Editor Templates 
-            if (project != null && project.ProjectProperties.ActiveConfigurations.Configurations.OfType<IManagedProjectConfiguration>()
-                .Select(configuration => configuration.DefineConstants)
-                .All(defines => defines.Contains("UNITY_EDITOR")))
+
+            if (!project.IsOneOfPredefinedUnityProjects())
             {
-                yield return new InUnityCSharpEditorFolder();
+                // For a project with UNITY_EDITOR define we have to allow Editor Templates 
+                if (project != null && project.ProjectProperties.ActiveConfigurations.Configurations
+                    .OfType<IManagedProjectConfiguration>()
+                    .Select(configuration => configuration.DefineConstants)
+                    .All(defines => defines.Contains("UNITY_EDITOR")))
+                {
+                    yield return new InUnityCSharpEditorFolder();
+                }
             }
         }
 

--- a/resharper/resharper-unity/src/ProjectModel/ProjectExtensions.cs
+++ b/resharper/resharper-unity/src/ProjectModel/ProjectExtensions.cs
@@ -51,9 +51,36 @@ namespace JetBrains.ReSharper.Plugins.Unity.ProjectModel
             // for our tests // todo: refactor tests so they also check logic above
             return project.HasSubItems(AssetsFolder) && IsUnityProject(project);
         }
+        
         public static bool HasUnityFlavour([CanBeNull] this IProject project)
         {
             return project != null && project.HasFlavour<UnityProjectFlavor>();
+        }
+        
+        public static bool IsOneOfPredefinedUnityProjects([CanBeNull] this IProject project)
+        {
+            return project != null && project.IsAssemblyCSharp() || project.IsAssemblyCSharpEditor() ||
+                   project.IsAssemblyCSharpFirstpass() || project.IsAssemblyCSharpFirstpassEditor();
+        }
+        
+        public static bool IsAssemblyCSharp([CanBeNull] this IProject project)
+        {
+            return project != null && project.Name == "Assembly-CSharp";
+        }
+        
+        public static bool IsAssemblyCSharpEditor([CanBeNull] this IProject project)
+        {
+            return project != null && project.Name == "Assembly-CSharp-Editor";
+        }
+        
+        public static bool IsAssemblyCSharpFirstpass([CanBeNull] this IProject project)
+        {
+            return project != null && project.Name == "Assembly-CSharp-firstpass";
+        }
+        
+        public static bool IsAssemblyCSharpFirstpassEditor([CanBeNull] this IProject project)
+        {
+            return project != null && project.Name == "Assembly-CSharp-Editor-firstpass";
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Modules/UnityExternalFilesModuleProcessor.cs
@@ -137,8 +137,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules
 
             // We know that the default projects are not .asmdef based, and will obviously live in Assets, which we've
             // already processed. This is just an optimisation - if a plugin renames the projects, we'll still work ok
-            if (project.Name == "Assembly-CSharp" || project.Name == "Assembly-CSharp-Editor" ||
-                project.Name == "Assembly-CSharp-firstpass" || project.Name == "Assembly-CSharp-Editor-firstpass")
+            if (project.IsOneOfPredefinedUnityProjects())
             {
                 return;
             }


### PR DESCRIPTION
https://jetbrains.slack.com/archives/C53QFRZ7G/p1620924775194600

When we have asmdef with Editor
"includePlatforms": [
    "Editor",
],
UNITY_EDITOR define is in the csproj

Otherwise - when asmdef either exсludes Editor or doesn't include it - UNITY_EDITOR define is not in the csproj
"excludePlatforms": [
    "Editor"
]

Assembly-CSharp and Assembly-CSharp-firstpass contain UNITY_EDITOR define, however Editor api-s compilation would fail.
If Player projects generation is enabled - those Player projects would not contain UNITY_EDITOR define.