### PR TITLE
fix RIDER-70098 - MetaTracker for multiple opened solutions

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/MetaTracker.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/MetaTracker.kt
@@ -110,7 +110,7 @@ class MetaTracker : BulkFileListener, VfsBackendRequester, Disposable {
                 }
             }
 
-            if (actions.isEmpty()) return
+            if (actions.isEmpty()) continue
 
             val commandProcessor = CommandProcessor.getInstance()
             var groupId = commandProcessor.currentCommandGroupId
@@ -126,6 +126,7 @@ class MetaTracker : BulkFileListener, VfsBackendRequester, Disposable {
                     }, actions.getCommandName(), groupId)
                 }
             }
+            return // action was handled, so we should not try to process it again with other projects
         }
     }
 

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -108,7 +108,6 @@
     <projectViewPane implementation="com.jetbrains.rider.plugins.unity.explorer.UnityExplorer" id="UnityExplorer" order="first, before SolutionExplorer"/>
     <projectModelViewUpdater implementation="com.jetbrains.rider.plugins.unity.explorer.UnityExplorerProjectModelViewUpdater"/>
     <projectModelViewExtensions implementation="com.jetbrains.rider.plugins.unity.explorer.UnityProjectModelViewExtensions"/>
-    <projectService serviceImplementation="com.jetbrains.rider.plugins.unity.explorer.MetaTracker" preload="true" />
 
     <!-- Project Model -->
     <solutionExplorerCustomization implementation="com.jetbrains.rider.plugins.unity.explorer.UnitySolutionExplorerCustomization" />
@@ -181,6 +180,7 @@
 
   <applicationListeners>
     <listener class="com.jetbrains.rider.plugins.unity.SaveAllTracker" topic="com.intellij.openapi.actionSystem.ex.AnActionListener" />
+    <listener class="com.jetbrains.rider.plugins.unity.explorer.MetaTracker" topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
   </applicationListeners>
 
   <actions>


### PR DESCRIPTION
Correct MetaTracker for the case with multiple opened Unity/non-Unity solutions