### PR TITLE
Fix issues with iOS USB device enumeration app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Add inspection to validate define symbols and expressions and version range in `.asmdef` files ([#2191](https://github.com/JetBrains/resharper-unity/pull/2191))
 - Add code completion for define symbols and package IDs in `.asmdef` files ([#2191](https://github.com/JetBrains/resharper-unity/pull/2191))
 - Rider: Remove "add reference" actions for Unity projects ([#2194](https://github.com/JetBrains/resharper-unity/pull/2194))
+- Rider: Add support for debugging iOS devices over USB on Linux ([#2207](https://github.com/JetBrains/resharper-unity/pull/2207))
 
 ### Changed
 
@@ -55,6 +56,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix UnityYamlMarge integration when all conflicts are automatically resolved ([RIDER-69030](https://youtrack.jetbrains.com/issue/RIDER-69030), [#2188](https://github.com/JetBrains/resharper-unity/pull/2188))
 - Rider: Fix opening non-text files from Unity ([#2182](https://github.com/JetBrains/resharper-unity/pull/2182))
 - Rider: Fix opening files from Unity on Apple Silicon ([RIDER-68877](https://youtrack.jetbrains.com/issue/RIDER-68877), [#2192](https://github.com/JetBrains/resharper-unity/pull/2192))
+- Rider: Fix exception when opening "Attach to Unity Process" dialog with Unity 2021.2, or an older Unity and an M1 Mac ([RIDER-69809](https://youtrack.jetbrains.com/issue/RIDER-69809), [#2207](https://github.com/JetBrains/resharper-unity/pull/2207))
 - ReSharper: Fix asset usage updating when asset is open in VS editor ([#2169](https://github.com/JetBrains/resharper-unity/pull/2169))
 
 

--- a/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/ios_list_usb_devices__net472_.xml
+++ b/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/ios_list_usb_devices__net472_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ios-list-usb-devices" type="DotNetProject" factoryName=".NET Project">
+  <configuration default="false" name="ios-list-usb-devices (net472)" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/build/ios-list-usb-devices/bin/Debug/net472/JetBrains.Rider.Unity.ListIosUsbDevices.exe" />
-    <option name="PROGRAM_PARAMETERS" value="/Applications/Unity/Hub/Editor/2020.3.16f1/PlaybackEngines/iOSSupport 1000" />
+    <option name="PROGRAM_PARAMETERS" value="/Applications/Unity/Hub/Editor/2021.2.0f1/PlaybackEngines/iOSSupport 1000" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/build/ios-list-usb-devices/bin/Debug/net472" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />

--- a/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/ios_list_usb_devices__net5_0_.xml
+++ b/resharper/.idea/.idea.resharper-unity/.idea/runConfigurations/ios_list_usb_devices__net5_0_.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ios-list-usb-devices (net5.0)" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/build/ios-list-usb-devices/bin/Debug/net5.0/JetBrains.Rider.Unity.ListIosUsbDevices.dll" />
+    <option name="PROGRAM_PARAMETERS" value="/Applications/Unity/Hub/Editor/2020.3.21f1/PlaybackEngines/iOSSupport 1000" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/build/ios-list-usb-devices/bin/Debug/net5.0" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/../debugger/ios-list-usb-devices/src/ios-list-usb-devices.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net5.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/resharper/resharper-unity.sln.DotSettings
+++ b/resharper/resharper-unity.sln.DotSettings
@@ -50,5 +50,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaders/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=smcs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=swea/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Usbmuxd/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=VSTU/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
 


### PR DESCRIPTION
This PR fixes some issues with the helper app that's invoked when the Attach to Unity Process dialog starts. This app loads a native library provided by Unity and polls for Apple devices attached via USB. If the iOS Build Support module isn't installed, the helper app isn't invoked.

- [x] Stop throwing exceptions on a background thread. Fixes [RIDER-69809](https://youtrack.jetbrains.com/issue/RIDER-69809). Some versions of macOS will silently ignore this, others will show a "dotnet has unexpectedly quit" dialog
- [x] Update paths to native library for Unity 2021.2. The files have moved into `x64` and `arm64` directories. The app will now try to load the library from the new location and fallback to the location from previous versions
- [x] Load the correct native library when running on M1 Macs. If Rider is running under Rosetta, the helper app will load the `x64` library. If running natively on M1, it will load `arm64`. If running natively on M1 and there is no native install of Unity, it will gracefully not load the library and USB debugging will be unavailable. The [troubleshooting guide](https://github.com/JetBrains/resharper-unity/wiki/Troubleshooting-debugging-Unity-players) linked from the dialog has been updated to include this scenario. (Loading the wrong library is what caused the exception shown in [RIDER-69809](https://youtrack.jetbrains.com/issue/RIDER-69809))
- [x] Support USB debugging on Linux, loading the native library that's available on Linux (and correctly handling the path change for Unity 2021.2)

Note that the change in location for Unity 2021.2 means that older versions of Rider will be unable to load the library with newer versions of Unity, and USB debugging will not be available. Depending on OS, there might also be a crash dialog shown.