### PR TITLE
Fix "Show in Unity" for local packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix packages occasionally not showing or updating in Unity Explorer when Unity is not running ([RIDER-62558](https://youtrack.jetbrains.com/issue/RIDER-62558), [#2085](https://github.com/JetBrains/resharper-unity/pull/2085))
 - Rider: Fix "New in This Directory" action not working ([RIDER-64427](https://youtrack.jetbrains.com/issue/RIDER-64427), [DEXP-591679](https://youtrack.jetbrains.com/issue/DEXP-591679), [#2113](https://github.com/JetBrains/resharper-unity/pull/2113))
 - Rider: Fix out of memory exceptions when trying to view very large compiled shader files ([RIDER-65080](https://youtrack.jetbrains.com/issue/RIDER-65080), [#2121](https://github.com/JetBrains/resharper-unity/pull/2121))
-
+- Rider: Fix "Show in Unity" action for local packages ([RIDER-65128](https://youtrack.jetbrains.com/issue/RIDER-65128), [#2123](https://github.com/JetBrains/resharper-unity/pull/2123))
 
 
 ## 2021.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix packages occasionally not showing or updating in Unity Explorer when Unity is not running ([RIDER-62558](https://youtrack.jetbrains.com/issue/RIDER-62558), [#2085](https://github.com/JetBrains/resharper-unity/pull/2085))
 - Rider: Fix "New in This Directory" action not working ([RIDER-64427](https://youtrack.jetbrains.com/issue/RIDER-64427), [DEXP-591679](https://youtrack.jetbrains.com/issue/DEXP-591679), [#2113](https://github.com/JetBrains/resharper-unity/pull/2113))
 - Rider: Fix out of memory exceptions when trying to view very large compiled shader files ([RIDER-65080](https://youtrack.jetbrains.com/issue/RIDER-65080), [#2121](https://github.com/JetBrains/resharper-unity/pull/2121))
-- Rider: Fix "Show in Unity" action for local packages ([RIDER-65128](https://youtrack.jetbrains.com/issue/RIDER-65128), [#2123](https://github.com/JetBrains/resharper-unity/pull/2123))
+- Rider: Fix "Show in Unity" action for local packages ([RIDER-65128](https://youtrack.jetbrains.com/issue/RIDER-65128), [#2124](https://github.com/JetBrains/resharper-unity/pull/2124))
 
 
 ## 2021.1.3

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/ShowFileInUnityAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/ShowFileInUnityAction.kt
@@ -49,7 +49,7 @@ open class ShowFileInUnityAction : DumbAwareAction() {
             if (value != null)
                 Utils.AllowUnitySetForegroundWindow(value)
 
-            model.showFileInUnity.fire(File(file.path).relativeTo(File(project.projectDir.path)).invariantSeparatorsPath)
+            model.showFileInUnity.fire(file.path)
         }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/NonUserEditableEditorNotification.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/ui/NonUserEditableEditorNotification.kt
@@ -30,8 +30,10 @@ class NonUserEditableEditorNotification : EditorNotifications.Provider<EditorNot
         if (project.isUnityProject() && isNonEditableUnityFile(file)) {
             val panel = EditorNotificationPanel()
             panel.text = "This file is internal to Unity and should not be edited manually."
-            UIUtil.invokeLaterIfNeeded {
-                addShowInUnityAction(project.lifetime, panel, file, project)
+            if (!file.extension.equals("meta", true)) {
+                UIUtil.invokeLaterIfNeeded {
+                    addShowInUnityAction(project.lifetime, panel, file, project)
+                }
             }
             return panel
         }

--- a/unity/.editorconfig
+++ b/unity/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_size = 2

--- a/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
+++ b/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using JetBrains.Collections.Viewable;
 using JetBrains.Rider.Model.Unity.BackendUnity;
 using JetBrains.Rider.Unity.Editor.Navigation;
 using JetBrains.Rider.Unity.Editor.Navigation.Window;
 using JetBrains.Rider.Unity.Editor.NonUnity;
 using UnityEditor;
 using UnityEngine;
+using Object = System.Object;
 
 namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
 {
@@ -16,11 +19,11 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
     {
       var modelValue = modelAndLifetime.Model;
       var connectionLifetime = modelAndLifetime.Lifetime;
-      modelValue.ShowUsagesInUnity.Advise(connectionLifetime,  findUsagesResult =>
+      modelValue.ShowUsagesInUnity.Advise(connectionLifetime, findUsagesResult =>
       {
         if (findUsagesResult != null)
         {
-          MainThreadDispatcher.Instance.Queue(() =>
+          MainThreadDispatcher.Instance.Queue(() => // todo: remove MainThreadDispatcher call - not needed
           {
             ExpandMinimizedUnityWindow();
 
@@ -51,7 +54,7 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
       {
         if (result != null)
         {
-          MainThreadDispatcher.Instance.Queue(() =>
+          MainThreadDispatcher.Instance.Queue(() => // todo: remove MainThreadDispatcher call - not needed
           {
             GUI.BringWindowToFront(EditorWindow.GetWindow<SceneView>().GetInstanceID());
             GUI.BringWindowToFront(EditorWindow.GetWindow(typeof(SceneView).Assembly.GetType("UnityEditor.SceneHierarchyWindow")).GetInstanceID());
@@ -63,16 +66,26 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
         }
       });
 
-      modelValue.ShowFileInUnity.Advise(connectionLifetime, result =>
+      modelValue.ShowFileInUnity.AdviseNotNull(connectionLifetime, result =>
       {
-        if (result != null)
+        var fullName = new FileInfo(Path.GetFullPath(result)).FullName;
+        // only works for Assets folder
+        var matchedUnityPath = fullName.Substring(Directory.GetParent(Application.dataPath).FullName.Length + 1);
+
+        if (fullName != new FileInfo(Path.GetFullPath(matchedUnityPath)).FullName)
         {
-          MainThreadDispatcher.Instance.Queue(() =>
-          {
-            ExpandMinimizedUnityWindow();
-            EditorUtility.FocusProjectWindow();
-            ShowUtil.ShowFileUsage(result);
-          });
+          // works for any assets including local packages, but might be slow on big projects
+          matchedUnityPath = AssetDatabase.GetAllAssetPaths()
+            .FirstOrDefault(a =>
+              new FileInfo(Path.GetFullPath(a)).FullName ==
+              new FileInfo(result).FullName); // FileInfo normalizes separators (required on Windows)
+        }
+
+        if (matchedUnityPath != null)
+        {
+          ExpandMinimizedUnityWindow();
+          EditorUtility.FocusProjectWindow();
+          ShowUtil.ShowFileUsage(matchedUnityPath);
         }
       });
     }

--- a/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
+++ b/unity/EditorPlugin/AfterUnity56/Navigation/Initialization.cs
@@ -68,7 +68,7 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
 
       modelValue.ShowFileInUnity.AdviseNotNull(connectionLifetime, result =>
       {
-        var fullName = new FileInfo(Path.GetFullPath(result)).FullName;
+        var fullName = new FileInfo(result).FullName;
         // only works for Assets folder
         var matchedUnityPath = fullName.Substring(Directory.GetParent(Application.dataPath).FullName.Length + 1);
 
@@ -78,7 +78,7 @@ namespace JetBrains.Rider.Unity.Editor.AfterUnity56.Navigation
           matchedUnityPath = AssetDatabase.GetAllAssetPaths()
             .FirstOrDefault(a =>
               new FileInfo(Path.GetFullPath(a)).FullName ==
-              new FileInfo(result).FullName); // FileInfo normalizes separators (required on Windows)
+              fullName); // FileInfo normalizes separators (required on Windows)
         }
 
         if (matchedUnityPath != null)


### PR DESCRIPTION
This action "Show in Unity" can be called directly on current active file via Shift-Shift or for some files we show a notification in the editor with link to "Show in Unity" action.

This PR fixes the action for local packages and also avoids showing a link in notification for "meta" files.
https://youtrack.jetbrains.com/issue/RIDER-65128