### PR TITLE
Support v1 format for TagManager.asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Changed
 
 - Methods marked with `[UnitySetUp]` are treated as in use ([#2048](https://github.com/JetBrains/resharper-unity/issues/2048), [#2047](https://github.com/JetBrains/resharper-unity/pull/2047))
+- Improve localised caching for performance across all Unity analyses ([#2106](https://github.com/JetBrains/resharper-unity/pull/2106))
+- Parse layer names for legacy projects ([#2094](https://github.com/JetBrains/resharper-unity/issues/2094), [#2107](https://github.com/JetBrains/resharper-unity/pull/2107))
 - Rider: Improve performance showing packages in Unity Explorer when reopening a project ([RIDER-61805](https://youtrack.jetbrains.com/issue/RIDER-61805), [#2105](https://github.com/JetBrains/resharper-unity/pull/2105))
 - Rider: Group Unity run configurations in the run config dialog ([#2081](https://github.com/JetBrains/resharper-unity/pull/2081))
 - Rider: Ignore "break on unhandled exception" setting for IL2CPP players ([RIDER-62321](https://youtrack.jetbrains.com/issue/RIDER-62321), [#2098](https://github.com/JetBrains/resharper-unity/pull/2098))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 ### Changed
 
 - Methods marked with `[UnitySetUp]` are treated as in use ([#2048](https://github.com/JetBrains/resharper-unity/issues/2048), [#2047](https://github.com/JetBrains/resharper-unity/pull/2047))
-- Improve localised caching for performance across all Unity analyses ([#2106](https://github.com/JetBrains/resharper-unity/pull/2106))
+- Improve localised caching for performance across all Unity analyses ([RIDER-62709](https://youtrack.jetbrains.com/issue/RIDER-62709), [#2106](https://github.com/JetBrains/resharper-unity/pull/2106))
 - Parse layer names for legacy projects ([#2094](https://github.com/JetBrains/resharper-unity/issues/2094), [#2107](https://github.com/JetBrains/resharper-unity/pull/2107))
 - Rider: Improve performance showing packages in Unity Explorer when reopening a project ([RIDER-61805](https://youtrack.jetbrains.com/issue/RIDER-61805), [#2105](https://github.com/JetBrains/resharper-unity/pull/2105))
 - Rider: Group Unity run configurations in the run config dialog ([#2081](https://github.com/JetBrains/resharper-unity/pull/2081))

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
@@ -48,10 +48,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
                 if (scene == null)
                     continue;
 
-                var path = GetUnityScenePathRepresentation(scene.GetSimpleMapEntryPlainScalarText("path")
+                var path = GetUnityScenePathRepresentation(scene.GetMapEntryPlainScalarText("path")
                     .NotNull("EditorBuildSettings.scenes[x].path"));
                 var simple = path.Split('/').Last();
-                var isEnabledNode = scene.GetSimpleMapEntryValue<IPlainScalarNode>("enabled")
+                var isEnabledNode = scene.GetMapEntryValue<IPlainScalarNode>("enabled")
                     .NotNull("EditorBuildSettings.scenes[x].enabled");
                 var isEnabled = isEnabledNode.GetPlainScalarText()
                     .NotNull("isEnabledNode.GetPlainScalarText() != null")

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
@@ -40,29 +40,31 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
 
             var buildSettings = GetEditorBuildSettings(unityModule);
 
-            var scenes = GetSceneCollection(buildSettings.GetDominantPsiFile<YamlLanguage>() as IYamlFile) as IBlockSequenceNode;
+            var scenes = GetSceneCollection<IBlockSequenceNode>(buildSettings.GetDominantPsiFile<YamlLanguage>() as IYamlFile);
             Assertion.Assert(scenes != null, "scene != null");
             foreach (var entry in scenes.Entries)
             {
-                var scene = entry.Value;
-                var sceneRecord = scene as IBlockMappingNode;
-                if (sceneRecord == null)
+                var scene = entry.Value as IBlockMappingNode;
+                if (scene == null)
                     continue;
 
-                var path = GetUnityScenePathRepresentation(
-                    (sceneRecord.Entries[1].Content.Value as IPlainScalarNode).NotNull("PlainScalarNode:1").Text.GetText());
+                var path = GetUnityScenePathRepresentation(scene.GetSimpleMapEntryPlainScalarText("path")
+                    .NotNull("EditorBuildSettings.scenes[x].path"));
                 var simple = path.Split('/').Last();
-                var isEnabledPlaneScalarNode = (sceneRecord.Entries[0].Content.Value as IPlainScalarNode).NotNull("PlainScalarNode:0");
-                var isEnabled = isEnabledPlaneScalarNode.Text.GetText().Equals("1");
+                var isEnabledNode = scene.GetSimpleMapEntryValue<IPlainScalarNode>("enabled")
+                    .NotNull("EditorBuildSettings.scenes[x].enabled");
+                var isEnabled = isEnabledNode.GetPlainScalarText()
+                    .NotNull("isEnabledNode.GetPlainScalarText() != null")
+                    .Equals("1");
                 if (!isEnabled && (path.Equals(sceneName) || simple.Equals(sceneName)))
                 {
                     using (WriteLockCookie.Create(myWarning.Argument.IsPhysical()))
                     {
                         var text = YamlTokenType.NS_PLAIN_ONE_LINE_IN.Create("1");
-                        if (isEnabledPlaneScalarNode.Text != null)
-                            LowLevelModificationUtil.ReplaceChildRange(isEnabledPlaneScalarNode.Text, isEnabledPlaneScalarNode.Text, text);
+                        if (isEnabledNode.Text != null)
+                            LowLevelModificationUtil.ReplaceChildRange(isEnabledNode.Text, isEnabledNode.Text, text);
                         else
-                            LowLevelModificationUtil.AddChild(isEnabledPlaneScalarNode.Text, text);
+                            LowLevelModificationUtil.AddChild(isEnabledNode, text);
                     }
                 }
 

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneEnableQuickFix.cs
@@ -40,6 +40,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
 
             var buildSettings = GetEditorBuildSettings(unityModule);
 
+            // An empty array would be an IFlowSequenceNode with no elements. We've got a disabled scene, so we know we
+            // must have an item, which will be serialised as a block sequence
             var scenes = GetSceneCollection<IBlockSequenceNode>(buildSettings.GetDominantPsiFile<YamlLanguage>() as IYamlFile);
             Assertion.Assert(scenes != null, "scene != null");
             foreach (var entry in scenes.Entries)

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneQuickFix.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneQuickFix.cs
@@ -132,6 +132,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
 
                 using (WriteLockCookie.Create(yamlFile.IsPhysical()))
                 {
+                    // An empty array is represented by a flow sequence node with no elements. `scenes: []`
                     if (scenesNode is IFlowSequenceNode)
                     {
                         var blockSequenceNode = CreateBlockSequenceNode(mySceneName, myGuid, myUnityModule);

--- a/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneQuickFix.cs
+++ b/resharper/resharper-unity/src/Rider/CSharp/Feature/Services/QuickFixes/SceneManagerLoadSceneQuickFix.cs
@@ -128,7 +128,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
                 var yamlFile = editorBuildSettings.GetDominantPsiFile<YamlLanguage>() as IYamlFile;
                 Assertion.Assert(yamlFile != null, "yamlFile != null");
 
-                var scenesNode = GetSceneCollection(yamlFile);
+                var scenesNode = GetSceneCollection<INode>(yamlFile);
 
                 using (WriteLockCookie.Create(yamlFile.IsPhysical()))
                 {
@@ -136,7 +136,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
                     {
                         var blockSequenceNode = CreateBlockSequenceNode(mySceneName, myGuid, myUnityModule);
                         LowLevelModificationUtil.ReplaceChildRange(scenesNode, scenesNode, blockSequenceNode);
-                    } else if (scenesNode is IBlockSequenceNode)
+                    }
+                    else if (scenesNode is IBlockSequenceNode)
                     {
                         var blockSequenceNode = CreateBlockSequenceNode(mySceneName, myGuid, myUnityModule);
                         LowLevelModificationUtil.AddChild(scenesNode, YamlTokenType.INDENT.Create("  "));
@@ -157,7 +158,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
 
             public override string Text => $"Add '{mySceneName}' to build settings";
 
-            private IBlockSequenceNode CreateBlockSequenceNode(string sceneName, Guid guid, IPsiModule module)
+            private static IBlockSequenceNode CreateBlockSequenceNode(string sceneName, Guid guid, IPsiModule module)
             {
                 var buffer = new StringBuffer($"EditorBuildSettings:\n  m_Scenes:\n  - enabled: 1\n    path: Assets/{sceneName}.unity\n    guid: {guid:N}");
                 var languageService = YamlLanguage.Instance.LanguageService().NotNull();
@@ -165,8 +166,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.Services.QuickF
                 var file = (languageService.CreateParser(lexer, module, null) as IYamlParser)
                     .NotNull("Not yaml parser").ParseFile() as IYamlFile;
 
-                var sceneRecord = GetSceneCollection((file.Documents.First().Body.BlockNode as IBlockMappingNode)
-                    .NotNull("blockMappingNode != null")) as IBlockSequenceNode;
+                var sceneRecord = GetSceneCollection<IBlockSequenceNode>(file);
                 SandBox.CreateSandBoxFor(sceneRecord.NotNull("sceneRecord != null"), module);
                 return sceneRecord;
             }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/EditorBuildSettingsAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/EditorBuildSettingsAssetHandler.cs
@@ -17,6 +17,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         {
             myLogger = logger;
         }
+
         public bool IsApplicable(IPsiSourceFile sourceFile)
         {
             return sourceFile.Name.Equals("EditorBuildSettings.asset") && sourceFile.GetLocation().SniffYamlHeader();
@@ -25,42 +26,35 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         public void Build(IPsiSourceFile sourceFile, ProjectSettingsCacheItem cacheItem)
         {
             var file = sourceFile.GetDominantPsiFile<YamlLanguage>() as IYamlFile;
-            var scenesArray = GetSceneCollection(file);
+            if (file == null)
+                return;
 
+            var scenesArray = GetSceneCollection<IBlockSequenceNode>(file);
             if (scenesArray == null)
             {
-                myLogger.Error("scenesArray != null");
+                myLogger.Error("scenesArray == null");
                 return;
             }
-            
-            if (scenesArray is IBlockSequenceNode node)
+
+            foreach (var s in scenesArray.Entries)
             {
-                foreach (var s in node.Entries)
-                {
-                    var scene = s.Value;
-                    var sceneRecord = scene as IBlockMappingNode;
-                    if (sceneRecord == null)
-                        continue;
+                var scene = s.Value as IBlockMappingNode;
+                if (scene == null || scene.Entries.Count < 2)
+                    continue;
 
-                    if (sceneRecord.Entries.Count < 2)
-                        continue;
-                    
-                    var scenePath = sceneRecord.Entries[1].Content?.Value.GetPlainScalarText();
-                    if (scenePath == null)
-                        continue;
+                var isEnabled = scene.GetSimpleMapEntryPlainScalarText("enabled")?.Equals("1");
 
-                    var path = GetUnityScenePathRepresentation(scenePath);
-                    var isEnabledPlaneScalarNode = sceneRecord.Entries[0].Content?.Value as IPlainScalarNode;
-                    var isEnabled = isEnabledPlaneScalarNode?.Text.GetText().Equals("1");
-                    if (path == null || !isEnabled.HasValue)
-                        continue;
-                    
-                    cacheItem.Scenes.SceneNamesFromBuildSettings.Add(path);
-                    if (!isEnabled.Value)
-                    {
-                        cacheItem.Scenes.DisabledSceneNamesFromBuildSettings.Add(path);
-                    }
-                }
+                var scenePath = scene.GetSimpleMapEntryPlainScalarText("path");
+                if (scenePath == null)
+                    continue;
+
+                var path = GetUnityScenePathRepresentation(scenePath);
+                if (path == null || !isEnabled.HasValue)
+                    continue;
+
+                cacheItem.Scenes.SceneNamesFromBuildSettings.Add(path);
+                if (!isEnabled.Value)
+                    cacheItem.Scenes.DisabledSceneNamesFromBuildSettings.Add(path);
             }
         }
     }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/EditorBuildSettingsAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/EditorBuildSettingsAssetHandler.cs
@@ -42,9 +42,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
                 if (scene == null || scene.Entries.Count < 2)
                     continue;
 
-                var isEnabled = scene.GetSimpleMapEntryPlainScalarText("enabled")?.Equals("1");
+                var isEnabled = scene.GetMapEntryPlainScalarText("enabled")?.Equals("1");
 
-                var scenePath = scene.GetSimpleMapEntryPlainScalarText("path");
+                var scenePath = scene.GetMapEntryPlainScalarText("path");
                 if (scenePath == null)
                     continue;
 

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/InputManagerAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/InputManagerAssetHandler.cs
@@ -4,7 +4,6 @@ using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Files;
 using JetBrains.Util;
-using static JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches.UnityProjectSettingsUtils;
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
 {
@@ -17,7 +16,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         {
             myLogger = logger;
         }
-        
+
         public bool IsApplicable(IPsiSourceFile sourceFile)
         {
             return sourceFile.Name.Equals("InputManager.asset")  && sourceFile.GetLocation().SniffYamlHeader();
@@ -25,31 +24,23 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
 
         public void Build(IPsiSourceFile sourceFile, ProjectSettingsCacheItem cacheItem)
         {
+            var file = sourceFile.GetDominantPsiFile<YamlLanguage>() as IYamlFile;
+            var inputs = file.GetUnityObjectPropertyValue<IBlockSequenceNode>("InputManager", "m_Axes");
+            if (inputs == null)
             {
-                var file = sourceFile.GetDominantPsiFile<YamlLanguage>() as IYamlFile;
-                var inputs = GetCollection(file, "InputManager", "m_Axes");
+                myLogger.Error("inputs == null");
+                return;
+            }
 
-                if (inputs == null)
-                {
-                    myLogger.Error("inputs != null");
-                    return;
-                }
-                
-                if (inputs is IBlockSequenceNode node)
-                {
-                    foreach (var s in node.Entries)
-                    {
-                        var input = s.Value;
-                        var inputRecord = input as IBlockMappingNode;
-                        if (inputRecord == null)
-                            continue;
+            foreach (var s in inputs.Entries)
+            {
+                var input = s.Value as IBlockMappingNode;
+                if (input == null)
+                    continue;
 
-                        var name = inputRecord.Entries.FirstOrDefault(t => t.Key.GetText().Equals(UnityYamlConstants.NameProperty))?.Content.Value.GetPlainScalarText();
-                        
-                        if (!name.IsNullOrEmpty())
-                            cacheItem.Inputs.Add(name);
-                    }
-                }
+                var name = input.GetSimpleMapEntryPlainScalarText(UnityYamlConstants.NameProperty);
+                if (!name.IsNullOrEmpty())
+                    cacheItem.Inputs.Add(name);
             }
         }
     }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/InputManagerAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/InputManagerAssetHandler.cs
@@ -38,7 +38,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
                 if (input == null)
                     continue;
 
-                var name = input.GetSimpleMapEntryPlainScalarText(UnityYamlConstants.NameProperty);
+                var name = input.GetMapEntryPlainScalarText(UnityYamlConstants.NameProperty);
                 if (!name.IsNullOrEmpty())
                     cacheItem.Inputs.Add(name);
             }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
@@ -75,7 +75,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             var document = yamlFile.Documents.FirstOrDefault();
             if (document?.Body.BlockNode is IBlockMappingNode blockMappingNode)
             {
-                var guid = blockMappingNode.GetSimpleMapEntryPlainScalarText("guid");
+                var guid = blockMappingNode.GetMapEntryPlainScalarText("guid");
                 if (guid != null && Guid.TryParse(guid, out var rGuid))
                     return new MetaFileCacheItem(rGuid);
             }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/MetaFileGuidCache.cs
@@ -30,8 +30,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         // Note that Map is a map of *meta file* to asset guid, NOT asset file!
         private readonly Dictionary<FileSystemPath, Guid> myAssetFilePathToGuid =
             new Dictionary<FileSystemPath, Guid>();
-        
-        public Signal<(IPsiSourceFile sourceFile, Guid? oldGuid, Guid? newGuid)> GuidChanged = 
+
+        public Signal<(IPsiSourceFile sourceFile, Guid? oldGuid, Guid? newGuid)> GuidChanged =
             new Signal<(IPsiSourceFile sourceFile, Guid? oldGuid, Guid? newGuid)>("GuidChanged");
 
         public MetaFileGuidCache(Lifetime lifetime, IShellLocks shellLocks, IPersistentIndexManager persistentIndexManager, ILogger logger)
@@ -73,18 +73,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
 
             // Note that this opens the document body chameleon, but we don't care for .meta files. They're lightweight
             var document = yamlFile.Documents.FirstOrDefault();
-
             if (document?.Body.BlockNode is IBlockMappingNode blockMappingNode)
             {
-                foreach (var entry in blockMappingNode.Entries)
-                {
-                    if (entry.Key?.CompareBufferText("guid") == true && entry.Content.Value is IPlainScalarNode valueScalarNode)
-                    {
-                        var guid = valueScalarNode.Text?.GetText();
-                        if (guid != null && Guid.TryParse(guid, out var rGuid))
-                            return new MetaFileCacheItem(rGuid);
-                    }
-                }
+                var guid = blockMappingNode.GetSimpleMapEntryPlainScalarText("guid");
+                if (guid != null && Guid.TryParse(guid, out var rGuid))
+                    return new MetaFileCacheItem(rGuid);
             }
 
             return null;
@@ -103,8 +96,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             {
                 myLogger.Error(e, "An error occured during changing guid");
             }
-            
-            
+
             RemoveFromLocalCache(sourceFile);
             AddToLocalCache(sourceFile, builtPart as MetaFileCacheItem);
             base.Merge(sourceFile, builtPart);
@@ -127,7 +119,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             {
                 myLogger.Error(e, "An error occured during changing guid");
             }
-            
+
             RemoveFromLocalCache(sourceFile);
             base.Drop(sourceFile);
         }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/TagManagerAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/TagManagerAssetHandler.cs
@@ -30,18 +30,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
 
             var document = file.GetFirstMatchingUnityObjectDocument("TagManager");
 
-            var tagsArray = document.GetUnityObjectPropertyValue<IBlockSequenceNode>("tags");
-            if (tagsArray == null)
+            // An empty array will be an IFlowSequenceNode with no elements, otherwise we'll get a block sequence
+            var tagsArrayNode = document.GetUnityObjectPropertyValue<INode>("tags");
+            if (tagsArrayNode == null)
             {
                 myLogger.Error("tagsArray == null");
                 return;
             }
 
-            foreach (var s in tagsArray.EntriesEnumerable)
+            if (tagsArrayNode is IBlockSequenceNode tagsArray)
             {
-                var text = s.Value.GetPlainScalarText();
-                if (!text.IsNullOrEmpty())
-                    cacheItem.Tags.Add(text);
+                foreach (var s in tagsArray.EntriesEnumerable)
+                {
+                    var text = s.Value.GetPlainScalarText();
+                    if (!text.IsNullOrEmpty())
+                        cacheItem.Tags.Add(text);
+                }
             }
 
             var layersArray = document.GetUnityObjectPropertyValue<IBlockSequenceNode>("layers");

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/TagManagerAssetHandler.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/TagManagerAssetHandler.cs
@@ -3,6 +3,7 @@ using JetBrains.ReSharper.Plugins.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Files;
+using JetBrains.Text;
 using JetBrains.Util;
 using static JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches.UnityProjectSettingsUtils;
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
@@ -16,7 +17,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         {
             myLogger = logger;
         }
-        
+
         public bool IsApplicable(IPsiSourceFile sourceFile)
         {
             return sourceFile.Name.Equals("TagManager.asset") && sourceFile.GetLocation().SniffYamlHeader();
@@ -25,6 +26,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
         public void Build(IPsiSourceFile sourceFile, ProjectSettingsCacheItem cacheItem)
         {
             var file = sourceFile.GetDominantPsiFile<YamlLanguage>() as IYamlFile;
+            if (file == null)
+                return;
+
             var tagsArray = GetCollection(file, "TagManager", "tags");
             if (tagsArray == null)
             {
@@ -36,26 +40,42 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             {
                 foreach (var s in node.Entries)
                 {
-                    var text = (s.Value as IPlainScalarNode)?.Text.GetText();
+                    var text = s.Value.GetPlainScalarText();
                     if (!text.IsNullOrEmpty())
                         cacheItem.Tags.Add(text);
                 }
             }
-            
-            var layersArray = GetCollection(file, "TagManager", "layers");
-            if (layersArray == null)
+
+            if (GetCollection(file, "TagManager", "layers") is IBlockSequenceNode layersArray)
             {
-                myLogger.Error("layersArray != null");
-                return;
-            }
-            
-            if (layersArray is IBlockSequenceNode layersNode)
-            {
-                foreach (var s in layersNode.Entries)
+                foreach (var s in layersArray.EntriesEnumerable)
                 {
-                    var text = (s.Value as IPlainScalarNode)?.Text.GetText();
+                    var text = s.Value.GetPlainScalarText();
                     if (!text.IsNullOrEmpty())
                         cacheItem.Layers.Add(text);
+                }
+            }
+            else
+            {
+                // Older versions of Unity (not sure when, but pre-5.6) have a v1 format, where each layer is stored as
+                // a named property - "Builtin Layer 0:" to "Builtin Layer 7:" and "User Layer 8:" to "User Layer 31:"
+                var objectProperties = file.Documents[0].FindRootBlockMapEntries();
+                if (objectProperties == null)
+                {
+                    myLogger.Error("Cannot find v1 or v2 layers");
+                    return;
+                }
+
+                foreach (var entry in objectProperties.EntriesEnumerable)
+                {
+                    var propertyName = entry.Key.GetPlainScalarTextBuffer();
+                    if (propertyName != null &&
+                        (propertyName.StartsWith("Builtin Layer") || propertyName.StartsWith("User Layer")))
+                    {
+                        var text = entry.Content?.Value?.GetPlainScalarText();
+                        if (!text.IsNullOrEmpty())
+                            cacheItem.Layers.Add(text);
+                    }
                 }
             }
         }

--- a/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityProjectSettingsUtils.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/Caches/UnityProjectSettingsUtils.cs
@@ -3,7 +3,6 @@ using System.Text;
 using JetBrains.Annotations;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Modules;
-using JetBrains.ReSharper.Plugins.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.Util.Extension;
@@ -33,30 +32,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             return sb.ToString();
         }
 
-        public static INode GetSceneCollection([NotNull] IYamlFile file)
+        [CanBeNull]
+        public static T GetSceneCollection<T>([CanBeNull] IYamlFile file)
+            where T : class, INode
         {
-            return GetCollection(file, "EditorBuildSettings", "m_Scenes");
-        }
-
-        public static INode GetCollection([CanBeNull] IYamlFile file, string documentName, string name)
-        {
-            var blockMappingNode = file?.Documents[0].Body.BlockNode as IBlockMappingNode;
-            return GetCollection(blockMappingNode, documentName, name);
-        }
-
-        public static INode GetSceneCollection([CanBeNull] IBlockMappingNode blockMappingNode)
-        {
-            return GetCollection(blockMappingNode, "EditorBuildSettings", "m_Scenes");
-        }
-
-        public static INode GetCollection([CanBeNull] IBlockMappingNode blockMappingNode, string documentName, string name)
-        {
-            var documentEntry = blockMappingNode?.Entries.FirstOrDefault(
-                t => documentName.Equals(t.Key.GetPlainScalarText()))?.Content.Value as IBlockMappingNode;
-
-            var collection = documentEntry?.Entries.FirstOrDefault(t => name.Equals(t.Key.GetPlainScalarText()))?.Content.Value;
-
-            return collection;
+            return file.GetUnityObjectPropertyValue<T>("EditorBuildSettings", "m_Scenes");
         }
 
         public static string GetUnityScenePathRepresentation(string scenePath)

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimationEventsUsages/AnimationExtractor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimationEventsUsages/AnimationExtractor.cs
@@ -54,7 +54,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
 
         private static int ExtractSampleRateFrom([NotNull] IBlockMappingNode root)
         {
-            var sampleRateText = root.GetSimpleMapEntryPlainScalarText("m_SampleRate");
+            var sampleRateText = root.GetMapEntryPlainScalarText("m_SampleRate");
             var foundSampleRate = int.TryParse(sampleRateText, out var sampleRate);
             return foundSampleRate ? sampleRate : throw new AnimationExtractorException();
         }
@@ -88,33 +88,33 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
         [NotNull]
         private static string ExtractAnimationClipNameFrom([NotNull] IBlockMappingNode root)
         {
-            return root.GetSimpleMapEntryPlainScalarText("m_Name") ?? throw new AnimationExtractorException();
+            return root.GetMapEntryPlainScalarText("m_Name") ?? throw new AnimationExtractorException();
         }
 
         [CanBeNull]
         private static Guid? ExtractEventFunctionGuidFrom([NotNull] IBlockMappingNode record)
         {
-            var guidText = record.GetSimpleMapEntryValue<IFlowMappingNode>("objectReferenceParameter")
-                ?.GetSimpleMapEntryPlainScalarText("guid");
+            var guidText = record.GetMapEntryValue<IFlowMappingNode>("objectReferenceParameter")
+                ?.GetMapEntryPlainScalarText("guid");
             return guidText != null ? new Guid(guidText) : (Guid?) null;
         }
 
         private static double ExtractEventFunctionTimeFrom([NotNull] IBlockMappingNode record)
         {
-            var timeText = record.GetSimpleMapEntryPlainScalarText("time");
+            var timeText = record.GetMapEntryPlainScalarText("time");
             return double.TryParse(timeText, out var time) ? time : throw new AnimationExtractorException();
         }
 
         [CanBeNull]
         private static string ExtractEventFunctionNameFrom([NotNull] IBlockMappingNode record)
         {
-            return record.GetSimpleMapEntryPlainScalarText("functionName");
+            return record.GetMapEntryPlainScalarText("functionName");
         }
 
         [NotNull]
         private static IBlockSequenceNode ExtractAnimationEventsFrom([NotNull] IBlockMappingNode root)
         {
-            return root.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Events") ??
+            return root.GetMapEntryValue<IBlockSequenceNode>("m_Events") ??
                    throw new AnimationExtractorException();
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimationEventsUsages/AnimationExtractor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimationEventsUsages/AnimationExtractor.cs
@@ -14,7 +14,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
     {
         [NotNull] private readonly AssetDocument myDocument;
         [NotNull] private readonly IPsiSourceFile myFile;
-        
+
         public AnimationExtractor([NotNull] IPsiSourceFile file,
                                   [NotNull] AssetDocument document)
         {
@@ -38,7 +38,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
         [NotNull, ItemNotNull]
         private List<AnimationUsage> ExtractEventUsage()
         {
-            var root = ExtractRoot();
+            var root = GetUnityObjectProperties();
             var location = CreateReferenceToAnimationClip();
             var animationName = ExtractAnimationClipNameFrom(root);
             var sampleRate = ExtractSampleRateFrom(root);
@@ -54,15 +54,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
 
         private static int ExtractSampleRateFrom([NotNull] IBlockMappingNode root)
         {
-            var sampleRateText = root.FindMapEntryBySimpleKey("m_SampleRate")?.Content?.Value.GetPlainScalarText();
+            var sampleRateText = root.GetSimpleMapEntryPlainScalarText("m_SampleRate");
             var foundSampleRate = int.TryParse(sampleRateText, out var sampleRate);
             return foundSampleRate ? sampleRate : throw new AnimationExtractorException();
         }
 
         [NotNull]
-        private IBlockMappingNode ExtractRoot()
+        private IBlockMappingNode GetUnityObjectProperties()
         {
-            return myDocument.Document.FindRootBlockMapEntries() ?? throw new AnimationExtractorException();
+            return myDocument.Document.GetUnityObjectProperties() ?? throw new AnimationExtractorException();
         }
 
         [NotNull]
@@ -88,40 +88,33 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimationEve
         [NotNull]
         private static string ExtractAnimationClipNameFrom([NotNull] IBlockMappingNode root)
         {
-            return root.FindMapEntryBySimpleKey("m_Name")?.Content?.Value.GetPlainScalarText() ??
-                throw new AnimationExtractorException();
+            return root.GetSimpleMapEntryPlainScalarText("m_Name") ?? throw new AnimationExtractorException();
         }
 
         [CanBeNull]
         private static Guid? ExtractEventFunctionGuidFrom([NotNull] IBlockMappingNode record)
         {
-            var objectReferenceParameterRecord = record
-                .FindMapEntryBySimpleKey("objectReferenceParameter")?
-                .Content?
-                .Value as IFlowMappingNode;
-            var guidText = objectReferenceParameterRecord?
-                .FindMapEntryBySimpleKey("guid")?
-                .Value
-                .GetPlainScalarText();
+            var guidText = record.GetSimpleMapEntryValue<IFlowMappingNode>("objectReferenceParameter")
+                ?.GetSimpleMapEntryPlainScalarText("guid");
             return guidText != null ? new Guid(guidText) : (Guid?) null;
         }
 
         private static double ExtractEventFunctionTimeFrom([NotNull] IBlockMappingNode record)
         {
-            var timeText = record.FindMapEntryBySimpleKey("time")?.Content?.Value.GetPlainScalarText();
+            var timeText = record.GetSimpleMapEntryPlainScalarText("time");
             return double.TryParse(timeText, out var time) ? time : throw new AnimationExtractorException();
         }
-        
+
         [CanBeNull]
         private static string ExtractEventFunctionNameFrom([NotNull] IBlockMappingNode record)
         {
-            return record.FindMapEntryBySimpleKey("functionName")?.Content?.Value.GetPlainScalarText();
+            return record.GetSimpleMapEntryPlainScalarText("functionName");
         }
 
         [NotNull]
         private static IBlockSequenceNode ExtractAnimationEventsFrom([NotNull] IBlockMappingNode root)
         {
-            return root.FindMapEntryBySimpleKey("m_Events")?.Content?.Value as IBlockSequenceNode ??
+            return root.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Events") ??
                    throw new AnimationExtractorException();
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorExtractor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorExtractor.cs
@@ -40,7 +40,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         private AnimatorStateMachineScriptUsage ExtractStateMachine()
         {
             var referenceToAnimatorState = CreateReferenceToAnimatorState();
-            var root = ExtractRoot();
+            var root = GetUnityObjectProperties();
             var stateMachineName = ExtractAnimatorStateNameFrom(root);
             var stateMachineBehavioursAnchors = ExtractStateMachineBehavioursAnchorsFrom(root);
             var childStateMachinesAnchors = ExtractChildStateMachinesAnchors(root);
@@ -73,12 +73,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         private static LocalList<long> ExtractChildAnchors(
             [NotNull] IBlockMappingNode root, string recordKey, string innerRecordKey)
         {
-            var anchors = (root.FindMapEntryBySimpleKey(recordKey)?.Content?.Value as IBlockSequenceNode)?
-                .Entries
+            var anchors = root.GetSimpleMapEntryValue<IBlockSequenceNode>(recordKey)?.Entries
                 .SelectNotNull(t => t?.Value as IBlockMappingNode)
-                .SelectNotNull(t => t.FindMapEntryBySimpleKey(innerRecordKey)?.Content?.Value as IFlowMappingNode)
-                .SelectNotNull(t => t.FindMapEntryBySimpleKey("fileID")?.Value as IPlainScalarNode)
-                .SelectNotNull(t => long.TryParse(t?.GetPlainScalarText(), out var anchor) ? anchor : (long?) null);
+                .SelectNotNull(t => t.GetSimpleMapEntryValue<IFlowMappingNode>(innerRecordKey))
+                .SelectNotNull(t => t.GetSimpleMapEntryPlainScalarText("fileID"))
+                .SelectNotNull(t => long.TryParse(t, out var anchor) ? anchor : (long?) null);
             var list = new LocalList<long>();
             if (anchors is null) return list;
             foreach (var anchor in anchors) list.Add(anchor);
@@ -101,10 +100,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         private AnimatorStateScriptUsage ExtractUsage()
         {
             var referenceToAnimatorState = CreateReferenceToAnimatorState();
-            var root = ExtractRoot();
+            var root = GetUnityObjectProperties();
             var animatorStateName = ExtractAnimatorStateNameFrom(root);
             var stateMachineBehavioursAnchors = ExtractStateMachineBehavioursAnchorsFrom(root);
-            return new AnimatorStateScriptUsage(referenceToAnimatorState, animatorStateName, 
+            return new AnimatorStateScriptUsage(referenceToAnimatorState, animatorStateName,
                 stateMachineBehavioursAnchors);
         }
 
@@ -117,24 +116,21 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         }
 
         [NotNull]
-        private IBlockMappingNode ExtractRoot()
+        private IBlockMappingNode GetUnityObjectProperties()
         {
-            return myDocument.Document.FindRootBlockMapEntries() ?? throw new AnimatorExtractorException();
+            return myDocument.Document.GetUnityObjectProperties() ?? throw new AnimatorExtractorException();
         }
 
         [NotNull]
         private static string ExtractAnimatorStateNameFrom([NotNull] IBlockMappingNode root)
         {
-            var name = root.FindMapEntryBySimpleKey("m_Name")?.Content?.Value?.GetPlainScalarText();
-            if (name is null) throw new AnimatorExtractorException();
-            return name;
+            return root.GetSimpleMapEntryPlainScalarText("m_Name") ?? throw new AnimatorExtractorException();
         }
 
         private static LocalList<long> ExtractStateMachineBehavioursAnchorsFrom([NotNull] IBlockMappingNode root)
         {
-            var node = root.FindMapEntryBySimpleKey("m_StateMachineBehaviours")?.Content?.Value;
-            if (!(node is IBlockSequenceNode record)) return new LocalList<long>();
-            return record.Entries.Aggregate(new LocalList<long>(), AddAnchor);
+            var node = root.GetSimpleMapEntryValue<IBlockSequenceNode>("m_StateMachineBehaviours");
+            return node?.Entries.Aggregate(new LocalList<long>(), AddAnchor) ?? new LocalList<long>();
         }
 
         private static LocalList<long> AddAnchor(LocalList<long> anchors, [NotNull] ISequenceEntry record)
@@ -146,7 +142,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
             anchors.Add(anchor);
             return anchors;
         }
-        
+
         private class AnimatorExtractorException : Exception
         {
         }

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorExtractor.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorExtractor.cs
@@ -73,10 +73,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         private static LocalList<long> ExtractChildAnchors(
             [NotNull] IBlockMappingNode root, string recordKey, string innerRecordKey)
         {
-            var anchors = root.GetSimpleMapEntryValue<IBlockSequenceNode>(recordKey)?.Entries
+            var anchors = root.GetMapEntryValue<IBlockSequenceNode>(recordKey)?.Entries
                 .SelectNotNull(t => t?.Value as IBlockMappingNode)
-                .SelectNotNull(t => t.GetSimpleMapEntryValue<IFlowMappingNode>(innerRecordKey))
-                .SelectNotNull(t => t.GetSimpleMapEntryPlainScalarText("fileID"))
+                .SelectNotNull(t => t.GetMapEntryValue<IFlowMappingNode>(innerRecordKey))
+                .SelectNotNull(t => t.GetMapEntryPlainScalarText("fileID"))
                 .SelectNotNull(t => long.TryParse(t, out var anchor) ? anchor : (long?) null);
             var list = new LocalList<long>();
             if (anchors is null) return list;
@@ -124,12 +124,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         [NotNull]
         private static string ExtractAnimatorStateNameFrom([NotNull] IBlockMappingNode root)
         {
-            return root.GetSimpleMapEntryPlainScalarText("m_Name") ?? throw new AnimatorExtractorException();
+            return root.GetMapEntryPlainScalarText("m_Name") ?? throw new AnimatorExtractorException();
         }
 
         private static LocalList<long> ExtractStateMachineBehavioursAnchorsFrom([NotNull] IBlockMappingNode root)
         {
-            var node = root.GetSimpleMapEntryValue<IBlockSequenceNode>("m_StateMachineBehaviours");
+            var node = root.GetMapEntryValue<IBlockSequenceNode>("m_StateMachineBehaviours");
             return node?.Entries.Aggregate(new LocalList<long>(), AddAnchor) ?? new LocalList<long>();
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorScriptUsagesElementContainer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AnimatorUsages/AnimatorScriptUsagesElementContainer.cs
@@ -9,7 +9,6 @@ using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarchy;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarchy.References;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.Utils;
-using JetBrains.ReSharper.Plugins.Yaml.Psi;
 using JetBrains.ReSharper.Plugins.Yaml.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
@@ -315,12 +314,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AnimatorUsag
         {
             var anchorRaw = AssetUtils.GetAnchorFromBuffer(document.Buffer);
             if (!anchorRaw.HasValue) return null;
-            var guid = (document.Document.FindRootBlockMapEntries()?.Entries)?
-                .Cast<IBlockMappingEntry>()
-                .Where(entry => entry != null && entry.Key.MatchesPlainScalarText("m_Script") && entry.Content != null)
-                .Select(entry => entry.Content.Value.ToHierarchyReference(file) as ExternalReference?)
-                .FirstOrDefault()?
-                .ExternalAssetGuid;
+            var script = document.Document.GetUnityObjectPropertyValue<INode>(UnityYamlConstants.ScriptProperty);
+            var guid = (script.ToHierarchyReference(file) as ExternalReference?)?.ExternalAssetGuid;
             return guid != null ? new AnimatorScript(guid.Value, anchorRaw.Value) : (AnimatorScript?) null;
         }
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetHierarchy/AssetDocumentHierarchyElementContainer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetHierarchy/AssetDocumentHierarchyElementContainer.cs
@@ -27,14 +27,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
         private readonly IPersistentIndexManager myManager;
         private readonly UnityExternalFilesPsiModule myPsiModule;
         private readonly MetaFileGuidCache myMetaFileGuidCache;
-        
+
         private readonly PrefabImportCache myPrefabImportCache;
         private readonly IShellLocks myShellLocks;
         private readonly IEnumerable<IAssetInspectorValueDeserializer> myAssetInspectorValueDeserializers;
 
         private readonly ConcurrentDictionary<IPsiSourceFile, IUnityAssetDataElementPointer> myAssetDocumentsHierarchy =
             new ConcurrentDictionary<IPsiSourceFile, IUnityAssetDataElementPointer>();
-        
+
         public AssetDocumentHierarchyElementContainer(IPersistentIndexManager manager, PrefabImportCache prefabImportCache, IShellLocks shellLocks,
             UnityExternalFilesModuleFactory psiModuleProvider, MetaFileGuidCache metaFileGuidCache, IEnumerable<IAssetInspectorValueDeserializer> assetInspectorValueDeserializers)
         {
@@ -70,31 +70,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
             {
                 var prefabInstance = AssetUtils.GetPrefabInstance(currentAssetSourceFile, assetDocument.Buffer) as LocalReference?;
                 var correspondingSourceObject = AssetUtils.GetCorrespondingSourceObject(currentAssetSourceFile, assetDocument.Buffer) as ExternalReference?;
-                
+
                 if (prefabInstance != null && correspondingSourceObject != null)
                     return new StrippedHierarchyElement(location, prefabInstance.Value, correspondingSourceObject.Value);
-                
+
                 return null;
             }
-            
+
             var gameObject = AssetUtils.GetGameObjectReference(currentAssetSourceFile, assetDocument.Buffer) as LocalReference?;
 
             if (gameObject != null && AssetUtils.IsMonoBehaviourDocument(assetDocument.Buffer))
             {
-                var entries = assetDocument.Document.FindRootBlockMapEntries()?.Entries;
-                if (entries == null)
-                    return null;
-
-                IHierarchyReference documentReference = null;
-
-                foreach (var entry in entries)
-                {
-                    if (entry.Key.MatchesPlainScalarText(UnityYamlConstants.ScriptProperty))
-                    {
-                        documentReference = entry.Content.Value.ToHierarchyReference(currentAssetSourceFile);
-                        break;
-                    }
-                }
+                var documentReference =
+                    assetDocument.Document.GetUnityObjectPropertyValue<INode>(UnityYamlConstants.ScriptProperty)
+                        ?.ToHierarchyReference(currentAssetSourceFile);
 
                 if (documentReference is ExternalReference scriptReference)
                 {
@@ -105,7 +94,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
                 var father = AssetUtils.GetTransformFather(currentAssetSourceFile, assetDocument.Buffer) as LocalReference?;
                 if (father == null)
                     return null;
-                
+
                 var rootIndex = AssetUtils.GetRootIndex(assetDocument.Buffer);
                 return new TransformHierarchy(location, gameObject.Value, father.Value, rootIndex);
             } else if (AssetUtils.IsGameObject(assetDocument.Buffer))
@@ -118,8 +107,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
             } else if (AssetUtils.IsPrefabModification(assetDocument.Buffer))
             {
                 var modification = AssetUtils.GetPrefabModification(assetDocument.Document);
-                var parentTransform = modification?.GetValue("m_TransformParent")?.ToHierarchyReference(currentAssetSourceFile) as LocalReference? ?? LocalReference.Null;
-                var modifications = modification?.GetValue("m_Modifications") as IBlockSequenceNode;
+                var parentTransform =
+                    modification?.GetSimpleMapEntryValue<INode>("m_TransformParent")
+                        ?.ToHierarchyReference(currentAssetSourceFile) as LocalReference? ?? LocalReference.Null;
+                var modifications = modification?.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Modifications");
                 var result = new List<PrefabModification>();
                 if (modifications != null)
                 {
@@ -127,29 +118,30 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
                     {
                         var map = entry.Value as IBlockMappingNode;
 
-                        var target = map?.GetValue("target").ToHierarchyReference(currentAssetSourceFile);
+                        var target = map?.GetSimpleMapEntryValue<INode>("target")
+                            .ToHierarchyReference(currentAssetSourceFile);
                         if (target == null)
                             continue;
-                        
-                        var name = map.GetValue("propertyPath").GetPlainScalarText();
+
+                        var name = map.GetSimpleMapEntryPlainScalarText("propertyPath");
                         if (name == null)
                             continue;
-                        
+
                         var valueNode = map.FindMapEntryBySimpleKey("value")?.Content;
                         if (valueNode == null)
                             continue;
-                        
+
                         IAssetValue value = null;
                         foreach (var assetInspectorValueDeserializer in myAssetInspectorValueDeserializers)
                         {
                             if (assetInspectorValueDeserializer.TryGetInspectorValue(currentAssetSourceFile, valueNode, out value))
                                 break;
                         }
-                        
-                        var objectReference = map.FindMapEntryBySimpleKey("objectReference")?.Content.Value.ToHierarchyReference(currentAssetSourceFile);
-                        
+
+                        var objectReference = map.GetSimpleMapEntryValue<INode>("objectReference").ToHierarchyReference(currentAssetSourceFile);
+
                         var valueRange = valueNode.GetTreeTextRange();
-                        
+
                         result.Add(new PrefabModification(target, name, value,
                             new TextRange(assetDocument.StartOffset + valueRange.StartOffset.Offset,
                                 assetDocument.StartOffset + valueRange.EndOffset.Offset),  objectReference));
@@ -193,7 +185,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
             myShellLocks.AssertReadAccessAllowed();
             if (reference == null)
                 return null;
-            
+
             var sourceFile = GetSourceFile(reference, out var guid);
             if (sourceFile == null || guid == null)
                 return null;
@@ -201,37 +193,37 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
             var element = myAssetDocumentsHierarchy[sourceFile].GetElement(sourceFile, Id) as AssetDocumentHierarchyElement;
             if (element == null)
                 return null;
-            
+
             return element.GetHierarchyElement(guid.Value, reference.LocalDocumentAnchor, prefabImport ? myPrefabImportCache : null);
         }
 
         public AssetDocumentHierarchyElement GetAssetHierarchyFor(IPsiSourceFile sourceFile)
         {
             myShellLocks.AssertReadAccessAllowed();
-            
+
             if (myAssetDocumentsHierarchy.TryGetValue(sourceFile, out var result))
                 return result.GetElement(sourceFile, Id) as AssetDocumentHierarchyElement;
-            
+
             return null;
         }
-        
+
         public AssetDocumentHierarchyElement GetAssetHierarchyFor(LocalReference location, out Guid? guid)
         {
             myShellLocks.AssertReadAccessAllowed();
-            
+
             var sourceFile = GetSourceFile(location, out guid);
             if (sourceFile == null || guid == null)
                 return null;
-            
+
             return myAssetDocumentsHierarchy.GetValueSafe(sourceFile)?.GetElement(sourceFile, Id) as AssetDocumentHierarchyElement;
         }
-        
+
         public IPsiSourceFile GetSourceFile(IHierarchyReference hierarchyReference, out Guid? guid)
         {
             guid = null;
             if (hierarchyReference == null)
                 return null;
-            
+
             myShellLocks.AssertReadAccessAllowed();
             switch (hierarchyReference)
             {
@@ -251,8 +243,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
                     throw new InvalidOperationException();
             }
         }
-        
-        
+
+
         public string Id => nameof(AssetDocumentHierarchyElementContainer);
         public int Order => int.MaxValue;
         public void Invalidate()

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetHierarchy/AssetDocumentHierarchyElementContainer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetHierarchy/AssetDocumentHierarchyElementContainer.cs
@@ -108,9 +108,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
             {
                 var modification = AssetUtils.GetPrefabModification(assetDocument.Document);
                 var parentTransform =
-                    modification?.GetSimpleMapEntryValue<INode>("m_TransformParent")
+                    modification?.GetMapEntryValue<INode>("m_TransformParent")
                         ?.ToHierarchyReference(currentAssetSourceFile) as LocalReference? ?? LocalReference.Null;
-                var modifications = modification?.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Modifications");
+                var modifications = modification?.GetMapEntryValue<IBlockSequenceNode>("m_Modifications");
                 var result = new List<PrefabModification>();
                 if (modifications != null)
                 {
@@ -118,16 +118,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
                     {
                         var map = entry.Value as IBlockMappingNode;
 
-                        var target = map?.GetSimpleMapEntryValue<INode>("target")
+                        var target = map?.GetMapEntryValue<INode>("target")
                             .ToHierarchyReference(currentAssetSourceFile);
                         if (target == null)
                             continue;
 
-                        var name = map.GetSimpleMapEntryPlainScalarText("propertyPath");
+                        var name = map.GetMapEntryPlainScalarText("propertyPath");
                         if (name == null)
                             continue;
 
-                        var valueNode = map.FindMapEntryBySimpleKey("value")?.Content;
+                        var valueNode = map.GetMapEntry("value")?.Content;
                         if (valueNode == null)
                             continue;
 
@@ -138,7 +138,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarc
                                 break;
                         }
 
-                        var objectReference = map.GetSimpleMapEntryValue<INode>("objectReference").ToHierarchyReference(currentAssetSourceFile);
+                        var objectReference = map.GetMapEntryValue<INode>("objectReference").ToHierarchyReference(currentAssetSourceFile);
 
                         var valueRange = valueNode.GetTreeTextRange();
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetUtils.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/AssetUtils.cs
@@ -71,10 +71,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
         public static bool IsStripped(IBuffer buffer) =>
             ourStrippedSearcher.Find(buffer, 0, Math.Min(buffer.Length, 150)) >= 0;
 
-        public static bool IsAnimatorState(IBuffer buffer) => 
+        public static bool IsAnimatorState(IBuffer buffer) =>
             ourAnimatorStateSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
 
-        public static bool IsAnimatorStateMachine(IBuffer buffer) => 
+        public static bool IsAnimatorStateMachine(IBuffer buffer) =>
             ourAnimatorStateMachineSearcher.Find(buffer, 0, Math.Min(buffer.Length, 30)) >= 0;
 
         public static long? GetAnchorFromBuffer(IBuffer buffer)
@@ -205,7 +205,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
         public static IBlockMappingNode GetPrefabModification(IYamlDocument yamlDocument)
         {
             // Prefab instance has a map of modifications, that stores delta of instance and prefab
-            return yamlDocument.GetUnityObjectPropertyValue(UnityYamlConstants.ModificationProperty) as IBlockMappingNode;
+            return yamlDocument.GetUnityObjectPropertyValue<IBlockMappingNode>(UnityYamlConstants.ModificationProperty);
         }
 
         public static IEnumerable<string> GetAllNamesFor(IField field)
@@ -302,7 +302,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches
                 var sourceFile = declaration.GetSourceFile();
                 if (sourceFile == null || !sourceFile.IsValid())
                     continue;
-                        
+
                 if (!typeElement.ShortName.Equals(sourceFile.GetLocation().NameWithoutExtension))
                     continue;
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/UnityEvents/UnityEventsElementContainer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/UnityEvents/UnityEventsElementContainer.cs
@@ -22,7 +22,7 @@ using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.Util;
 using JetBrains.Util.Collections;
-       
+
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
 {
     // UnityEventsElementContainer stores whole index in memory, it is not expected to have millions of methods. In case of high memory usage
@@ -38,7 +38,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
         private readonly AssetDocumentHierarchyElementContainer myAssetDocumentHierarchyElementContainer;
         private readonly ILogger myLogger;
 
-        public UnityEventsElementContainer(ISolution solution, IShellLocks shellLocks, MetaFileGuidCache guidCache, 
+        public UnityEventsElementContainer(ISolution solution, IShellLocks shellLocks, MetaFileGuidCache guidCache,
             AssetDocumentHierarchyElementContainer elementContainer, ILogger logger)
         {
             mySolution = solution;
@@ -47,24 +47,24 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
             myAssetDocumentHierarchyElementContainer = elementContainer;
             myLogger = logger;
         }
-        
+
         private static readonly StringSearcher ourMethodNameSearcher = new StringSearcher("m_MethodName", false);
 
         #region FIND_USAGES_METHODS
-        
+
         private readonly OneToSetMap<IPsiSourceFile, UnityEventData> myPsiSourceFileToEventData = new OneToSetMap<IPsiSourceFile, UnityEventData>();
         private readonly OneToCompactCountingSet<string, IPsiSourceFile> myMethodNameToFilesWithUsages = new OneToCompactCountingSet<string, IPsiSourceFile>();
-        
+
         // for counter, could be remove in case of memory optimization and replaced by low-priority background task, do not forget to
         // add files to `myFilesWithUsages` instead of `myFilesWithPossibleUsages`.
         private readonly OneToCompactCountingSet<string, IPsiSourceFile> myMethodNameToFilesWithPossibleUsages = new OneToCompactCountingSet<string, IPsiSourceFile>();
         private readonly OneToCompactCountingSet<string, AssetMethodUsages> myLocalMethodUsages = new OneToCompactCountingSet<string, AssetMethodUsages>();
 
         #endregion
-        
+
         // Inspector values for unity event support
-        #region UNITY_EVENTS_FIND_USAGES 
-        
+        #region UNITY_EVENTS_FIND_USAGES
+
         // for estimated counter check
         private readonly OneToCompactCountingSet<int, Guid> myUnityEventNameHashToScriptGuids = new OneToCompactCountingSet<int, Guid>();
         private readonly CountingSet<string> myUnityEventsWithModifications = new CountingSet<string>();
@@ -98,35 +98,37 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 return new UnityEventsBuildResult(modifications, new LocalList<UnityEventData>());
 
             var anchor = anchorRaw.Value;
-            
-            var entries = assetDocument.Document.FindRootBlockMapEntries()?.Entries;
+
+            var properties = assetDocument.Document.GetUnityObjectProperties();
+            var entries = properties?.Entries;
             if (entries == null)
                 return new UnityEventsBuildResult(modifications, new LocalList<UnityEventData>());
 
-
-            var location = new LocalReference(currentAssetSourceFile.PsiStorage.PersistentIndex.NotNull("owningPsiPersistentIndex != null"), anchor);
-            var scriptReference = GetScriptReference(currentAssetSourceFile, entries.Value);
+            var scriptReference = properties.GetSimpleMapEntryValue<INode>(UnityYamlConstants.ScriptProperty)
+                    .ToHierarchyReference(currentAssetSourceFile) as ExternalReference?;
             if (scriptReference == null)
                 return new UnityEventsBuildResult(modifications, new LocalList<UnityEventData>());
-            
+
+            var location = new LocalReference(currentAssetSourceFile.PsiStorage.PersistentIndex.NotNull("owningPsiPersistentIndex != null"), anchor);
+
             var result = new LocalList<UnityEventData>();
             foreach (var entry in entries)
             {
                 if (ourMethodNameSearcher.Find(entry.Content.GetTextAsBuffer()) >= 0)
                 {
                     var name = entry.Key.GetPlainScalarText();
-                    if (name == null) 
+                    if (name == null)
                         continue;
-                    
+
                     var rootMap = entry.Content.Value as IBlockMappingNode;
-                    var persistentCallsMap = rootMap.GetValue("m_PersistentCalls") as IBlockMappingNode;
-                    var mCalls = persistentCallsMap.GetValue("m_Calls") as IBlockSequenceNode;
+                    var persistentCallsMap = rootMap.GetSimpleMapEntryValue<IBlockMappingNode>("m_PersistentCalls");
+                    var mCalls = persistentCallsMap.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Calls");
                     if (mCalls == null)
                         continue;
-                    
-                    var eventTypeName = rootMap.GetValue("m_TypeName").GetPlainScalarText();
+
+                    var eventTypeName = rootMap.GetSimpleMapEntryPlainScalarText("m_TypeName");
                     var calls = GetCalls(currentAssetSourceFile, assetDocument, mCalls, name, eventTypeName);
-                    
+
                     result.Add(new UnityEventData(name, location, scriptReference.Value, calls.ToArray()));
                 }
             }
@@ -134,12 +136,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
             return new UnityEventsBuildResult(modifications, result);
         }
 
-        private ExternalReference? GetScriptReference(IPsiSourceFile assetSourceFile, TreeNodeCollection<IBlockMappingEntry> entries)
-        {
-            return entries.FirstOrDefault(t => UnityYamlConstants.ScriptProperty.Equals(t.Key.GetPlainScalarText()))?.Content.Value.ToHierarchyReference(assetSourceFile) as ExternalReference?;
-        }
-
-        private LocalList<AssetMethodUsages> GetCalls(IPsiSourceFile currentAssetSourceFile, AssetDocument assetDocument, IBlockSequenceNode mCalls, string name, string eventTypeName)
+        private LocalList<AssetMethodUsages> GetCalls(IPsiSourceFile currentAssetSourceFile,
+                                                      AssetDocument assetDocument, IBlockSequenceNode mCalls,
+                                                      string name, string eventTypeName)
         {
             var result = new LocalList<AssetMethodUsages>();
             foreach (var call in mCalls.Entries)
@@ -147,29 +146,30 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 var methodDescription = call.Value as IBlockMappingNode;
                 if (methodDescription == null)
                     continue;
-                
-                var target = methodDescription.FindMapEntryBySimpleKey("m_Target")?.Content.Value.ToHierarchyReference(currentAssetSourceFile);
+
+                var target = methodDescription.GetSimpleMapEntryValue<INode>("m_Target")
+                    .ToHierarchyReference(currentAssetSourceFile);
                 if (target == null)
                     continue;
 
-                var methodNameNode = methodDescription.GetValue("m_MethodName");
+                var methodNameNode = methodDescription.GetSimpleMapEntryValue<INode>("m_MethodName");
                 var methodName = methodNameNode?.GetPlainScalarText();
                 if (methodName == null)
                     continue;
 
                 var methodNameRange = methodNameNode.GetTreeTextRange();
-                
-                var arguments = methodDescription.GetValue("m_Arguments") as IBlockMappingNode;
-                var modeText = methodDescription.GetValue("m_Mode")?.GetPlainScalarText();
+
+                var arguments = methodDescription.GetSimpleMapEntryValue<IBlockMappingNode>("m_Arguments");
+                var modeText = methodDescription.GetSimpleMapEntryPlainScalarText("m_Mode");
                 var argMode = EventHandlerArgumentMode.EventDefined;
                 if (int.TryParse(modeText, out var mode))
                 {
                     if (1 <= mode && mode <= 6)
-                        argMode = (EventHandlerArgumentMode) mode;
+                        argMode = (EventHandlerArgumentMode)mode;
                 }
-                
-                var argumentTypeName = arguments.GetValue("m_ObjectArgumentAssemblyTypeName")?.GetPlainScalarText();
-                
+
+                var argumentTypeName = arguments.GetSimpleMapEntryPlainScalarText("m_ObjectArgumentAssemblyTypeName");
+
                 var type = argumentTypeName?.Split(',').FirstOrDefault();
                 if (argMode == EventHandlerArgumentMode.EventDefined)
                     type = eventTypeName?.Split(',').FirstOrDefault();
@@ -179,12 +179,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 var range = new TextRange(assetDocument.StartOffset + methodNameRange.StartOffset.Offset,
                     assetDocument.StartOffset + methodNameRange.EndOffset.Offset);
 
-                result.Add(new AssetMethodUsages( name, methodName, range, currentAssetSourceFile.PsiStorage.PersistentIndex.NotNull("owningPsiPersistentIndex != null"), argMode, type, target));
+                result.Add(new AssetMethodUsages(name, methodName, range,
+                    currentAssetSourceFile.PsiStorage.PersistentIndex.NotNull("owningPsiPersistentIndex != null"),
+                    argMode, type, target));
             }
 
             return result;
         }
-        
+
         public void Drop(IPsiSourceFile currentAssetSourceFile, AssetDocumentHierarchyElement assetDocumentHierarchyElement, IUnityAssetDataElement unityAssetDataElement)
         {
             var element = unityAssetDataElement as UnityEventsDataElement;
@@ -195,19 +197,19 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 myUnityEventNameHashToScriptGuids.Remove(eventName.GetPlatformIndependentHashCode(), guid);
                 myUnityEventNameToSourceFiles.Remove(eventName, currentAssetSourceFile);
                 myUnityEventUsageCount.Add((eventName, guid), -unityEventData.Calls.Count);
-                    
+
                 myUnityEventDatas.Remove((unityEventData.OwningScriptLocation, unityEventData.Name));
                 foreach (var call in unityEventData.Calls)
                 {
-                    myMethodNameToFilesWithUsages.Remove(call.MethodName, currentAssetSourceFile); 
-                
+                    myMethodNameToFilesWithUsages.Remove(call.MethodName, currentAssetSourceFile);
+
                     if (call.TargetScriptReference is ExternalReference)
                     {
                         myMethodNameToFilesWithPossibleUsages.Remove(call.MethodName, currentAssetSourceFile);
                     } else if (call.TargetScriptReference is LocalReference localReference)
                     {
                         var scriptElement = assetDocumentHierarchyElement.GetHierarchyElement(null, localReference.LocalDocumentAnchor, null);
-                        
+
                         if (scriptElement is IScriptComponentHierarchy script)
                         {
                             myLocalMethodUsages.Remove(call.MethodName, new AssetMethodUsages(unityEventData.Name, call.MethodName, TextRange.InvalidRange, 0,
@@ -251,13 +253,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                     else if (method.TargetScriptReference is LocalReference localReference)
                     {
                         var scriptElement = assetDocumentHierarchyElement.GetHierarchyElement(null, localReference.LocalDocumentAnchor, null);
-                        
+
                         // If targetScriptReference points to scene's script, we could extract script guid and calculate buckets for each AssetMethodUsages
                         // For each bucket we need resolve only once and then we could increment counter for declared element by bucket size
                         if (scriptElement is IScriptComponentHierarchy script)
                         {
                             // only for fast resolve & counter
-                            myLocalMethodUsages.Add(method.MethodName, new AssetMethodUsages(unityEventData.Name, method.MethodName, TextRange.InvalidRange, 
+                            myLocalMethodUsages.Add(method.MethodName, new AssetMethodUsages(unityEventData.Name, method.MethodName, TextRange.InvalidRange,
                                 0, method.Mode, method.Type, script.ScriptReference));
                         }
                         else
@@ -275,7 +277,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
         private bool IsPossibleEventHandler(IDeclaredElement declaredElement)
         {
             myShellLocks.AssertReadAccessAllowed();
-            
+
             if (declaredElement is IProperty property)
             {
                 var setter = property.Setter;
@@ -284,7 +286,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
 
                 return false;
             }
-                
+
             return IsPossibleEventHandler(declaredElement.ShortName);
         }
 
@@ -308,7 +310,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                     count += GetAssetUsagesCountInner(getter, out var getterEstimated);
                     estimatedResult |= getterEstimated;
                 }
-                
+
                 if (setter != null)
                 {
                     count += GetAssetUsagesCountInner(setter, out var setterEstimated);
@@ -330,7 +332,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
 
             if (!IsPossibleEventHandler(declaredElement))
                 return 0;
-            
+
             if (myMethodNameToFilesWithPossibleUsages.GetOrEmpty(declaredElement.ShortName).Count > 0)
                 estimatedResult = true;
 
@@ -343,12 +345,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
             {
                 var solution = declaredElement.GetSolution();
                 var module = clrDeclaredElement.Module;
-                    
+
                 // we have already cache guid in merge method for methodData in myLocalUsages
                 var guid = (assetMethodData.TargetScriptReference as ExternalReference?)?.ExternalAssetGuid;
                 if (guid == null)
                     continue;
-                
+
                 var symbolTable = GetReferenceSymbolTable(solution, module, assetMethodData, guid.Value);
                 var resolveResult = symbolTable.GetResolveResult(assetMethodData.MethodName);
                 if (resolveResult.ResolveErrorType == ResolveErrorType.OK && Equals(resolveResult.DeclaredElement, declaredElement))
@@ -364,8 +366,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
         {
             var reference = assetMethodUsages.TargetScriptReference;
             var scriptComponent = myAssetDocumentHierarchyElementContainer.GetHierarchyElement(reference, true) as IScriptComponentHierarchy;
-            var guid = scriptComponent?.ScriptReference.ExternalAssetGuid; 
-            
+            var guid = scriptComponent?.ScriptReference.ExternalAssetGuid;
+
             return guid;
         }
 
@@ -382,7 +384,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                     result.Add(new UnityEventHandlerFindResult(psiSourceFile, declaredElement, methodData, owningScriptLocation, isPrefab));
                 }
             }
-            
+
             myLogger.Trace($"{psiSourceFile.Name} --> {result.Count} usage(s)");
             return result;
         }
@@ -390,12 +392,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
         public int GetUsageCountForEvent(IField field, out bool isEstimated)
         {
             myShellLocks.AssertReadAccessAllowed();
-            
+
             isEstimated = false;
             var containingType = field?.GetContainingType();
             if (containingType == null)
                 return 0;
-            
+
             var guid = AssetUtils.GetGuidFor(myGuidCache, containingType);
             if (guid == null)
                 return 0;
@@ -412,10 +414,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
             if (!isEstimated)
                 isEstimated = AssetUtils.HasPossibleDerivedTypesWithMember(guid.Value, containingType,
                     AssetUtils.GetAllNamesFor(field), myUnityEventNameHashToScriptGuids);
-            
+
             return result;
         }
-        
+
         public IEnumerable<UnityEventSubscriptionFindResult> GetMethodsForUnityEvent(IPsiSourceFile psiSourceFile, IField field)
         {
             myShellLocks.AssertReadAccessAllowed();
@@ -434,12 +436,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 var ownerName = method.OwnerName;
                 if (!names.Contains(ownerName))
                     continue;
-                
+
                 var scriptElement = myAssetDocumentHierarchyElementContainer.GetHierarchyElement(owningScriptLocation, true) as IScriptComponentHierarchy;
                 Assertion.Assert(scriptElement != null, "scriptElement != null");
                 if (scriptElement.ScriptReference.ExternalAssetGuid != guid)
                     continue;
-                
+
                 var symbolTable = GetReferenceSymbolTable(psiSourceFile.GetSolution(), psiSourceFile.GetPsiModule(), method, GetScriptGuid(method));
                 var resolveResult = symbolTable.GetResolveResult(method.MethodName);
                 if (resolveResult.ResolveErrorType == ResolveErrorType.OK)
@@ -471,7 +473,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
 
         public string Id => nameof(UnityEventsElementContainer);
         public int Order => 0;
-        
+
         public void Invalidate()
         {
             myUnityEventUsageCount.Clear();
@@ -500,13 +502,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 foreach (var name in AssetUtils.GetAllNamesFor(field))
                     foreach (var psiSourceFile in myUnityEventNameToSourceFiles.GetValuesSafe(name))
                         result.Add(psiSourceFile);
-                
+
                 return result;
             }
 
             foreach (var sourceFile in myMethodNameToFilesWithUsages.GetValues(shortName))
                 result.Add(sourceFile);
-            
+
             foreach (var sourceFile in myMethodNameToFilesWithPossibleUsages.GetValues(shortName))
                 result.Add(sourceFile);
 

--- a/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/UnityEvents/UnityEventsElementContainer.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/DeferredCaches/UnityEvents/UnityEventsElementContainer.cs
@@ -104,7 +104,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
             if (entries == null)
                 return new UnityEventsBuildResult(modifications, new LocalList<UnityEventData>());
 
-            var scriptReference = properties.GetSimpleMapEntryValue<INode>(UnityYamlConstants.ScriptProperty)
+            var scriptReference = properties.GetMapEntryValue<INode>(UnityYamlConstants.ScriptProperty)
                     .ToHierarchyReference(currentAssetSourceFile) as ExternalReference?;
             if (scriptReference == null)
                 return new UnityEventsBuildResult(modifications, new LocalList<UnityEventData>());
@@ -121,12 +121,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                         continue;
 
                     var rootMap = entry.Content.Value as IBlockMappingNode;
-                    var persistentCallsMap = rootMap.GetSimpleMapEntryValue<IBlockMappingNode>("m_PersistentCalls");
-                    var mCalls = persistentCallsMap.GetSimpleMapEntryValue<IBlockSequenceNode>("m_Calls");
+                    var persistentCallsMap = rootMap.GetMapEntryValue<IBlockMappingNode>("m_PersistentCalls");
+                    var mCalls = persistentCallsMap.GetMapEntryValue<IBlockSequenceNode>("m_Calls");
                     if (mCalls == null)
                         continue;
 
-                    var eventTypeName = rootMap.GetSimpleMapEntryPlainScalarText("m_TypeName");
+                    var eventTypeName = rootMap.GetMapEntryPlainScalarText("m_TypeName");
                     var calls = GetCalls(currentAssetSourceFile, assetDocument, mCalls, name, eventTypeName);
 
                     result.Add(new UnityEventData(name, location, scriptReference.Value, calls.ToArray()));
@@ -147,20 +147,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                 if (methodDescription == null)
                     continue;
 
-                var target = methodDescription.GetSimpleMapEntryValue<INode>("m_Target")
+                var target = methodDescription.GetMapEntryValue<INode>("m_Target")
                     .ToHierarchyReference(currentAssetSourceFile);
                 if (target == null)
                     continue;
 
-                var methodNameNode = methodDescription.GetSimpleMapEntryValue<INode>("m_MethodName");
+                var methodNameNode = methodDescription.GetMapEntryValue<INode>("m_MethodName");
                 var methodName = methodNameNode?.GetPlainScalarText();
                 if (methodName == null)
                     continue;
 
                 var methodNameRange = methodNameNode.GetTreeTextRange();
 
-                var arguments = methodDescription.GetSimpleMapEntryValue<IBlockMappingNode>("m_Arguments");
-                var modeText = methodDescription.GetSimpleMapEntryPlainScalarText("m_Mode");
+                var arguments = methodDescription.GetMapEntryValue<IBlockMappingNode>("m_Arguments");
+                var modeText = methodDescription.GetMapEntryPlainScalarText("m_Mode");
                 var argMode = EventHandlerArgumentMode.EventDefined;
                 if (int.TryParse(modeText, out var mode))
                 {
@@ -168,7 +168,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.UnityEvents
                         argMode = (EventHandlerArgumentMode)mode;
                 }
 
-                var argumentTypeName = arguments.GetSimpleMapEntryPlainScalarText("m_ObjectArgumentAssemblyTypeName");
+                var argumentTypeName = arguments.GetMapEntryPlainScalarText("m_ObjectArgumentAssemblyTypeName");
 
                 var type = argumentTypeName?.Split(',').FirstOrDefault();
                 if (argMode == EventHandlerArgumentMode.EventDefined)

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
@@ -82,6 +82,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
             return GetUnityObjectProperties(document).GetMapEntryValue<T>(key);
         }
 
+        // TODO: Consider adding GetUnityObjectPropertyArray
+        // This would return IBlockSequenceNode for a populated array, or IFlowSequenceNode (with no children) for an
+        // empty array. This would require adding a base ISequenceNode interface which would also help (although block
+        // sequence nodes have a Content chameleon and flow sequence nodes don't)
+
         // This will open the Body chameleon
         [CanBeNull]
         public static IBlockMappingNode GetUnityObjectProperties([CanBeNull] this IYamlDocument document)

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
@@ -11,24 +11,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
     public static class UnityYamlPsiExtensions
     {
         [CanBeNull]
-        public static string AsString([CanBeNull] this INode node)
-        {
-            return node?.GetPlainScalarText();
-        }
-
-        [CanBeNull]
         public static IHierarchyReference ToHierarchyReference([CanBeNull] this INode node, IPsiSourceFile assetSourceFile)
         {
             if (node is IFlowMappingNode flowMappingNode)
             {
-                var localDocumentAnchor = flowMappingNode.FindMapEntryBySimpleKey("fileID")?.Value.AsString();
+                var localDocumentAnchor = flowMappingNode.GetSimpleMapEntryPlainScalarText("fileID");
                 if (localDocumentAnchor == null || !long.TryParse(localDocumentAnchor, out var result))
                     return new LocalReference(0, 0);
 
                 if (result == 0)
                     return LocalReference.Null;
 
-                var externalAssetGuid = flowMappingNode.FindMapEntryBySimpleKey("guid")?.Value.AsString();
+                var externalAssetGuid = flowMappingNode.GetSimpleMapEntryPlainScalarText("guid");
 
                 if (externalAssetGuid == null)
                 {
@@ -49,28 +43,59 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
 
         // This will open the Body chameleon
         [CanBeNull]
-        public static INode GetUnityObjectPropertyValue([CanBeNull] this IYamlDocument document, [NotNull] string key)
+        public static IYamlDocument GetFirstMatchingUnityObjectDocument([CanBeNull] this IYamlFile file, [NotNull] string objectType)
         {
-            // Get the object's properties as a map, and find the property by name
-            return FindRootBlockMapEntries(document).FindMapEntryBySimpleKey(key)?.Content.Value;
+            if (file == null)
+                return null;
+
+            foreach (var document in file.DocumentsEnumerable)
+            {
+                if (document.Body.BlockNode is IBlockMappingNode map)
+                {
+                    // Object type will be the first entry. If it's the required document, return it. For simple assets,
+                    // such as scriptable objects, there will be only one document, most likely of the expected type.
+                    // For other assets, such as scenes, there can be many documents, and can be many matching object
+                    // documents. This will get the first
+                    if (map.FindMapEntryBySimpleKey(objectType) != null)
+                        return document;
+                }
+            }
+
+            return null;
         }
 
         // This will open the Body chameleon
         [CanBeNull]
-        public static IBlockMappingNode FindRootBlockMapEntries([CanBeNull] this IYamlDocument document)
+        public static T GetUnityObjectPropertyValue<T>([CanBeNull] this IYamlFile file, [NotNull] string objectType,
+                                                       [NotNull] string key)
+            where T : class, INode
+        {
+            return file.GetFirstMatchingUnityObjectDocument(objectType)?.GetUnityObjectPropertyValue<T>(key);
+        }
+
+        // This will open the Body chameleon
+        [CanBeNull]
+        public static T GetUnityObjectPropertyValue<T>([CanBeNull] this IYamlDocument document, [NotNull] string key)
+            where T : class, INode
+        {
+            // Get the object's properties as a map, and find the property by name
+            return GetUnityObjectProperties(document).GetSimpleMapEntryValue<T>(key);
+        }
+
+        // This will open the Body chameleon
+        [CanBeNull]
+        public static IBlockMappingNode GetUnityObjectProperties([CanBeNull] this IYamlDocument document)
         {
             // A YAML document has a single root body node, which can more or less be anything (scalar, map or sequence
             // - it's in a block context, but that only affects parsing, and not much). For a Unity YAML document, the
             // root node is a block map, with the key being the type of the serialised object (e.g. MonoBehaviour,
-            // GameObject, Transform) and the value being another block mapping mode. The entries of this map are the
-            // properties of the Unity object.
+            // GameObject, Transform) and the value being another block mapping mode. This method returns the second
+            // block map, which represent the properties of the object. E.g. the m_* values here:
+            // GameObject:
+            //   m_ObjectHideFlags: 0
+            //   m_CorrespondingSourceObject: ...
             var rootBlockMappingNode = document?.Body.BlockNode as IBlockMappingNode;
             return rootBlockMappingNode?.EntriesEnumerable.FirstOrDefault()?.Content.Value as IBlockMappingNode;
-        }
-
-        public static INode GetValue(this IBlockMappingNode document, string key)
-        {
-            return document.FindMapEntryBySimpleKey(key)?.Content?.Value;
         }
     }
 }

--- a/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
+++ b/resharper/resharper-unity/src/Yaml/Psi/UnityYamlPsiExtensions.cs
@@ -15,14 +15,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
         {
             if (node is IFlowMappingNode flowMappingNode)
             {
-                var localDocumentAnchor = flowMappingNode.GetSimpleMapEntryPlainScalarText("fileID");
+                var localDocumentAnchor = flowMappingNode.GetMapEntryPlainScalarText("fileID");
                 if (localDocumentAnchor == null || !long.TryParse(localDocumentAnchor, out var result))
                     return new LocalReference(0, 0);
 
                 if (result == 0)
                     return LocalReference.Null;
 
-                var externalAssetGuid = flowMappingNode.GetSimpleMapEntryPlainScalarText("guid");
+                var externalAssetGuid = flowMappingNode.GetMapEntryPlainScalarText("guid");
 
                 if (externalAssetGuid == null)
                 {
@@ -56,7 +56,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
                     // such as scriptable objects, there will be only one document, most likely of the expected type.
                     // For other assets, such as scenes, there can be many documents, and can be many matching object
                     // documents. This will get the first
-                    if (map.FindMapEntryBySimpleKey(objectType) != null)
+                    if (map.GetMapEntry(objectType) != null)
                         return document;
                 }
             }
@@ -79,7 +79,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi
             where T : class, INode
         {
             // Get the object's properties as a map, and find the property by name
-            return GetUnityObjectProperties(document).GetSimpleMapEntryValue<T>(key);
+            return GetUnityObjectProperties(document).GetMapEntryValue<T>(key);
         }
 
         // This will open the Body chameleon

--- a/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
+++ b/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
@@ -11,7 +11,7 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     [CanBeNull]
     public static string GetPlainScalarText([CanBeNull] this INode node)
     {
-      return node is IPlainScalarNode scalar ? scalar.Text.GetText() : null;
+      return (node as IPlainScalarNode)?.Text.GetText();
     }
 
     [CanBeNull]
@@ -59,6 +59,25 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
       }
 
       return null;
+    }
+
+    [CanBeNull]
+    public static T GetSimpleMapEntryValue<T>([CanBeNull] this IBlockMappingNode mapNode, string keyName)
+      where T : class, INode
+    {
+      return mapNode.FindMapEntryBySimpleKey(keyName)?.Content?.Value as T;
+    }
+
+    [CanBeNull]
+    public static string GetSimpleMapEntryPlainScalarText([CanBeNull] this IBlockMappingNode mapNode, string keyName)
+    {
+      return mapNode.FindMapEntryBySimpleKey(keyName)?.Content?.Value.GetPlainScalarText();
+    }
+
+    [CanBeNull]
+    public static string GetSimpleMapEntryPlainScalarText([CanBeNull] this IFlowMappingNode mapNode, string keyName)
+    {
+      return mapNode.FindMapEntryBySimpleKey(keyName)?.Value.GetPlainScalarText();
     }
   }
 }

--- a/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
+++ b/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
@@ -32,14 +32,14 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     }
 
     [CanBeNull]
-    public static IBlockMappingEntry FindMapEntryBySimpleKey([CanBeNull] this IBlockMappingNode mapNode, string keyName)
+    public static IBlockMappingEntry GetMapEntry([CanBeNull] this IBlockMappingNode mapNode, string simpleKey)
     {
       if (mapNode == null)
         return null;
 
       foreach (var mappingEntry in mapNode.EntriesEnumerable)
       {
-        if (mappingEntry.Key.MatchesPlainScalarText(keyName))
+        if (mappingEntry.Key.MatchesPlainScalarText(simpleKey))
           return mappingEntry;
       }
 
@@ -47,14 +47,14 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     }
 
     [CanBeNull]
-    public static IFlowMapEntry FindMapEntryBySimpleKey([CanBeNull] this IFlowMappingNode mapNode, string keyName)
+    public static IFlowMapEntry GetMapEntry([CanBeNull] this IFlowMappingNode mapNode, string simpleKey)
     {
       if (mapNode == null)
         return null;
 
       foreach (var sequenceEntry in mapNode.EntriesEnumerable)
       {
-        if (sequenceEntry.Key.MatchesPlainScalarText(keyName))
+        if (sequenceEntry.Key.MatchesPlainScalarText(simpleKey))
           return sequenceEntry;
       }
 
@@ -62,22 +62,22 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
     }
 
     [CanBeNull]
-    public static T GetSimpleMapEntryValue<T>([CanBeNull] this IBlockMappingNode mapNode, string keyName)
+    public static T GetMapEntryValue<T>([CanBeNull] this IBlockMappingNode mapNode, string simpleKey)
       where T : class, INode
     {
-      return mapNode.FindMapEntryBySimpleKey(keyName)?.Content?.Value as T;
+      return mapNode.GetMapEntry(simpleKey)?.Content?.Value as T;
     }
 
     [CanBeNull]
-    public static string GetSimpleMapEntryPlainScalarText([CanBeNull] this IBlockMappingNode mapNode, string keyName)
+    public static string GetMapEntryPlainScalarText([CanBeNull] this IBlockMappingNode mapNode, string simpleKey)
     {
-      return mapNode.FindMapEntryBySimpleKey(keyName)?.Content?.Value.GetPlainScalarText();
+      return mapNode.GetMapEntry(simpleKey)?.Content?.Value.GetPlainScalarText();
     }
 
     [CanBeNull]
-    public static string GetSimpleMapEntryPlainScalarText([CanBeNull] this IFlowMappingNode mapNode, string keyName)
+    public static string GetMapEntryPlainScalarText([CanBeNull] this IFlowMappingNode mapNode, string simpleKey)
     {
-      return mapNode.FindMapEntryBySimpleKey(keyName)?.Value.GetPlainScalarText();
+      return mapNode.GetMapEntry(simpleKey)?.Value.GetPlainScalarText();
     }
   }
 }

--- a/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
+++ b/resharper/resharper-yaml/src/Psi/PsiExtensions.cs
@@ -14,6 +14,12 @@ namespace JetBrains.ReSharper.Plugins.Yaml.Psi
       return node is IPlainScalarNode scalar ? scalar.Text.GetText() : null;
     }
 
+    [CanBeNull]
+    public static IBuffer GetPlainScalarTextBuffer([CanBeNull] this INode node)
+    {
+      return (node as IPlainScalarNode)?.Text.GetTextAsBuffer();
+    }
+
     public static bool MatchesPlainScalarText([CanBeNull] this INode node, string value)
     {
       if (node is IPlainScalarNode scalar)


### PR DESCRIPTION
Add support for the old format of `TagManager.asset` where layers were stored as individual properties (`Builtin Layer 0` - `Builtin Layer 7` and `User Layer 8` - `User Layer 31`) instead of as a simple array.

Also refactors the helper methods for working with the YAML PSI and Unity specific PSI helpers.