### PR TITLE
mark [UnityTearDown] as [MeansImplicitUseAttribute] via external annotations

### DIFF
--- a/resharper/resharper-unity/src/CSharp/Feature/Services/Navigation/GoToUnityUsages/GoToUnityUsagesProvider.cs
+++ b/resharper/resharper-unity/src/CSharp/Feature/Services/Navigation/GoToUnityUsages/GoToUnityUsagesProvider.cs
@@ -47,7 +47,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.Navigation.G
         protected override void ExecuteSearchRequest(IDataContext context, SearchRequest searchRequest, INavigationExecutionHost host)
         {
             var provider = searchRequest.Solution.GetComponent<FindUsagesAsyncViewProviderBase>();
-            var viewFactory = provider.GetFactoryGotoUsages(searchRequest, host, this);
+            var viewFactory = provider.GetFactoryShowUsages(searchRequest, host, this);
             var executer = new SearchRequestExecuter(context, searchRequest, this, host, viewFactory);
             executer.Execute();
         }

--- a/resharper/resharper-unity/src/annotations/UnityEngine.TestRunner.xml
+++ b/resharper/resharper-unity/src/annotations/UnityEngine.TestRunner.xml
@@ -2,4 +2,7 @@
   <member name="T:UnityEngine.TestTools.UnitySetUpAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
+  <member name="T:UnityEngine.TestTools.UnityTearDownAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
 </assembly>


### PR DESCRIPTION
Should I backport [this](https://github.com/JetBrains/resharper-unity/pull/2135/commits/49da3f68b7c7bf9ea5b1f478c9fed67c856126cc) to 212 bugfix?