### PR TITLE
Fix "Show in Unity" for local packages

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/ShowFileInUnityAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/ShowFileInUnityAction.kt
@@ -49,7 +49,7 @@ open class ShowFileInUnityAction : DumbAwareAction() {
             if (value != null)
                 Utils.AllowUnitySetForegroundWindow(value)
 
-            model.showFileInUnity.fire(File(file.path).relativeTo(File(project.projectDir.path)).invariantSeparatorsPath)
+            model.showFileInUnity.fire(file.path)
         }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/NonUserEditableEditorNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/NonUserEditableEditorNotification.kt
@@ -30,8 +30,10 @@ class NonUserEditableEditorNotification : EditorNotifications.Provider<EditorNot
         if (project.isUnityProject() && isNonEditableUnityFile(file)) {
             val panel = EditorNotificationPanel()
             panel.text = "This file is internal to Unity and should not be edited manually."
-            UIUtil.invokeLaterIfNeeded {
-                addShowInUnityAction(project.lifetime, panel, file, project)
+            if (!file.extension.equals("meta", true)) {
+                UIUtil.invokeLaterIfNeeded {
+                    addShowInUnityAction(project.lifetime, panel, file, project)
+                }
             }
             return panel
         }

--- a/unity/.editorconfig
+++ b/unity/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_size = 2

--- a/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
+++ b/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using JetBrains.Collections.Viewable;
 using JetBrains.Rider.Model.Unity.BackendUnity;
 using JetBrains.Rider.Unity.Editor.Navigation;
 using JetBrains.Rider.Unity.Editor.Navigation.Window;
@@ -17,11 +18,11 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
     {
       var modelValue = modelAndLifetime.Model;
       var connectionLifetime = modelAndLifetime.Lifetime;
-      modelValue.ShowUsagesInUnity.Advise(connectionLifetime,  findUsagesResult =>
+      modelValue.ShowUsagesInUnity.Advise(connectionLifetime, findUsagesResult =>
       {
         if (findUsagesResult != null)
         {
-          MainThreadDispatcher.Instance.Queue(() =>
+          MainThreadDispatcher.Instance.Queue(() => // todo: remove MainThreadDispatcher call - not needed
           {
             ExpandMinimizedUnityWindow();
 
@@ -52,7 +53,7 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
       {
         if (result != null)
         {
-          MainThreadDispatcher.Instance.Queue(() =>
+          MainThreadDispatcher.Instance.Queue(() => // todo: remove MainThreadDispatcher call - not needed
           {
             GUI.BringWindowToFront(EditorWindow.GetWindow<SceneView>().GetInstanceID());
             GUI.BringWindowToFront(EditorWindow.GetWindow(typeof(SceneView).Assembly.GetType("UnityEditor.SceneHierarchyWindow")).GetInstanceID());
@@ -64,21 +65,17 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
         }
       });
 
-      modelValue.ShowFileInUnity.Advise(connectionLifetime, result =>
+      modelValue.ShowFileInUnity.AdviseNotNull(connectionLifetime, result =>
       {
-        if (result != null)
+        var matchedUnityPath = AssetDatabase.GetAllAssetPaths()
+          .FirstOrDefault(a =>
+            new FileInfo(Path.GetFullPath(a)).FullName ==
+            new FileInfo(result).FullName); // FileInfo normalizes separators (required on Windows)
+        if (matchedUnityPath != null)
         {
-          var matchedUnityPath = AssetDatabase.GetAllAssetPaths()
-            .FirstOrDefault(a => new FileInfo(Path.GetFullPath(a)).FullName == new FileInfo(result).FullName); // FileInfo normalizes separators (required on Windows)
-          if (matchedUnityPath != null)
-          {
-            MainThreadDispatcher.Instance.Queue(() =>
-            {
-              ExpandMinimizedUnityWindow();
-              EditorUtility.FocusProjectWindow();
-              ShowUtil.ShowFileUsage(matchedUnityPath);
-            });  
-          }
+          ExpandMinimizedUnityWindow();
+          EditorUtility.FocusProjectWindow();
+          ShowUtil.ShowFileUsage(matchedUnityPath);
         }
       });
     }

--- a/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
+++ b/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using JetBrains.Rider.Model.Unity.BackendUnity;
 using JetBrains.Rider.Unity.Editor.Navigation;
@@ -66,13 +67,17 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
       modelValue.ShowFileInUnity.Advise(connectionLifetime, result =>
       {
         if (result != null)
-        {
-          MainThreadDispatcher.Instance.Queue(() =>
+        { 
+          var matchedUnityPath = AssetDatabase.GetAllAssetPaths().FirstOrDefault(a => Path.GetFullPath(a) == result);
+          if (matchedUnityPath != null)
           {
-            ExpandMinimizedUnityWindow();
-            EditorUtility.FocusProjectWindow();
-            ShowUtil.ShowFileUsage(result);
-          });
+            MainThreadDispatcher.Instance.Queue(() =>
+            {
+              ExpandMinimizedUnityWindow();
+              EditorUtility.FocusProjectWindow();
+              ShowUtil.ShowFileUsage(matchedUnityPath);
+            });  
+          }
         }
       });
     }

--- a/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
+++ b/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
@@ -67,8 +67,9 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
       modelValue.ShowFileInUnity.Advise(connectionLifetime, result =>
       {
         if (result != null)
-        { 
-          var matchedUnityPath = AssetDatabase.GetAllAssetPaths().FirstOrDefault(a => Path.GetFullPath(a) == result);
+        {
+          var matchedUnityPath = AssetDatabase.GetAllAssetPaths()
+            .FirstOrDefault(a => new FileInfo(Path.GetFullPath(a)).FullName == new FileInfo(result).FullName); // FileInfo normalizes separators (required on Windows)
           if (matchedUnityPath != null)
           {
             MainThreadDispatcher.Instance.Queue(() =>


### PR DESCRIPTION
This action "Show in Unity" can be called directly on current active file via Shift-Shift or for some files we show a notification in the editor with link to "Show in Unity" action.

This PR fixes the action for local packages and also avoids showing a link in notification for "meta" files.