### PR TITLE
Prevent break on unhandled ExitGUIException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Improve performance showing packages in Unity Explorer when reopening a project ([RIDER-61805](https://youtrack.jetbrains.com/issue/RIDER-61805), [#2105](https://github.com/JetBrains/resharper-unity/pull/2105))
 - Rider: Group Unity run configurations in the run config dialog ([#2081](https://github.com/JetBrains/resharper-unity/pull/2081))
 - Rider: Ignore "break on unhandled exception" setting for IL2CPP players ([RIDER-62321](https://youtrack.jetbrains.com/issue/RIDER-62321), [#2098](https://github.com/JetBrains/resharper-unity/pull/2098))
+- Rider: Ignore unhandled `ExitGUIException` while debugging the editor ([#2119](https://github.com/JetBrains/resharper-unity/pull/2119))
 - Rider: Show localised external Unity documentation if English isn't available ([RIDER-55737](https://youtrack.jetbrains.com/issue/RIDER-55737), [#2050](https://github.com/JetBrains/resharper-unity/pull/2050))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Improve performance showing packages in Unity Explorer when reopening a project ([RIDER-61805](https://youtrack.jetbrains.com/issue/RIDER-61805), [#2105](https://github.com/JetBrains/resharper-unity/pull/2105))
 - Rider: Group Unity run configurations in the run config dialog ([#2081](https://github.com/JetBrains/resharper-unity/pull/2081))
 - Rider: Ignore "break on unhandled exception" setting for IL2CPP players ([RIDER-62321](https://youtrack.jetbrains.com/issue/RIDER-62321), [#2098](https://github.com/JetBrains/resharper-unity/pull/2098))
-- Rider: Ignore unhandled `ExitGUIException` while debugging the editor ([#2119](https://github.com/JetBrains/resharper-unity/pull/2119))
+- Rider: Ignore unhandled `ExitGUIException` while debugging the editor in Unity 2021.2 ([RIDER-64944](https://youtrack.jetbrains.com/issue/RIDER-64944), [#2119](https://github.com/JetBrains/resharper-unity/pull/2119))
 - Rider: Show localised external Unity documentation if English isn't available ([RIDER-55737](https://youtrack.jetbrains.com/issue/RIDER-55737), [#2050](https://github.com/JetBrains/resharper-unity/pull/2050))
 
 ### Fixed

--- a/debugger/debugger-worker/src/Exceptions/UnityUnhandledExceptionHandler.cs
+++ b/debugger/debugger-worker/src/Exceptions/UnityUnhandledExceptionHandler.cs
@@ -1,0 +1,33 @@
+using Mono.Debugger.Soft;
+using Mono.Debugging.Autofac;
+using Mono.Debugging.Soft;
+using Mono.Debugging.Soft.Exceptions;
+
+namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Exceptions
+{
+    [DebuggerSessionComponent(typeof(SoftDebuggerType))]
+    public class UnityUnhandledExceptionHandler : ISoftDebuggerUnhandledExceptionHandler
+    {
+        private readonly IUnityOptions myUnityOptions;
+
+        public UnityUnhandledExceptionHandler(IUnityOptions unityOptions)
+        {
+            myUnityOptions = unityOptions;
+        }
+
+        public bool ShouldContinueOnException(ObjectMirror exception)
+        {
+            if (!myUnityOptions.ExtensionsEnabled)
+                return false;
+
+            // Unity 2021.2 has an upgraded Mono (from 5.12ish to 6.something) and the behaviour around unhandled
+            // exceptions has changed. Previously, Unity's Mono would not break on unhandled exceptions - it would not
+            // notify the debugger. This appears to have been unintentional, and it's not currently clear if this
+            // behaviour will be rolled back. (See also Il2CppAwareSessionOptions)
+            // In the meantime, Unity uses ExitGUIException for control flow - thrown in managed code and caught in
+            // native code. Mono reports this as an unhandled exception, because it is unhandled in managed code. But it
+            // is used to break out of the immediate mode GUI loop, and is used frequently, thrown by the ExitGUI method
+            return exception.Type.FullName == "UnityEngine.ExitGUIException";
+        }
+    }
+}

--- a/debugger/debugger-worker/src/Exceptions/UnityUnhandledExceptionHandler.cs
+++ b/debugger/debugger-worker/src/Exceptions/UnityUnhandledExceptionHandler.cs
@@ -26,7 +26,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Exceptions
             // behaviour will be rolled back. (See also Il2CppAwareSessionOptions)
             // In the meantime, Unity uses ExitGUIException for control flow - thrown in managed code and caught in
             // native code. Mono reports this as an unhandled exception, because it is unhandled in managed code. But it
-            // is used to break out of the immediate mode GUI loop, and is used frequently, thrown by the ExitGUI method
+            // is used to break out of the immediate mode GUI loop, and is thrown frequently while using the Inspector
+            // and other UI (see uses of ExitGUI in the reference source)
             return exception.Type.FullName == "UnityEngine.ExitGUIException";
         }
     }


### PR DESCRIPTION
The Unity 2021.2 beta has an upgraded Mono which now reports unhandled exceptions to the debugger. The previous Mono version (~5.12ish) didn't report unhandled exceptions. This old behaviour does not appear to be deliberate or intentional, and it's not yet clear if this behaviour will be rolled back or not.

However, it has the consequence that the debugger will now frequently stop on unhandled `ExitGUIException`s. These are used as control flow exceptions, thrown in managed code and caught in native code (and therefore considered "unhandled" by Mono and Rider) in order to cancel behaviour in the GUI. The exception is thrown frequently as the user works with the Inspector and other windows, and makes using the Unity editor while debugging very annoying. This PR will ignore any unhandled `ExitGUIException`s for Unity projects.

If the behaviour is rolled back (or even back ported to older Unity versions), the feature is safe - it will only suppress unhandled exceptions with a full name of `UnityEngine.ExitGUIException`. If Unity stop reporting the exception, there will be no exception to match.

Note that this Unity change also means that Rider will break on unhandled exceptions that the user throws, which is a change in behaviour from previous versions. Ironically, this release of Rider suppresses unhandled exceptions in IL2CPP, which has always reported them to the debugger, to better match the old editor behaviour (and it also helps avoid situations with empty call stacks due to exceptions being thrown in library code that IL2CPP doesn't generate debug information for, and/or which doesn't have any managed code to decompile and show). This feature is enabled by default but can be disabled in the settings. We can re-evaluate the default setting for the next release, depending on what Unity decides should be their default unhandled exception strategy.