### PR TITLE
Fix registration of tooltip only highlighter for ReSharper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,36 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
+## 2021.3.2
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net213-rtm-2021.3.0...net213)
+* [Milestone](https://github.com/JetBrains/resharper-unity/milestone/51?closed=1)
+
+### Changed
+
+- Stop indexing `.anim` files that are larger than 50Mb ([RIDER-71633](https://youtrack.jetbrains.com/issue/RIDER-71633), [#2229](https://github.com/JetBrains/resharper-unity/pull/2229))
+
+### Fixed
+
+- Rider: Fix starting Unity with project path containing spaces ([RIDER-62209](https://youtrack.jetbrains.com/issue/RIDER-62209), [#2225](https://github.com/JetBrains/resharper-unity/pull/2225))
+- Rider: Fix missing debug output when launching Unity editor or player ([RIDER-71411](https://youtrack.jetbrains.com/issue/RIDER-71411), [#2227](https://github.com/JetBrains/resharper-unity/pull/2227))
+- ReSharper: Fix exception when placing caret on GUID reference in `.asmdef` file ([RSPL-6988](https://youtrack.jetbrains.com/issue/RSPL-6988), [#2234](https://github.com/JetBrains/resharper-unity/pull/2234))
+
+
+
+## 2021.3.1
+* Released: [2021-12-10](https://blog.jetbrains.com/dotnet/2021/12/10/rider-2021-3-1-and-resharper-2021-3-1/)
+* Build: 2021.3.0.216
+* [No code changes](https://github.com/JetBrains/resharper-unity/compare/net213-rtm-2021.3.0...net213-rtm-2021.3.0-rtm-2021.3.1)
+
+
+
 ## 2021.3.0
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net212...net213)
+* Released: [2021-12-08](https://blog.jetbrains.com/dotnet/2021/12/08/rider-2021-3-released/)
+* Build: 2021.3.0.208
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net212...net213-rtm-2021.3.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/48?closed=1)
+* [GitHub release](https://github.com/JetBrains/resharper-unity/releases/tag/net213-rtm-2021.3.0)
+* [ReSharper release](https://resharper-plugins.jetbrains.com/packages/JetBrains.Unity/2021.3.0.208)
 
 ### Added
 

--- a/resharper/resharper-unity/src/AsmDef/Feature/Services/Daemon/Attributes/AsmDefHighlightingAttributeIds.cs
+++ b/resharper/resharper-unity/src/AsmDef/Feature/Services/Daemon/Attributes/AsmDefHighlightingAttributeIds.cs
@@ -2,7 +2,11 @@ using JetBrains.TextControl.DocumentMarkup;
 
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Daemon.Attributes
 {
-    [RegisterHighlighter(GUID_REFERENCE_TOOLTIP, EffectType = EffectType.TEXT)]
+    // Rider doesn't support an empty set of attributes (all the implementations of IRiderHighlighterModelCreator
+    // return null), so we must define something. If we define an EffectType, ReSharper throws if we don't define it
+    // properly. But this is just a tooltip, and should have EffectType.NONE. So define one dummy attribute, this keeps
+    // both Rider and ReSharper happy
+    [RegisterHighlighter(GUID_REFERENCE_TOOLTIP, FontFamily = "Unused")]
     public static class AsmDefHighlightingAttributeIds
     {
         public const string GUID_REFERENCE_TOOLTIP = "ReSharper AsmDef GUID Reference Tooltip";

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -10,7 +10,7 @@ productVersion=2021.3
 # Revision for plugin version, appended to productVersion, e.g. 2020.2.2
 # Used for published version, plus retrieving correct changelog notes
 # TODO: Should ideally come from the TC build. Manually incrementing for each release is error prone (RIDER-49929)
-maintenanceVersion=0
+maintenanceVersion=2
 
 # Set to "true" on the command line to skip building the dotnet tasks, as a no-op
 # nuget restore and msbuild takes too long


### PR DESCRIPTION
GUID references in a `.asmdef` file show a tooltip with the name of the referenced assembly definition. This `INFO` level highlighter was registered with `TextEffect.TEXT`, but should have been registered with `TextEffect.NONE`.

If registered with `TEXT`, then ReSharper requires non-default values for the highlighter attributes, and throws an exception when trying to use the attribute (e.g. by placing the caret on a GUID reference). If registered with an empty set of attributes, Rider will not pass the details to the front-end and the tooltip is not shown. This change uses `NONE`, so ReSharper ignores the text attributes, and adds one non-default attribute, so that Rider will still pass the highlighter to the frontend (but because it's set to `NONE`, it's ignored.

Resolves part of [RSPL-6988](https://youtrack.jetbrains.com/issue/RSPL-6988).