### PR TITLE
Drop usages of TestRunner.Abstractions

### DIFF
--- a/resharper/resharper-unity/src/AsmDef/Feature/Services/CodeCompletion/AsmDefDefineConstraintItemsProvider.cs
+++ b/resharper/resharper-unity/src/AsmDef/Feature/Services/CodeCompletion/AsmDefDefineConstraintItemsProvider.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure;
@@ -10,7 +11,6 @@ using JetBrains.ReSharper.Plugins.Unity.JsonNew.Psi;
 using JetBrains.ReSharper.Plugins.Unity.JsonNew.Psi.Tree;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Resources;
-using JetBrains.ReSharper.TestRunner.Abstractions.Extensions;
 using JetBrains.Text;
 using JetBrains.Util;
 

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/ReferenceExpression/BurstStaticReadonlyReadAccessAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/ReferenceExpression/BurstStaticReadonlyReadAccessAnalyzer.cs
@@ -5,7 +5,7 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
-using JetBrains.ReSharper.TestRunner.Abstractions.Extensions;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.BurstCodeAnalysis.Analyzers.ReferenceExpression
 {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/ReferenceExpression/BurstWriteAccessAnalyzer.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/ReferenceExpression/BurstWriteAccessAnalyzer.cs
@@ -4,7 +4,7 @@ using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.ReSharper.TestRunner.Abstractions.Extensions;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.BurstCodeAnalysis.Analyzers.ReferenceExpression
 {

--- a/resharper/resharper-unity/src/CSharp/Daemon/Stages/ContextSystem/CallGraphContext.cs
+++ b/resharper/resharper-unity/src/CSharp/Daemon/Stages/ContextSystem/CallGraphContext.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Daemon.CallGraph;
 using JetBrains.ReSharper.Daemon.CSharp.CallGraph;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.ReSharper.TestRunner.Abstractions.Extensions;
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.ContextSystem
 {
@@ -37,7 +37,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.ContextSystem
             {
                 var collectUsageProcess = daemonProcess.GetStageProcess<CollectUsagesStageProcess>().NotNull();
                 if (collectUsageProcess.SwaExtensionsUsageDataInfo.TryGetValue(CallGraphSwaExtensionProvider.Id, out var dataElement))
-                    myGraphDataElement = dataElement.As<CallGraphDataElement>();
+                    myGraphDataElement = dataElement as CallGraphDataElement;
             }
 
             myStack.Push(new BoundContextTag(CallGraphContextTag.NONE, null));


### PR DESCRIPTION
Related to  #2199

`TestRunner.Abstractions` has copies of NotNull and similar extension methods, but have a fixed version and any usage of its members will raise an error in runtime when the product is updated.