### PR TITLE
Fix obsolete warnings

### DIFF
--- a/resharper/resharper-json/src/Json/Psi/DeclaredElements/JsonNewDeclaredElementType.cs
+++ b/resharper/resharper-json/src/Json/Psi/DeclaredElements/JsonNewDeclaredElementType.cs
@@ -1,5 +1,5 @@
-﻿using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Psi.Naming.Impl;
+﻿using JetBrains.ReSharper.Plugins.Json.Util;
+using JetBrains.ReSharper.Psi;
 using JetBrains.UI.Icons;
 
 namespace JetBrains.ReSharper.Plugins.Json.Psi.DeclaredElements
@@ -21,8 +21,6 @@ namespace JetBrains.ReSharper.Plugins.Json.Psi.DeclaredElements
         public override bool IsPresentable(PsiLanguageType language) => language.Is<JsonNewLanguage>();
 
         // Obsolete, but the suggested alternative method is missing, and this is still in use in the platform
-#pragma warning disable CS0618
         public virtual bool IsValidName(string name) => NamingUtil.IsIdentifier(name);
-#pragma warning restore CS0618
     }
 }

--- a/resharper/resharper-json/src/Json/Psi/Tree/JsonNewUtil.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/JsonNewUtil.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.ReSharper.Psi.Tree;
@@ -8,22 +9,24 @@ using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree
 {
+    [PublicAPI]
     public static class JsonNewUtil
     {
         public static IJsonNewObject? GetRootObject(this IJsonNewFile file) => file.Value as IJsonNewObject;
 
-        public static bool IsRootObject(this IJsonNewObject? jsonObject) =>
+        public static bool IsRootObject([NotNullWhen(true)] this IJsonNewObject? jsonObject) =>
             JsonNewFileNavigator.GetByValue(jsonObject) != null;
 
-        public static bool IsRootProperty(this IJsonNewMember? member) =>
+        public static bool IsRootProperty([NotNullWhen(true)] this IJsonNewMember? member) =>
             JsonNewObjectNavigator.GetByMember(member).IsRootObject();
 
-        public static bool IsRootPropertyValue(this IJsonNewValue? value, string expectedKey)
+        public static bool IsRootPropertyValue([NotNullWhen(true)] this IJsonNewValue? value, string expectedKey)
         {
             var member = JsonNewMemberNavigator.GetByValue(value);
-            return member.IsRootProperty() && member?.Key == expectedKey;
+            return member.IsRootProperty() && member.Key == expectedKey;
         }
 
+        [ContractAnnotation("node:null => null")]
         public static IJsonNewLiteralExpression? AsStringLiteralValue(this ITreeNode? node)
         {
             if (node is IJsonNewLiteralExpression { ConstantValueType: ConstantValueTypes.String } literal)
@@ -44,6 +47,7 @@ namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree
             return jsonObject.GetFirstPropertyValue<IJsonNewLiteralExpression>(key)?.GetStringValue();
         }
 
+        [ContractAnnotation("jsonValue:null => null")]
         public static IJsonNewMember? GetNamedMemberByValue(this IJsonNewValue? jsonValue, string key)
         {
             var property = JsonNewMemberNavigator.GetByValue(jsonValue);

--- a/resharper/resharper-json/src/Json/Util/NamingUtil.cs
+++ b/resharper/resharper-json/src/Json/Util/NamingUtil.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+namespace JetBrains.ReSharper.Plugins.Json.Util
+{
+    internal class NamingUtil
+    {
+        public static bool IsIdentifier(string name)
+        {
+            if (name.Length == 0)
+                return false;
+            char[] charArray = name.ToCharArray();
+            if (!char.IsLetter(charArray[0]) && charArray[0] != '_')
+                return false;
+            for (int index = 1; index < charArray.Length; ++index)
+            {
+                char c = charArray[index];
+                if (!char.IsLetterOrDigit(c) && c != '_')
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Unity.Rider/CSharp/Feature/RunMarkers/UnityRunMarkerHighlighting.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/CSharp/Feature/RunMarkers/UnityRunMarkerHighlighting.cs
@@ -1,18 +1,20 @@
-using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.Rider.Backend.Features.RunMarkers;
 using JetBrains.Util.Dotnet.TargetFrameworkIds;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.RunMarkers
 {
     [StaticSeverityHighlighting(Severity.INFO, typeof(RunMarkers), OverlapResolve = OverlapResolveKind.NONE)]
     public class UnityRunMarkerHighlighting : RunMarkerHighlighting
     {
-        public UnityRunMarkerHighlighting([NotNull] IMethodDeclaration method, [NotNull] string attributeId,
-            DocumentRange range, TargetFrameworkId targetFrameworkId)
-            : base(method, attributeId, range, targetFrameworkId)
+        public UnityRunMarkerHighlighting(IMethod method, IMethodDeclaration declaration, string attributeId,
+                                          DocumentRange range, TargetFrameworkId targetFrameworkId)
+            : base(method, declaration, attributeId, range, targetFrameworkId)
         {
         }
     }

--- a/resharper/resharper-unity/src/Unity.Rider/CSharp/Feature/RunMarkers/UnityRunMarkerProvider.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/CSharp/Feature/RunMarkers/UnityRunMarkerProvider.cs
@@ -10,6 +10,8 @@ using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.Rider.Backend.Features.RunMarkers;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.RunMarkers
 {
     [Language(typeof(CSharpLanguage))]
@@ -18,18 +20,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.CSharp.Feature.RunMarkers
         public void CollectRunMarkers(IFile file, IContextBoundSettingsStore settings, IHighlightingConsumer consumer)
         {
             if (!file.GetSolution().GetComponent<UnitySolutionTracker>().IsUnityProject.HasTrueValue()) return;
-            if (!(file is ICSharpFile csharpFile)) return;
+            if (file is not ICSharpFile csharpFile) return;
 
             foreach (var declaration in CachedDeclarationsCollector.Run<IMethodDeclaration>(csharpFile))
             {
-                if (!(declaration.DeclaredElement is IMethod method)) continue;
+                if (declaration.DeclaredElement is not { } method) continue;
 
                 if (UnityRunMarkerUtil.IsSuitableStaticMethod(method))
                 {
                     var range = declaration.GetNameDocumentRange();
-                    var highlighting = new UnityRunMarkerHighlighting(
-                        declaration, UnityRunMarkerAttributeIds.RUN_METHOD_MARKER_ID, range,
-                        file.GetPsiModule().TargetFrameworkId);
+                    var highlighting = new UnityRunMarkerHighlighting(method, declaration,
+                        UnityRunMarkerAttributeIds.RUN_METHOD_MARKER_ID, range, file.GetPsiModule().TargetFrameworkId);
                     consumer.AddHighlighting(highlighting, range);
                 }
             }

--- a/resharper/resharper-unity/src/Unity.Rider/Debugger/Host/DebuggerOutputAssemblies/UnityDebuggerOutputAssembliesProviderHost.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/Debugger/Host/DebuggerOutputAssemblies/UnityDebuggerOutputAssembliesProviderHost.cs
@@ -5,12 +5,15 @@ using Debugger.Common.OutputAssemblies;
 using JetBrains.Application.Infra;
 using JetBrains.Debugger.Host.DebuggerOutputAssemblies;
 using JetBrains.Lifetimes;
+using JetBrains.Metadata.Reader.API;
 using JetBrains.Metadata.Utils;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel;
 using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Rider.Backend.Features.Debugger.Utils;
 using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Host.DebuggerOutputAssemblies
 {
@@ -63,7 +66,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Debugger.Host.DebuggerOutputAs
                         projectLocation.Combine("Library/ScriptAssemblies").Combine(outputAssemblyName);
                     if (!unityOutputPath.IsEmpty && unityOutputPath.IsAbsolute)
                     {
-                        var assemblyNameInfo = assemblyInfoDatabase.GetAssemblyName(unityOutputPath);
+                        var assemblyNameInfo = assemblyInfoDatabase.GetAssemblyName(unityOutputPath.ToAssemblyLocation());
                         if (assemblyNameInfo.IsNullOrEmpty())
                         {
                             // The file should always exist - Unity will make sure it's there, as long as there are no

--- a/resharper/resharper-unity/src/Unity.Rider/HlslSupport/ShaderContextCache.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/HlslSupport/ShaderContextCache.cs
@@ -10,6 +10,8 @@ using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Util;
 using JetBrains.Util.Caches;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.HlslSupport
 {
     [SolutionComponent]
@@ -19,8 +21,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.HlslSupport
         private readonly InjectedHlslFileLocationTracker myLocationTracker;
         private readonly DocumentManager myManager;
         private readonly ILogger myLogger;
-        private readonly DirectMappedCache<VirtualFileSystemPath, IRangeMarker> myShaderContext = new DirectMappedCache<VirtualFileSystemPath, IRangeMarker>(100);
-    
+        private readonly DirectMappedCache<VirtualFileSystemPath, IRangeMarker> myShaderContext = new(100);
+
         public ShaderContextCache(ISolution solution, InjectedHlslFileLocationTracker locationTracker, DocumentManager manager, ILogger logger)
         {
             mySolution = solution;
@@ -28,7 +30,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.HlslSupport
             myManager = manager;
             myLogger = logger;
         }
-
 
         public void SetContext(IPsiSourceFile psiSourceFile, CppFileLocation? root)
         {
@@ -65,7 +66,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.HlslSupport
                     var path = myManager.TryGetProjectFile(result.Document)?.Location;
                     if (path != null)
                     {
-                        var location = new CppFileLocation(new FileSystemPathWithRange(path, result.Range));
+                        var location =
+                            new CppFileLocation(new FileSystemPathWithRange(path, result.DocumentRange.TextRange));
                         if (!myLocationTracker.Exists(location))
                         {
                             myLogger.Trace(

--- a/resharper/resharper-unity/src/Unity.Rider/Protocol/BackendUnityProtocol.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/Protocol/BackendUnityProtocol.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using JetBrains.Application.changes;
 using JetBrains.Application.FileSystemTracker;
 using JetBrains.Application.Threading;
@@ -18,6 +17,8 @@ using JetBrains.Rider.Model.Unity.BackendUnity;
 using JetBrains.Rider.Unity.Editor.NonUnity;
 using JetBrains.Util;
 using Newtonsoft.Json;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
 {
@@ -36,12 +37,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
 
         private DateTime myLastChangeTime;
 
-        public BackendUnityProtocol(Lifetime lifetime, ILogger logger,
-            BackendUnityHost backendUnityHost,
-            IScheduler dispatcher, IShellLocks locks, ISolution solution,
-            UnitySolutionTracker unitySolutionTracker, 
-            IFileSystemTracker fileSystemTracker,
-            UnityPluginInstaller pluginInstaller)
+        public BackendUnityProtocol(Lifetime lifetime,
+                                    ILogger logger,
+                                    BackendUnityHost backendUnityHost,
+                                    IScheduler dispatcher,
+                                    IShellLocks locks,
+                                    ISolution solution,
+                                    UnitySolutionTracker unitySolutionTracker,
+                                    IFileSystemTracker fileSystemTracker,
+                                    UnityPluginInstaller pluginInstaller)
         {
             myPluginInstallations = new JetHashSet<VirtualFileSystemPath>();
 
@@ -95,7 +99,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
                 return;
 
             myLogger.Info($"EditorPlugin protocol port {protocolInstance.Port} for Solution: {protocolInstance.SolutionName}.");
-            
+
             var thisSessionLifetime = mySessionLifetimes.Next();
 
             if (protocolInstance.ProtocolGuid != ProtocolCompatibility.ProtocolGuid)
@@ -115,7 +119,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
                     BackwardsCompatibleWireFormat = true
                 };
 
-                var protocol = new Rd.Impl.Protocol("UnityEditorPlugin", new Serializers(thisSessionLifetime, null, null),
+                var protocol = new Rd.Impl.Protocol("UnityEditorPlugin", new Serializers(null, null),
                     new Identities(IdKind.Client), myDispatcher, wire, thisSessionLifetime)
                 {
                     ThrowErrorOnOutOfSyncModels = false
@@ -150,13 +154,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
             }
         }
 
-        [CanBeNull]
-        private ProtocolInstance GetProtocolInstanceData(VirtualFileSystemPath protocolInstancePath)
+        private ProtocolInstance? GetProtocolInstanceData(VirtualFileSystemPath protocolInstancePath)
         {
             if (!protocolInstancePath.ExistsFile)
                 return null;
 
-            List<ProtocolInstance> protocolInstanceList;
+            List<ProtocolInstance>? protocolInstanceList;
             try
             {
                 protocolInstanceList = ProtocolInstance.FromJson(protocolInstancePath.ReadAllText2().Text);
@@ -209,7 +212,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Protocol
             ProtocolGuid = protocolGuid;
         }
 
-        public static List<ProtocolInstance> FromJson(string json)
+        public static List<ProtocolInstance>? FromJson(string json)
         {
             return JsonConvert.DeserializeObject<List<ProtocolInstance>>(json);
         }

--- a/resharper/resharper-unity/src/Unity.Rider/ShaderLab/Daemon/CodeFolding/ShaderLabCodeFoldingProcessor.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/ShaderLab/Daemon/CodeFolding/ShaderLabCodeFoldingProcessor.cs
@@ -5,6 +5,8 @@ using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Parsing;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.ShaderLab.Daemon.CodeFolding
 {
     internal class ShaderLabCodeFoldingProcessor : TreeNodeVisitor<FoldingHighlightingConsumer>, ICodeFoldingProcessor
@@ -33,27 +35,23 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.ShaderLab.Daemon.CodeFolding
         public override void VisitBlockValueNode(IBlockValue blockValue, FoldingHighlightingConsumer consumer)
 #pragma warning restore 672
         {
-            var containingNode = blockValue.GetContainingNode<IBlockCommand>();
-            Assertion.AssertNotNull(containingNode, "containingNode != null");
-            if (containingNode != null)
-                consumer.AddFoldingForBracedConstruct(blockValue.LBrace, blockValue.RBrace, containingNode);
+            var containingNode = blockValue.GetContainingNode<IBlockCommand>()
+                .NotNull("blockValue.GetContainingNode<IBlockCommand>() != null");
+            consumer.AddFoldingForBracedConstruct(blockValue.LBrace, blockValue.RBrace, containingNode);
         }
 
         public override void VisitTexturePropertyValueNode(ITexturePropertyValue texturePropertyValue, FoldingHighlightingConsumer consumer)
         {
+#pragma warning disable 618
             VisitBlockValueNode(texturePropertyValue, consumer);
+#pragma warning restore 618
         }
 
         public override void VisitCgContentNode(ICgContent cgContent, FoldingHighlightingConsumer consumer)
         {
             var range = cgContent.GetHighlightingRange();
             if (!range.IsEmpty)
-            {
-                // TODO: Might be nice to have a better repreentation
-                // This will fold to `CGPROGRAM{...}ENDCG`
-                // But what? `{ CGPROGRAM }`?
                 consumer.AddDefaultPriorityFolding(CodeFoldingAttributes.DEFAULT_FOLDING_ATTRIBUTE, range, "{...}");
-            }
         }
     }
 }

--- a/resharper/resharper-unity/src/Unity.Rider/ShaderLab/Daemon/ContextHighlighters/RiderShaderLabUsageContextHighlighterAvailability.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/ShaderLab/Daemon/ContextHighlighters/RiderShaderLabUsageContextHighlighterAvailability.cs
@@ -4,7 +4,8 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters;
 using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Resources.Shell;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.ShaderLab.Daemon.ContextHighlighters
 {
@@ -13,8 +14,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.ShaderLab.Daemon.ContextHighli
     {
         public override bool IsAvailable(IPsiSourceFile psiSourceFile)
         {
-            return Shell.Instance.IsTestShell ||
-                   psiSourceFile.GetSolution().GetSettingsStore().GetValue(HighlightingSettingsAccessor.HighlightUsages);
+            return psiSourceFile.GetSolution().GetSettingsStore()
+                .GetValue(HighlightingSettingsAccessor.HighlightUsages);
         }
     }
 }

--- a/resharper/resharper-unity/src/Unity.Rider/Unity.Rider.csproj
+++ b/resharper/resharper-unity/src/Unity.Rider/Unity.Rider.csproj
@@ -4,10 +4,8 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Rider</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity.Rider</RootNamespace>
     <LangVersion>9</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath Condition="'$(ReSharperUnityCommonOutputPath)'!=''">$(ReSharperUnityCommonOutputPath)</OutputPath>
-    <!-- TODO: Fix obsolete warnings! -->
-    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <!-- ********** -->
   <ItemGroup Label="Model">

--- a/resharper/resharper-unity/src/Unity.Rider/UnityEditorIntegration/UnityRefreshTracker.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/UnityEditorIntegration/UnityRefreshTracker.cs
@@ -59,9 +59,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.UnityEditorIntegration
 
         public void StartRefresh(RefreshType refreshType)
         {
-#pragma warning disable 4014
             Refresh(myLifetime, refreshType);
-#pragma warning restore 4014
         }
 
         /// <summary>

--- a/resharper/resharper-unity/src/Unity.Rider/Yaml/Feature/Services/Navigation/RiderUnityAssetOccurrenceNavigator.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/Yaml/Feature/Services/Navigation/RiderUnityAssetOccurrenceNavigator.cs
@@ -1,4 +1,3 @@
-using JetBrains.Application.UI.PopupLayout;
 using JetBrains.Application.UI.Tooltips;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Rider.Protocol;
@@ -6,7 +5,10 @@ using JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Navigation;
 using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.DeferredCaches.AssetHierarchy.References;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Pointers;
+using JetBrains.TextControl.CodeWithMe;
 using JetBrains.TextControl.TextControlsManagement;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Rider.Yaml.Feature.Services.Navigation
 {
@@ -17,14 +19,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Yaml.Feature.Services.Navigati
         {
             if (!solution.GetComponent<BackendUnityHost>().IsConnectionEstablished())
             {
-                var textControl = solution.GetComponent<TextControlManager>().LastFocusedTextControl.Value;
+                var textControl = solution.GetComponent<TextControlManager>().LastFocusedTextControlPerClient
+                    .ForCurrentClient();
                 if (textControl == null)
                     return true;
 
                 var tooltipManager = solution.GetComponent<ITooltipManager>();
-                tooltipManager.Show("Start the Unity Editor to view results",
-                    new PopupWindowContextSource(lifetime =>
-                        textControl.PopupWindowContextFactory.CreatePopupWindowContext(lifetime)));
+                tooltipManager.Show("Start the Unity Editor to view results", textControl.PopupWindowContextFactory.ForCaret());
                 return true;
             }
 
@@ -33,7 +34,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Yaml.Feature.Services.Navigati
             if (declaredElement == null)
                 return true;
 
-            findRequestCreator.CreateRequestToUnity(declaredElement, location, true);
+            findRequestCreator.CreateRequestToUnity(declaredElement, location);
             return false;
         }
     }

--- a/resharper/resharper-unity/src/Unity.Shaders/Cg/Daemon/Stages/CgSyntaxHighlightingStage.cs
+++ b/resharper/resharper-unity/src/Unity.Shaders/Cg/Daemon/Stages/CgSyntaxHighlightingStage.cs
@@ -5,13 +5,16 @@ using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Daemon.Stages;
 using JetBrains.ReSharper.Daemon.UsageChecking;
 using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes;
 using JetBrains.ReSharper.Plugins.Unity.Cg.Application.Settings;
 using JetBrains.ReSharper.Plugins.Unity.Cg.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.Cg.Psi.Parsing.TokenNodes;
 using JetBrains.ReSharper.Plugins.Unity.Cg.Psi.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.Util;
+
 // ReSharper disable StringLiteralTypo
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Cg.Daemon.Stages
 {
@@ -140,7 +143,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Cg.Daemon.Stages
             public override void VisitAsmStatementNode(IAsmStatement asmStatementParam, IHighlightingConsumer context)
             {
                 // TODO: custom HighlightingAttributeId
-                context.AddHighlighting(new CgHighlighting(HighlightingAttributeIds.INJECT_STRING_BACKGROUND, asmStatementParam.ContentNode.GetDocumentRange()));
+                context.AddHighlighting(new CgHighlighting(GeneralHighlightingAttributeIds.INJECT_STRING_BACKGROUND, asmStatementParam.ContentNode.GetDocumentRange()));
                 base.VisitAsmStatementNode(asmStatementParam, context);
             }
 
@@ -181,10 +184,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Cg.Daemon.Stages
                     range = node.Parent.GetDocumentRange();
                 if (range.TextRange.IsEmpty)
                 {
-                    if (range.TextRange.EndOffset < range.Document.GetTextLength())
-                        range = range.ExtendRight(1);
-                    else
-                        range = range.ExtendLeft(1);
+                    range = range.TextRange.EndOffset < range.Document.GetTextLength()
+                        ? range.ExtendRight(1)
+                        : range.ExtendLeft(1);
                 }
 
                 return range;

--- a/resharper/resharper-unity/src/Unity.Shaders/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
+++ b/resharper/resharper-unity/src/Unity.Shaders/HlslSupport/Integration/Cpp/UnityGameEngineDirectiveResolver.cs
@@ -22,7 +22,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
         private readonly object myLockObject = new object();
         private readonly ConcurrentDictionary<string, string> myVersionsFromDirectories = new ConcurrentDictionary<string, string>();
         private readonly ConcurrentDictionary<string, string> myPackageLockPaths = new ConcurrentDictionary<string, string>();
-        private bool myCacheInitialized = false;
+        private bool myCacheInitialized;
 
         public UnityGameEngineDirectiveResolver(ISolution solution, UnitySolutionTracker solutionTracker,
                                                 UnityReferencesTracker referencesTracker, ILogger logger)
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
             var solutionFolder = mySolution.SolutionDirectory;
             if (solutionFolder.Combine(path).Exists != FileSystemPath.Existence.Missing)
                 return path;
-            
+
             var pos = path.IndexOf('/') + 1;
             if (pos == -1)
                 return path;
@@ -61,7 +61,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
 
             return packagePath + path.Substring(endPos);
         }
-        
+
         private void ParsePackageLock()
         {
             try
@@ -95,13 +95,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
                                 }
                                 else
                                 {
-                                    var relativePackagePath = VirtualFileSystemPath.Parse("Packages", InteractionContext.SolutionContext).Combine(packagePath);
+                                    var relativePackagePath = VirtualFileSystemPath
+                                        .Parse("Packages", InteractionContext.SolutionContext)
+                                        .Combine(packagePath.AssertRelative());
                                     myPackageLockPaths[packageName] = relativePackagePath.FullPath;
                                 }
                             }
                             else if (source.Equals("registry"))
                             {
-                                var cachedPackagePath = VirtualFileSystemPath.Parse("Library", InteractionContext.SolutionContext).Combine("PackageCache")
+                                var cachedPackagePath = VirtualFileSystemPath
+                                    .Parse("Library", InteractionContext.SolutionContext)
+                                    .Combine("PackageCache")
                                     .Combine(packageName + "@" + version);
                                 myPackageLockPaths[packageName] = cachedPackagePath.FullPath;
                             } else if (source.Equals("git"))
@@ -109,7 +113,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
                                 var hash = (jProperty.Value["hash"] as JValue)?.Value as string;
                                 if (hash == null)
                                     continue;
-                                
+
                                 var cachedPackagePath = VirtualFileSystemPath.Parse("Library", InteractionContext.SolutionContext).Combine("PackageCache")
                                     .Combine(packageName + "@" + hash.Substring(0, Math.Min(hash.Length, 10)));
                                 myPackageLockPaths[packageName] = cachedPackagePath.FullPath;
@@ -151,13 +155,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.HlslSupport.Integration.Cpp
 
             if (myPackageLockPaths.TryGetValue(packageName, out var path))
                 return path;
-            
+
             if (!myVersionsFromDirectories.TryGetValue(packageName, out var version))
                 return null;
-            
+
             var solutionFolder = mySolution.SolutionDirectory;
             var localPackagePath = VirtualFileSystemPath.Parse("Packages", InteractionContext.SolutionContext)
-                .Combine(packageName + "@" + version);
+                .Combine(packageName + "@" + version).AssertRelative();
             if (solutionFolder.Combine(localPackagePath).Exists == FileSystemPath.Existence.File)
                 return localPackagePath.FullPath;
 

--- a/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Daemon/ContextHighlighters/ShaderLabMatchingBraceContextHighlighter.cs
+++ b/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Daemon/ContextHighlighters/ShaderLabMatchingBraceContextHighlighter.cs
@@ -1,9 +1,8 @@
 using System;
-using JetBrains.Annotations;
 using JetBrains.Lifetimes;
 using JetBrains.ReSharper.Daemon.CaretDependentFeatures;
 using JetBrains.ReSharper.Feature.Services.Contexts;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes;
 using JetBrains.ReSharper.Feature.Services.MatchingBrace;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi.Parsing;
@@ -15,6 +14,8 @@ using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl;
 using JetBrains.UI.RichText;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
 {
     // Note that the ContainingBracesContextHighlighterBase base class is for matching
@@ -22,15 +23,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
     [ContainsContextConsumer]
     public class ShaderLabMatchingBraceContextHighlighter : MatchingBraceContextHighlighterBase<ShaderLabLanguage>
     {
-        [CanBeNull, AsyncContextConsumer]
-        public static Action ProcessDataContext(
-            [NotNull] Lifetime lifetime,
-            [NotNull, ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))]
-           IPsiDocumentRangeView psiDocumentRangeView,
-            [NotNull] InvisibleBraceHintManager invisibleBraceHintManager,
-            [NotNull] MatchingBraceSuggester matchingBraceSuggester,
-            [NotNull] MatchingBraceConsumerFactory consumerFactory,
-            [NotNull] HighlightingProlongedLifetime prolongedLifetime)
+        [AsyncContextConsumer]
+        public static Action? ProcessDataContext(
+            Lifetime lifetime,
+            [ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView,
+            InvisibleBraceHintManager invisibleBraceHintManager,
+            MatchingBraceSuggester matchingBraceSuggester,
+            MatchingBraceConsumerFactory consumerFactory,
+            HighlightingProlongedLifetime prolongedLifetime)
         {
             var highlighter = new ShaderLabMatchingBraceContextHighlighter();
             return highlighter.ProcessDataContextImpl(lifetime, prolongedLifetime, psiDocumentRangeView,
@@ -52,10 +52,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
                 }
                 else
                 {
-                    consumer.ConsumeHighlighting(HighlightingAttributeIds.UNMATCHED_BRACE, selectedToken.GetDocumentEndOffset().ExtendLeft(1));
+                    consumer.ConsumeHighlighting(GeneralHighlightingAttributeIds.UNMATCHED_BRACE, selectedToken.GetDocumentEndOffset().ExtendLeft(1));
 
                     if (matchedNode != null)
-                        consumer.ConsumeHighlighting(HighlightingAttributeIds.UNMATCHED_BRACE, matchedNode.GetDocumentStartOffset().ExtendRight(1));
+                        consumer.ConsumeHighlighting(GeneralHighlightingAttributeIds.UNMATCHED_BRACE, matchedNode.GetDocumentStartOffset().ExtendRight(1));
                 }
             }
             else if (selectedTokenType == ShaderLabTokenType.STRING_LITERAL)
@@ -81,10 +81,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
                 }
                 else
                 {
-                    consumer.ConsumeHighlighting(HighlightingAttributeIds.UNMATCHED_BRACE, selectedToken.GetDocumentStartOffset().ExtendRight(1));
+                    consumer.ConsumeHighlighting(GeneralHighlightingAttributeIds.UNMATCHED_BRACE, selectedToken.GetDocumentStartOffset().ExtendRight(1));
 
                     if (matchedNode != null)
-                        consumer.ConsumeHighlighting(HighlightingAttributeIds.UNMATCHED_BRACE, matchedNode.GetDocumentEndOffset().ExtendLeft(1));
+                        consumer.ConsumeHighlighting(GeneralHighlightingAttributeIds.UNMATCHED_BRACE, matchedNode.GetDocumentEndOffset().ExtendLeft(1));
                 }
             }
             else if (selectedTokenType == ShaderLabTokenType.STRING_LITERAL)
@@ -138,14 +138,15 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
                    && tokenType != ShaderLabTokenType.CG_PROGRAM;
         }
 
-        private RichTextBlock GetHintText(ITextControl textControl, ITreeNode lBraceNode)
+        private static RichTextBlock? GetHintText(ITextControl textControl, ITreeNode? lBraceNode)
         {
             if (lBraceNode == null || lBraceNode.GetTokenType() != ShaderLabTokenType.LBRACE)
                 return null;
 
             var parent = lBraceNode.Parent as IBlockValue;
-            var blockCommand = parent?.Parent as IBlockCommand;
-            return blockCommand != null ? MatchingBraceUtil.PrepareRichText(textControl, blockCommand, lBraceNode, true) : null;
+            return parent?.Parent is IBlockCommand blockCommand
+                ? MatchingBraceUtil.PrepareRichText(textControl, blockCommand, lBraceNode, true)
+                : null;
         }
     }
 }

--- a/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsagesContextHighlighter.cs
+++ b/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Daemon/ContextHighlighters/ShaderLabUsagesContextHighlighter.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Lifetimes;
 using JetBrains.ReSharper.Daemon.CaretDependentFeatures;
 using JetBrains.ReSharper.Feature.Services.Contexts;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes;
 using JetBrains.ReSharper.Feature.Services.Navigation.Requests;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
 using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi;
@@ -16,27 +15,29 @@ using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Psi.Tree;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
 {
     [ContainsContextConsumer]
     public class ShaderLabUsagesContextHighlighter : ContextHighlighterBase
     {
-        [NotNull] private readonly IDeclaredElement myDeclaredElement;
-        [CanBeNull] private readonly IDeclaration myDeclarationUnderCaret;
+        private readonly IDeclaredElement myDeclaredElement;
+        private readonly IDeclaration? myDeclarationUnderCaret;
 
-        private ShaderLabUsagesContextHighlighter([NotNull] IDeclaredElement declaredElement, [CanBeNull] IDeclaration declarationUnderCaret)
+        private ShaderLabUsagesContextHighlighter(IDeclaredElement declaredElement, IDeclaration? declarationUnderCaret)
         {
             myDeclaredElement = declaredElement;
             myDeclarationUnderCaret = declarationUnderCaret;
         }
 
-        private const string HIGHLIGHTING_ID = HighlightingAttributeIds.USAGE_OF_ELEMENT_UNDER_CURSOR;
+        private const string HIGHLIGHTING_ID = GeneralHighlightingAttributeIds.USAGE_OF_ELEMENT_UNDER_CURSOR;
 
-        [CanBeNull, AsyncContextConsumer]
-        public static Action ProcessContext(
-            [NotNull] Lifetime lifetime, [NotNull] HighlightingProlongedLifetime prolongedLifetime,
-            [NotNull, ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView,
-            [NotNull] ShaderLabUsageContextHighlighterAvailability contextHighlighterAvailability)
+        [AsyncContextConsumer]
+        public static Action? ProcessContext(
+            Lifetime lifetime, HighlightingProlongedLifetime prolongedLifetime,
+            [ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView,
+            ShaderLabUsageContextHighlighterAvailability contextHighlighterAvailability)
         {
             var psiView = psiDocumentRangeView.View<ShaderLabLanguage>();
 
@@ -52,7 +53,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
             return highlighter.GetDataProcessAction(prolongedLifetime, psiDocumentRangeView);
         }
 
-        private static IDeclaredElement FindDeclaredElement(IPsiView psiView, out IDeclaration declarationUnderCaret)
+        private static IDeclaredElement? FindDeclaredElement(IPsiView psiView, out IDeclaration? declarationUnderCaret)
         {
             declarationUnderCaret = null;
 
@@ -84,7 +85,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Daemon.ContextHighlighters
             var elements = new[] {new DeclaredElementInstance(declaredElement)};
             var searchRequest = new SearchSingleFileDeclaredElementRequest(elements, elements, searchDomain);
 
-            foreach (var occurrence in searchRequest.Search(NullProgressIndicator.Create()))
+            // Search is [CanBeNull] on base type, but derived types always return a value
+            foreach (var occurrence in searchRequest.Search(NullProgressIndicator.Create())!)
             {
                 if (!(occurrence is ReferenceOccurrence referenceOccurrence)) continue;
 

--- a/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Settings/ShaderLabDefaultSettings.cs
+++ b/resharper/resharper-unity/src/Unity.Shaders/ShaderLab/Settings/ShaderLabDefaultSettings.cs
@@ -5,13 +5,17 @@ using JetBrains.ReSharper.Plugins.Unity.ShaderLab.Psi;
 using JetBrains.ReSharper.Psi.PerformanceThreshold.Settings;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.ShaderLab.Settings
 {
     [ShellComponent]
     public class UnityDefaultPerformanceThresholdSettingsProvider : HaveDefaultSettings
     {
         public UnityDefaultPerformanceThresholdSettingsProvider(ILogger logger, ISettingsSchema settingsSchema)
-            : base(logger, settingsSchema) { }
+            : base(settingsSchema, logger)
+        {
+        }
 
         public override void InitDefaultSettings(ISettingsStorageMountPoint mountPoint)
         {

--- a/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
+++ b/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
@@ -7,10 +7,9 @@
          support. We have no need to split by zone -->
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity</RootNamespace>
     <LangVersion>9</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- We still have lots of obsolete warnings from ParserGen, and disabling obsolete warnings totally is too broad -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath Condition="'$(ReSharperUnityCommonOutputPath)'!=''">$(ReSharperUnityCommonOutputPath)</OutputPath>
-    <!-- TODO: Fix obsolete warnings! -->
-    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <!-- ********** -->
   <ItemGroup Label="Cg">

--- a/resharper/resharper-unity/src/Unity/AsmDef/Daemon/ContextHighlighters/AsmDefUsagesContextHighlighter.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Daemon/ContextHighlighters/AsmDefUsagesContextHighlighter.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Lifetimes;
 using JetBrains.ReSharper.Daemon.CaretDependentFeatures;
 using JetBrains.ReSharper.Feature.Services.Contexts;
-using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes;
 using JetBrains.ReSharper.Feature.Services.Navigation.Requests;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
 using JetBrains.ReSharper.Plugins.Json.Psi;
@@ -21,28 +20,30 @@ using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Daemon.ContextHighlighters
 {
     [ContainsContextConsumer]
     public class AsmDefUsagesContextHighlighter : ContextHighlighterBase
     {
-        private const string HIGHLIGHTING_ID = HighlightingAttributeIds.USAGE_OF_ELEMENT_UNDER_CURSOR;
+        private const string HIGHLIGHTING_ID = GeneralHighlightingAttributeIds.USAGE_OF_ELEMENT_UNDER_CURSOR;
 
-        [NotNull] private readonly IDeclaredElement myDeclaredElement;
-        [CanBeNull] private readonly IJsonNewLiteralExpression myLiteralExpressionUnderCaret;
+        private readonly IDeclaredElement myDeclaredElement;
+        private readonly IJsonNewLiteralExpression? myLiteralExpressionUnderCaret;
 
         private AsmDefUsagesContextHighlighter(IDeclaredElement declaredElement,
-                                               [CanBeNull] IJsonNewLiteralExpression literalExpressionUnderCaret)
+                                               IJsonNewLiteralExpression? literalExpressionUnderCaret)
         {
             myDeclaredElement = declaredElement;
             myLiteralExpressionUnderCaret = literalExpressionUnderCaret;
         }
 
-        [CanBeNull, AsyncContextConsumer]
-        public static Action ProcessContext(
+        [AsyncContextConsumer]
+        public static Action? ProcessContext(
             Lifetime lifetime,
-            [NotNull] HighlightingProlongedLifetime prolongedLifetime,
-            [NotNull, ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView
+            HighlightingProlongedLifetime prolongedLifetime,
+            [ContextKey(typeof(ContextHighlighterPsiFileView.ContextKey))] IPsiDocumentRangeView psiDocumentRangeView
         )
         {
             var psiView = psiDocumentRangeView.View<JsonNewLanguage>();
@@ -58,8 +59,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Daemon.ContextHighlighters
             return highlighter.GetDataProcessAction(prolongedLifetime, psiDocumentRangeView);
         }
 
-        private static IDeclaredElement FindDeclaredElement(IPsiView psiView,
-            out IJsonNewLiteralExpression literalExpressionUnderCaret)
+        private static IDeclaredElement? FindDeclaredElement(IPsiView psiView,
+                                                             out IJsonNewLiteralExpression? literalExpressionUnderCaret)
         {
             literalExpressionUnderCaret = null;
 

--- a/resharper/resharper-unity/src/Unity/AsmDef/Extensions.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+﻿using System.Diagnostics.CodeAnalysis;
 using JetBrains.ReSharper.Plugins.Json.Psi.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 
@@ -8,35 +8,33 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef
 {
     public static class Extensions
     {
-        [ContractAnnotation("node:null => false")]
-        public static bool IsNamePropertyValue(this ITreeNode? node) =>
+        public static bool IsNamePropertyValue([NotNullWhen(true)] this ITreeNode? node) =>
             node.AsStringLiteralValue().IsRootPropertyValue("name");
 
-        [ContractAnnotation("node:null => false")]
-        public static bool IsReferencesArrayEntry(this ITreeNode? node)
+        public static bool IsReferencesArrayEntry([NotNullWhen(true)] this ITreeNode? node)
         {
             var value = node.AsStringLiteralValue();
             var array = JsonNewArrayNavigator.GetByValue(value);
             return array.IsRootPropertyValue("references");
         }
 
-        public static bool IsDefineConstraintsArrayEntry(this ITreeNode? node)
+        public static bool IsDefineConstraintsArrayEntry([NotNullWhen(true)] this ITreeNode? node)
         {
             var value = node.AsStringLiteralValue();
             var array = JsonNewArrayNavigator.GetByValue(value);
             return array.IsRootPropertyValue("defineConstraints");
         }
 
-        public static bool IsVersionDefinesObjectNameValue(this ITreeNode? node) =>
+        public static bool IsVersionDefinesObjectNameValue([NotNullWhen(true)] this ITreeNode? node) =>
             IsVersionDefinesObjectPropertyValue(node, "name");
 
-        public static bool IsVersionDefinesObjectExpressionValue(this ITreeNode? node) =>
+        public static bool IsVersionDefinesObjectExpressionValue([NotNullWhen(true)] this ITreeNode? node) =>
             IsVersionDefinesObjectPropertyValue(node, "expression");
 
-        public static bool IsVersionDefinesObjectDefineValue(this ITreeNode? node) =>
+        public static bool IsVersionDefinesObjectDefineValue([NotNullWhen(true)] this ITreeNode? node) =>
             IsVersionDefinesObjectPropertyValue(node, "define");
 
-        private static bool IsVersionDefinesObjectPropertyValue(this ITreeNode? node, string expectedPropertyKey)
+        private static bool IsVersionDefinesObjectPropertyValue([NotNullWhen(true)] this ITreeNode? node, string expectedPropertyKey)
         {
             var value = node.AsStringLiteralValue();
             var defineProperty = value.GetNamedMemberByValue(expectedPropertyKey);

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/MismatchedFilenameProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/MismatchedFilenameProblemAnalyzer.cs
@@ -4,7 +4,7 @@ using JetBrains.ReSharper.Plugins.Unity.AsmDef.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.LiveTemplates;
 using JetBrains.ReSharper.Psi.Util;
 
-#nullable  enable
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Daemon
 {

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Occurrences/AsmDefOccurrenceKindProvider.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Occurrences/AsmDefOccurrenceKindProvider.cs
@@ -3,6 +3,8 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
 using JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Resolve;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Occurrences
 {
     // Group usages of the name element by "Assembly definition reference"
@@ -10,24 +12,18 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Occurrences
     public class AsmDefOccurrenceKindProvider : IOccurrenceKindProvider
     {
         public static readonly OccurrenceKind AssemblyDefinitionReference =
-            new("Assembly definition reference", OccurrenceKind.SemanticAxis);
+            OccurrenceKind.CreateSemantic("Assembly definition reference");
 
-        public ICollection<OccurrenceKind> GetOccurrenceKinds(IOccurrence occurrence)
+        public ICollection<OccurrenceKind>? GetOccurrenceKinds(IOccurrence occurrence)
         {
             if (occurrence is AsmDefNameOccurrence)
-                return new[] {AssemblyDefinitionReference};
+                return new[] { AssemblyDefinitionReference };
 
             var referenceOccurrence = occurrence as ReferenceOccurrence;
             var reference = referenceOccurrence?.PrimaryReference;
-            if (reference is AsmDefNameReference)
-                return new[] {AssemblyDefinitionReference};
-
-            return null;
+            return reference is AsmDefNameReference ? new[] { AssemblyDefinitionReference } : null;
         }
 
-        public IEnumerable<OccurrenceKind> GetAllPossibleOccurrenceKinds()
-        {
-            return new[] {AssemblyDefinitionReference};
-        }
+        public IEnumerable<OccurrenceKind> GetAllPossibleOccurrenceKinds() => new[] { AssemblyDefinitionReference };
     }
 }

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/QuickFixes/RenameFileToMatchAssemblyNameQuickFix.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/QuickFixes/RenameFileToMatchAssemblyNameQuickFix.cs
@@ -11,6 +11,8 @@ using JetBrains.ReSharper.Psi.Util;
 using JetBrains.TextControl;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
 {
     [QuickFix]
@@ -23,7 +25,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
             myLiteral = warning.LiteralExpression;
         }
 
-        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
         {
             var projectFile = myLiteral.GetSourceFile().ToProjectFile();
             if (projectFile == null)
@@ -39,11 +41,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
                 }
                 else
                 {
-                    using (var transactionCookie = solution.CreateTransactionCookie(DefaultAction.Commit, Text,
-                        NullProgressIndicator.Instance))
-                    {
-                        transactionCookie.Rename(projectFile, newName);
-                    }
+                    using var transactionCookie = solution.CreateTransactionCookie(DefaultAction.Commit, Text,
+                        NullProgressIndicator.Create());
+                    transactionCookie.Rename(projectFile, newName);
                 }
             };
         }

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Refactorings/AsmDefNameAtomicRename.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Refactorings/AsmDefNameAtomicRename.cs
@@ -70,13 +70,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Refactorings
             {
                 foreach (var sortedReference in LanguageUtil.GetSortedReferences(pair.Value))
                 {
-#pragma warning disable CS0618
                     // TODO: Update once interruption set refactoring is complete
                     // ProgressIndicator should already have been added to the interruption set. This is the
                     // responsibility of the refactoring subsystem, but it's not clear that this has yet been done
                     // - other rename refactorings are still using this overload
                     InterruptableActivityCookie.CheckAndThrow(pi);
-#pragma warning restore CS0618
 
                     var referenceRange = sortedReference.GetDocumentRange();
 

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/DeclaredElements/AsmDefDeclaredElementType.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/DeclaredElements/AsmDefDeclaredElementType.cs
@@ -1,9 +1,10 @@
 ﻿using System.Linq;
-using JetBrains.Annotations;
 using JetBrains.ProjectModel.Resources;
 using JetBrains.ReSharper.Plugins.Json.Psi.DeclaredElements;
-using JetBrains.ReSharper.Psi.Naming.Impl;
+using JetBrains.ReSharper.Plugins.Unity.Utils;
 using JetBrains.UI.Icons;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.DeclaredElements
 {
@@ -12,7 +13,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.DeclaredElements
         public static readonly AsmDefDeclaredElementType AsmDef = new("assembly definition",
             ProjectModelThemedIcons.Assembly.Id);
 
-        private AsmDefDeclaredElementType(string name, [CanBeNull] IconId imageName)
+        private AsmDefDeclaredElementType(string name, IconId? imageName)
             : base(name, imageName)
         {
         }

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/BurstCodeInsights.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/BurstCodeInsights.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Collections;
-using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.ContextSystem;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
@@ -29,8 +28,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.BurstCodeAnalys
         public IEnumerable<BulbMenuItem> GetBurstActions(IMethodDeclaration methodDeclaration, IReadOnlyCallGraphContext context)
         {
             var result = new CompactList<BulbMenuItem>();
-            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient()
-                .NotNull("myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient() != null");
+            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient();
+            if (textControl == null)
+                return result;
 
             foreach (var bulbProvider in myBulbProviders)
             {

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/BurstCodeInsights.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/BurstCodeAnalysis/Analyzers/BurstCodeInsights.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Collections;
+using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.ContextSystem;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.TextControl;
+using JetBrains.TextControl.CodeWithMe;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.BurstCodeAnalysis.Analyzers
 {
@@ -16,28 +19,26 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.BurstCodeAnalys
         private readonly IEnumerable<IBurstBulbItemsProvider> myBulbProviders;
 
         public BurstCodeInsights(
-            ITextControlManager textControlManager, 
+            ITextControlManager textControlManager,
             IEnumerable<IBurstBulbItemsProvider> bulbProviders)
         {
             myTextControlManager = textControlManager;
             myBulbProviders = bulbProviders;
         }
-        
-        [NotNull]
-        [ItemNotNull]
-        public IEnumerable<BulbMenuItem> GetBurstActions([NotNull] IMethodDeclaration methodDeclaration, IReadOnlyCallGraphContext context)
+
+        public IEnumerable<BulbMenuItem> GetBurstActions(IMethodDeclaration methodDeclaration, IReadOnlyCallGraphContext context)
         {
             var result = new CompactList<BulbMenuItem>();
-            var textControl = myTextControlManager.LastFocusedTextControl.Value;
-            
+            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient()
+                .NotNull("myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient() != null");
+
             foreach (var bulbProvider in myBulbProviders)
             {
                 var menuItems = bulbProvider.GetMenuItems(methodDeclaration, textControl, context);
-                
                 foreach(var item in menuItems)
                     result.Add(item);
-            } 
-            
+            }
+
             return result;
         }
     }

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -15,6 +15,9 @@ using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.ReSharper.Resources.Resources.Icons;
 using JetBrains.TextControl;
+using JetBrains.TextControl.CodeWithMe;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders
 {
@@ -95,7 +98,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         protected override IEnumerable<BulbMenuItem> GetActions(ICSharpDeclaration declaration)
         {
             var result = new List<BulbMenuItem>();
-            var textControl = Solution.GetComponent<ITextControlManager>().LastFocusedTextControl.Value;
+            var textControl = Solution.GetComponent<ITextControlManager>().LastFocusedTextControlPerClient
+                .ForCurrentClient();
             if (declaration is IClassLikeDeclaration classLikeDeclaration &&
                 textControl != null && myUnityApi.IsUnityType(classLikeDeclaration.DeclaredElement))
             {

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
@@ -5,7 +5,6 @@ using JetBrains.Application.Settings;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Application.UI.Help;
 using JetBrains.Application.UI.Icons.CommonThemedIcons;
-using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Feature.Services.Daemon;
@@ -181,8 +180,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             if (!iconsEnabled)
                 return EmptyList<BulbMenuItem>.Instance;
 
-            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient()
-                .NotNull("myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient() != null");
+            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient();
+            if (textControl == null)
+                return EmptyList<BulbMenuItem>.Instance;
+
             var result = new List<BulbMenuItem>();
 
             foreach (var provider in myMenuItemProviders)

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/UnityCommonIconProvider.cs
@@ -5,6 +5,7 @@ using JetBrains.Application.Settings;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Application.UI.Help;
 using JetBrains.Application.UI.Icons.CommonThemedIcons;
+using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Feature.Services.Daemon;
@@ -21,7 +22,10 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.TextControl;
+using JetBrains.TextControl.CodeWithMe;
 using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.IconsProviders
 {
@@ -29,12 +33,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
     public class UnityCommonIconProvider
     {
         protected readonly IApplicationWideContextBoundSettingStore SettingsStore;
-        protected readonly UnityApi UnityApi;
         protected readonly PerformanceCriticalContextProvider PerformanceContextProvider;
+        private readonly UnityApi myUnityApi;
         private readonly ISolution mySolution;
         private readonly ITextControlManager myTextControlManager;
         private readonly IEnumerable<IPerformanceAnalysisBulbItemsProvider> myMenuItemProviders;
-       
+
         public UnityCommonIconProvider(ISolution solution, UnityApi unityApi,
                                        IApplicationWideContextBoundSettingStore settingsStore,
                                        PerformanceCriticalContextProvider performanceContextProvider,
@@ -42,7 +46,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         {
             mySolution = solution;
             myTextControlManager = solution.GetComponent<ITextControlManager>();
-            UnityApi = unityApi;
+            myUnityApi = unityApi;
             SettingsStore = settingsStore;
             PerformanceContextProvider = performanceContextProvider;
             myMenuItemProviders = menuItemProviders;
@@ -69,23 +73,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
         {
             // gutter mark
             var actions = GetActions(cSharpDeclaration, context);
-            
+
             consumer.AddHotHighlighting(PerformanceContextProvider, cSharpDeclaration,
                 SettingsStore.BoundSettingsStore, text, tooltip, context, actions, true);
         }
 
         protected IReadOnlyList<BulbMenuItem> GetEventFunctionActions(ICSharpDeclaration declaration, IReadOnlyCallGraphContext context)
         {
-            if (!(declaration is IMethodDeclaration methodDeclaration)) 
+            if (!(declaration is IMethodDeclaration methodDeclaration))
                 return EmptyList<BulbMenuItem>.Instance;
-            
-            var declaredElement = methodDeclaration.DeclaredElement;
-            var textControl = mySolution.GetComponent<ITextControlManager>().LastFocusedTextControl.Value;
 
-            if (textControl == null || declaredElement == null) 
+            var declaredElement = methodDeclaration.DeclaredElement;
+            var textControl = mySolution.GetComponent<ITextControlManager>().LastFocusedTextControlPerClient.ForCurrentClient();
+            if (textControl == null || declaredElement == null)
                 return EmptyList<BulbMenuItem>.Instance;
-            
-            var isCoroutine = IsCoroutine(methodDeclaration, UnityApi);
+
+            var isCoroutine = IsCoroutine(methodDeclaration, myUnityApi);
             var result = GetBulbMenuItems(declaration, context) as List<BulbMenuItem> ?? new List<BulbMenuItem>();
 
             if (isCoroutine.HasValue)
@@ -95,16 +98,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                     : new ConvertToCoroutineBulbAction(methodDeclaration);
 
                 var menuITem = UnityCallGraphUtil.BulbActionToMenuItem(bulbAction, textControl, mySolution, BulbThemedIcons.ContextAction.Id);
-                        
+
                 result.Add(menuITem);
             }
 
-            if (UnityApi.IsEventFunction(declaredElement))
+            if (myUnityApi.IsEventFunction(declaredElement))
             {
                 var showUnityHelp = mySolution.GetComponent<ShowUnityHelp>();
-                var documentationNavigationAction = new DocumentationNavigationAction(showUnityHelp, declaredElement, UnityApi);
+                var documentationNavigationAction = new DocumentationNavigationAction(showUnityHelp, declaredElement, myUnityApi);
                 var menuItem = UnityCallGraphUtil.BulbActionToMenuItem(documentationNavigationAction, textControl, mySolution, CommonThemedIcons.Question.Id);
-                
+
                 result.Add(menuItem);
             }
 
@@ -135,8 +138,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 myUnityApi = unityApi;
             }
 
-            protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution,
-                IProgressIndicator progress)
+            protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution,
+                                                                           IProgressIndicator progress)
             {
                 myShowUnityHelp.ShowHelp(myMethod.GetUnityEventFunctionName(myUnityApi), HelpSystem.HelpKind.Msdn);
                 return null;
@@ -145,9 +148,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
             public override string Text => "View documentation";
         }
 
-        protected static bool? IsCoroutine(IMethodDeclaration methodDeclaration, UnityApi unityApi)
+        private static bool? IsCoroutine(IMethodDeclaration methodDeclaration, UnityApi unityApi)
         {
-            if (methodDeclaration == null) return null;
             if (!methodDeclaration.IsFromUnityProject()) return null;
 
             var method = methodDeclaration.DeclaredElement;
@@ -161,32 +163,31 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
 
             return Equals(type.GetClrName(), PredefinedType.IENUMERATOR_FQN);
         }
-        
+
         protected IReadOnlyList<BulbMenuItem> GetActions(ICSharpDeclaration declaration, IReadOnlyCallGraphContext context)
         {
-            if (declaration.DeclaredElement is IMethod method && UnityApi.IsEventFunction(method))
+            if (declaration.DeclaredElement is IMethod method && myUnityApi.IsEventFunction(method))
                 return GetEventFunctionActions(declaration, context);
 
             return GetBulbMenuItems(declaration, context);
         }
 
-        protected IReadOnlyList<BulbMenuItem> GetBulbMenuItems(ICSharpDeclaration declaration, IReadOnlyCallGraphContext context)
+        private IReadOnlyList<BulbMenuItem> GetBulbMenuItems(ICSharpDeclaration declaration, IReadOnlyCallGraphContext context)
         {
             if (!(declaration is IMethodDeclaration methodDeclaration))
                 return EmptyList<BulbMenuItem>.Instance;
 
             var iconsEnabled = context.DaemonProcess.ContextBoundSettingsStore.GetValue((UnitySettings key) => key.EnableIconsForPerformanceCriticalCode);
-                    
             if (!iconsEnabled)
                 return EmptyList<BulbMenuItem>.Instance;
-            
-            var textControl = myTextControlManager.LastFocusedTextControl.Value;
+
+            var textControl = myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient()
+                .NotNull("myTextControlManager.LastFocusedTextControlPerClient.ForCurrentClient() != null");
             var result = new List<BulbMenuItem>();
 
             foreach (var provider in myMenuItemProviders)
             {
                 var menuItems = provider.GetMenuItems(methodDeclaration, textControl, context);
-
                 foreach (var item in menuItems)
                     result.Add(item);
             }

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Highlightings/PerformanceHighlightingAttributeIds.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/PerformanceCriticalCodeAnalysis/Highlightings/PerformanceHighlightingAttributeIds.cs
@@ -1,6 +1,8 @@
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings;
 using JetBrains.TextControl.DocumentMarkup;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCriticalCodeAnalysis.Highlightings
 {
     // Note that these are registered as part of the main "Unity" group, as they should appear in the main "Unity"
@@ -8,30 +10,35 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.PerformanceCrit
     [RegisterHighlighter(COSTLY_METHOD_INVOCATION,
         GroupId = UnityHighlightingAttributeIds.GROUP_ID,
         EffectType = EffectType.SOLID_UNDERLINE,
-        EffectColor = "#ff7526",
+        ForegroundColor = "#ff7526",
+        DarkForegroundColor = "#ff7526",
         NotRecyclable = true,
         Layer = HighlighterLayer.ADDITIONAL_SYNTAX)]
     [RegisterHighlighter(NULL_COMPARISON,
         GroupId = UnityHighlightingAttributeIds.GROUP_ID,
         EffectType = EffectType.SOLID_UNDERLINE,
-        EffectColor = "#ff7526",
+        ForegroundColor = "#ff7526",
+        DarkForegroundColor = "#ff7526",
         NotRecyclable = true,
         Layer = HighlighterLayer.ADDITIONAL_SYNTAX)]
     [RegisterHighlighter(CAMERA_MAIN,
         GroupId = UnityHighlightingAttributeIds.GROUP_ID,
-        EffectColor = "#ff7526",
+        ForegroundColor = "#ff7526",
+        DarkForegroundColor = "#ff7526",
         NotRecyclable = true,
         EffectType = EffectType.SOLID_UNDERLINE,
         Layer = HighlighterLayer.ADDITIONAL_SYNTAX)]
     [RegisterHighlighter(INEFFICIENT_MULTIDIMENSIONAL_ARRAYS_USAGE,
         GroupId = UnityHighlightingAttributeIds.GROUP_ID,
-        EffectColor = "#ff7526",
+        ForegroundColor = "#ff7526",
+        DarkForegroundColor = "#ff7526",
         NotRecyclable = true,
         EffectType = EffectType.SOLID_UNDERLINE,
         Layer = HighlighterLayer.ADDITIONAL_SYNTAX)]
     [RegisterHighlighter(INEFFICIENT_MULTIPLICATION_ORDER,
         GroupId = UnityHighlightingAttributeIds.GROUP_ID,
-        EffectColor = "#ff7526",
+        ForegroundColor = "#ff7526",
+        DarkForegroundColor = "#ff7526",
         NotRecyclable = true,
         EffectType = EffectType.SOLID_UNDERLINE,
         Layer = HighlighterLayer.ADDITIONAL_SYNTAX)]

--- a/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/ContextActions/ToggleSerializedFieldAction.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/ContextActions/ToggleSerializedFieldAction.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.Application.UI.Controls.BulbMenu.Anchors;
 using JetBrains.ProjectModel;
@@ -18,6 +17,8 @@ using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.TextControl;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActions
 {
     [ContextAction(Group = UnityContextActions.GroupID,
@@ -25,8 +26,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         Description = "Toggles a field in a Unity type between serialized and non-serialized. If the field is non-public, the 'UnityEngine.SerializeField' attribute is added. If the field is already serialized, the attribute is removed, and for public fields, the 'NonSerialized' field is added.")]
     public class ToggleSerializedFieldAction : IContextAction
     {
-        [NotNull] private static readonly SubmenuAnchor ourSubmenuAnchor =
-            new SubmenuAnchor(IntentionsAnchors.ContextActionsAnchor, SubmenuBehavior.Executable);
+        private static readonly SubmenuAnchor ourSubmenuAnchor =
+            new(IntentionsAnchors.ContextActionsAnchor, SubmenuBehavior.Executable);
 
         private readonly ICSharpContextActionDataProvider myDataProvider;
 
@@ -39,7 +40,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
         {
             var fieldDeclaration = myDataProvider.GetSelectedElement<IFieldDeclaration>();
             var multipleFieldDeclaration = MultipleFieldDeclarationNavigator.GetByDeclarator(fieldDeclaration);
-            if (multipleFieldDeclaration == null)
+            if (fieldDeclaration == null || multipleFieldDeclaration == null)
                 return EmptyList<IntentionAction>.Enumerable;
 
             var unityApi = myDataProvider.Solution.GetComponent<UnityApi>();
@@ -91,7 +92,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                 myIsSerialized = isSerialized;
             }
 
-            protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+            protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
             {
                 if (myIsSerialized)
                 {
@@ -99,8 +100,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                     if (myFieldDeclaration.GetAccessRights() == AccessRights.PUBLIC)
                     {
                         AttributeUtil.AddAttributeToEntireDeclaration(myMultipleFieldDeclaration,
-                            PredefinedType.NONSERIALIZED_ATTRIBUTE_CLASS, EmptyArray<AttributeValue>.Instance, null, myModule,
-                            myElementFactory);
+                            PredefinedType.NONSERIALIZED_ATTRIBUTE_CLASS, myModule, myElementFactory);
                     }
                 }
                 else
@@ -115,7 +115,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                     if (myFieldDeclaration.GetAccessRights() != AccessRights.PUBLIC)
                     {
                         AttributeUtil.AddAttributeToEntireDeclaration(myMultipleFieldDeclaration,
-                            KnownTypes.SerializeField, EmptyArray<AttributeValue>.Instance, null, myModule, myElementFactory);
+                            KnownTypes.SerializeField, myModule, myElementFactory);
                     }
                 }
 
@@ -161,7 +161,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActio
                 myIsSerialized = isSerialized;
             }
 
-            protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+            protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
             {
                 if (myIsSerialized)
                 {

--- a/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/LiveTemplates/UnityQuickListDefaultSettings.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/LiveTemplates/UnityQuickListDefaultSettings.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using JetBrains.Application;
 using JetBrains.Application.Settings;
 using JetBrains.Application.Settings.Implementation;
+using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Settings;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplates.Scope;
 using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplates
 {
@@ -23,12 +26,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplate
         public UnityQuickListDefaultSettings(ILogger logger, ISettingsSchema settingsSchema,
                                              UnityProjectScopeCategoryUIProvider projectScopeProvider,
                                              UnityScopeCategoryUIProvider filesScopeProvider)
-            : base(logger, settingsSchema)
+            : base(settingsSchema, logger)
         {
             myLogger = logger;
             mySettingsSchema = settingsSchema;
-            myProjectMainPoint = projectScopeProvider.MainPoint;
-            myFilesMainPoint = filesScopeProvider.MainPoint;
+            myProjectMainPoint = projectScopeProvider.MainPoint.NotNull("projectScopeProvider.MainPoint != null");
+            myFilesMainPoint = filesScopeProvider.MainPoint.NotNull("filesScopeProvider.MainPoint != null");
         }
 
         public override void InitDefaultSettings(ISettingsStorageMountPoint mountPoint)

--- a/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/QuickFixes/CreateSerializedFieldFromUsageAction.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/QuickFixes/CreateSerializedFieldFromUsageAction.cs
@@ -4,6 +4,7 @@ using JetBrains.ReSharper.Feature.Services.Intentions;
 using JetBrains.ReSharper.Feature.Services.Intentions.CreateDeclaration;
 using JetBrains.ReSharper.Feature.Services.Intentions.Impl.DeclarationBuilders;
 using JetBrains.ReSharper.Intentions.CSharp.QuickFixes;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CodeStyle;
@@ -12,7 +13,8 @@ using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Resolve;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
-using JetBrains.Util.Special;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
 {
@@ -27,11 +29,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
         {
             get
             {
-                var shortName = Reference.GetName();
+                // Marked as [CanBeNull] in base type, but we set it in ctor
+                var shortName = Reference!.GetName();
 
-                var target = (ITypeTarget) GetTarget();
-                var sourceTypeElement =
-                    target.Anchor.GetContainingNode<ITypeDeclaration>(true).IfNotNull(_ => _.DeclaredElement);
+                var target = (ITypeTarget) GetTarget().NotNull("GetTarget() != null");
+                var sourceTypeElement = target.Anchor?.GetContainingNode<ITypeDeclaration>()?.DeclaredElement;
                 var targetTypeElement = target.TargetType;
                 if (!targetTypeElement.Equals(sourceTypeElement))
                     shortName = target.TargetType.ShortName + "." + shortName;
@@ -43,29 +45,22 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
         protected override bool IsAvailableInternal()
         {
             var available = base.IsAvailableInternal();
-            if (available)
+            if (available && GetTarget() is ITypeTarget typeTarget)
             {
-                var typeTarget = GetTarget() as ITypeTarget;
-                if (typeTarget != null)
-                {
-                    var containingType = typeTarget.TargetType;
-                    var unityApi = containingType.GetSolution().GetComponent<UnityApi>();
-                    return unityApi.IsUnityType(containingType);
-                }
+                var containingType = typeTarget.TargetType;
+                var unityApi = containingType.GetSolution().GetComponent<UnityApi>();
+                return unityApi.IsUnityType(containingType);
             }
-            return available;
+            return false;
         }
 
         protected override IntentionResult ExecuteIntention(CreateFieldDeclarationContext context)
         {
             var intentionResult = FieldDeclarationBuilder.Create(context);
-            var fieldDeclaration = intentionResult.ResultDeclaration as IFieldDeclaration;
-            if (fieldDeclaration != null)
+            if (intentionResult.ResultDeclaration is IFieldDeclaration fieldDeclaration)
             {
-                var attributeType = TypeFactory.CreateTypeByCLRName("UnityEngine.SerializeField", fieldDeclaration.GetPsiModule());
-                var factory = CSharpElementFactory.GetInstance(fieldDeclaration);
-                var attribute = factory.CreateAttribute(attributeType.GetTypeElement());
-                fieldDeclaration.AddAttributeBefore(attribute, null);
+                AttributeUtil.AddAttributeToSingleDeclaration(fieldDeclaration, KnownTypes.SerializeField,
+                    fieldDeclaration.GetPsiModule(), CSharpElementFactory.GetInstance(fieldDeclaration));
 
                 var languageService = fieldDeclaration.Language.LanguageService().NotNull();
                 var codeFormatter = languageService.CodeFormatter.NotNull();

--- a/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/QuickFixes/MarkSerializableQuickFix.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/QuickFixes/MarkSerializableQuickFix.cs
@@ -9,6 +9,7 @@ using JetBrains.ReSharper.Feature.Services.QuickFixes;
 using JetBrains.ReSharper.Intentions.Util;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Errors;
 using JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Analysis;
+using JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
@@ -17,6 +18,8 @@ using JetBrains.ReSharper.Psi.ExtensionsAPI;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl;
 using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
 {
@@ -66,16 +69,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.QuickFixes
                 myTypeDeclaration = typeDeclaration;
             }
 
-            protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+            protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
             {
-                var attributeType = TypeFactory.CreateTypeByCLRName(PredefinedType.SERIALIZABLE_ATTRIBUTE_CLASS,
-                    myTypeDeclaration.GetPsiModule()).GetTypeElement();
-                if (attributeType != null)
-                {
-                    var elementFactory = CSharpElementFactory.GetInstance(myTypeDeclaration);
-                    var attribute = elementFactory.CreateAttribute(attributeType);
-                    myTypeDeclaration.AddAttributeAfter(attribute, null);
-                }
+                AttributeUtil.AddAttributeToSingleDeclaration(myTypeDeclaration,
+                    PredefinedType.SERIALIZABLE_ATTRIBUTE_CLASS, myTypeDeclaration.GetPsiModule(),
+                    CSharpElementFactory.GetInstance(myTypeDeclaration));
 
                 return null;
             }

--- a/resharper/resharper-unity/src/Unity/CSharp/Psi/Naming/Elements/UnityNamingRuleDefaultSettings.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Psi/Naming/Elements/UnityNamingRuleDefaultSettings.cs
@@ -7,6 +7,8 @@ using JetBrains.ReSharper.Psi.Naming.Elements;
 using JetBrains.ReSharper.Psi.Naming.Settings;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Naming.Elements
 {
     // Defining an element kind isn't enough, we also need to set up a rule that uses it. This is a different process
@@ -27,10 +29,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Naming.Elements
     [ShellComponent]
     public class UnityNamingRuleDefaultSettings : HaveDefaultSettings
     {
-        public static readonly Guid SerializedFieldRuleGuid = new Guid("5F0FDB63-C892-4D2C-9324-15C80B22A7EF");
+        public static readonly Guid SerializedFieldRuleGuid = new("5F0FDB63-C892-4D2C-9324-15C80B22A7EF");
 
         public UnityNamingRuleDefaultSettings(ILogger logger, ISettingsSchema settingsSchema)
-            : base(logger, settingsSchema)
+            : base(settingsSchema, logger)
         {
         }
 

--- a/resharper/resharper-unity/src/Unity/CSharp/Psi/Resolve/UnityObjectTypeOrNamespaceReference.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Psi/Resolve/UnityObjectTypeOrNamespaceReference.cs
@@ -11,7 +11,6 @@ using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve.Filters;
 using JetBrains.ReSharper.Psi.Impl.Shared.References;
 using JetBrains.ReSharper.Psi.Impl.Shared.Util;
 using JetBrains.ReSharper.Psi.Resolve;
-using JetBrains.ReSharper.Psi.Resx.Utils;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.Util;
 
@@ -27,10 +26,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Resolve
         private readonly ExpectedObjectTypeFilter myExpectedObjectTypeFilter;
 
         public UnityObjectTypeOrNamespaceReference(ICSharpLiteralExpression owner, [CanBeNull] IQualifier qualifier,
-                                                   ITokenNode token, TextRange rangeWithin,
+                                                   ITokenNode token, TreeTextRange rangeWithin,
                                                    ExpectedObjectTypeReferenceKind kind, ISymbolCache symbolCache,
                                                    bool isFinalPart)
-            : base(owner, qualifier, token, rangeWithin.ToTreeTextRange())
+            : base(owner, qualifier, token, rangeWithin)
         {
             mySymbolCache = symbolCache;
             myIsFinalPart = isFinalPart;
@@ -189,7 +188,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Resolve
             // add another namespace. If we're in the middle of the string, they might be changing their mind, and
             // adding a new (qualified) type, so adding either type or namespace (the text to the right will fail to
             // resolve)
-            return new ISymbolFilter[]
+            return new[]
             {
                 CSharpTypeOrNamespaceFilter.INSTANCE,
                 TypeElementMustBeClassFilter.INSTANCE,

--- a/resharper/resharper-unity/src/Unity/CSharp/Psi/Resolve/UnityObjectTypeReferenceFactory.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Psi/Resolve/UnityObjectTypeReferenceFactory.cs
@@ -40,7 +40,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Resolve
                 return ReferenceCollection.Empty;
 
             var invocationReference = invocationExpression.Reference;
-            if (!(invocationReference?.Resolve().DeclaredElement is IMethod invokedMethod))
+            if (invocationReference.Resolve().DeclaredElement is not IMethod invokedMethod)
                 return ReferenceCollection.Empty;
 
             var kind = GetExpectedReferenceKind(invokedMethod);
@@ -76,7 +76,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Resolve
 
         private bool DoesMethodBelongToType(IMethod invokedMethod, IClrTypeName typeName)
         {
-            var containingType = invokedMethod.GetContainingType();
+            var containingType = invokedMethod.ContainingType;
             return containingType != null && Equals(containingType.GetClrName(), typeName);
         }
 
@@ -98,7 +98,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Psi.Resolve
                 var endIndex = nextDotIndex != -1 ? nextDotIndex : literalValue.Length;
 
                 // startIndex + 1 to skip leading quote in tree node, which doesn't exist in literalValue
-                var rangeWithin = TextRange.FromLength(startIndex + 1, endIndex - startIndex);
+                var rangeWithin = TreeTextRange.FromLength(new TreeOffset(startIndex + 1), endIndex - startIndex);
 
                 // Behaviour and resolution is almost identical for each part.
                 // For a single component, it is either a Unity object with an inferred namespace, a type in the global

--- a/resharper/resharper-unity/src/Unity/Core/Daemon/NamespaceProviderProjectSettingsProvider.cs
+++ b/resharper/resharper-unity/src/Unity/Core/Daemon/NamespaceProviderProjectSettingsProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using JetBrains.Annotations;
 using JetBrains.Application.Settings;
 using JetBrains.Application.Settings.Implementation;
 using JetBrains.Collections.Viewable;
@@ -11,6 +10,8 @@ using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Plugins.Unity.Core.Application.Settings;
 using JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel;
 using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Core.Daemon
 {
@@ -70,7 +71,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.Daemon
         {
             if (!myUnitySolutionTracker.IsUnityProject.HasTrueValue())
                 return;
-            
+
             ExcludeFolderFromNamespace(mountPoint, "Assets");
             ExcludeFolderFromNamespace(mountPoint, @"Assets\Scripts");
 
@@ -132,7 +133,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.Daemon
                 //
                 // NOTE: KEEP UP TO DATE WITH ExternalPackageCustomNamespaceProvider!
                 if (folder.IsLinked && folder.ParentFolder != null)
-                    path = folder.Location.ConvertToRelativePath(folder.ParentFolder.Location).FullPath;
+                    path = folder.Location.MakeRelativeTo(folder.ParentFolder.Location).FullPath;
                 ExcludeFolderFromNamespace(mountPoint, path + @"\Runtime");
                 ExcludeFolderFromNamespace(mountPoint, path + @"\Scripts");
                 ExcludeFolderFromNamespace(mountPoint, path + @"\Runtime\Scripts");
@@ -164,11 +165,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.Daemon
             }
         }
 
-        private void SetIndexedValue<TKeyClass, TEntryIndex, TEntryValue>([NotNull] ISettingsStorageMountPoint mount,
-                                                                          [NotNull] Expression<Func<TKeyClass, IIndexedEntry<TEntryIndex, TEntryValue>>> lambdaexpression,
-                                                                          [NotNull] TEntryIndex index,
-                                                                          [NotNull] TEntryValue value,
-                                                                          IDictionary<SettingsKey, object> keyIndices = null)
+        private void SetIndexedValue<TKeyClass, TEntryIndex, TEntryValue>(ISettingsStorageMountPoint mount,
+                                                                          Expression<Func<TKeyClass, IIndexedEntry<TEntryIndex, TEntryValue>>> lambdaexpression,
+                                                                          TEntryIndex index,
+                                                                          TEntryValue value,
+                                                                          IDictionary<SettingsKey, object>? keyIndices = null)
+            where TEntryIndex : class
+            where TEntryValue : notnull
         {
             ScalarSettingsStoreAccess.SetIndexedValue(mount, mySettingsSchema.GetIndexedEntry(lambdaexpression), index,
                 keyIndices, value, null, myLogger);

--- a/resharper/resharper-unity/src/Unity/Unity.csproj
+++ b/resharper/resharper-unity/src/Unity/Unity.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity</RootNamespace>
-    <!-- TODO: Fix up the .psi files so we don't get the obsolete warnings -->
-    <NoWarn>0618</NoWarn>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath Condition="'$(ReSharperUnityCommonOutputPath)'!=''">$(ReSharperUnityCommonOutputPath)</OutputPath>

--- a/resharper/resharper-unity/src/Unity/Unity.csproj
+++ b/resharper/resharper-unity/src/Unity/Unity.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Unity</RootNamespace>
     <LangVersion>9</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath Condition="'$(ReSharperUnityCommonOutputPath)'!=''">$(ReSharperUnityCommonOutputPath)</OutputPath>
   </PropertyGroup>
   <!-- ********** -->

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityTypeSpec.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityTypeSpec.cs
@@ -1,4 +1,3 @@
-using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ReSharper.Psi;
@@ -6,17 +5,19 @@ using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
 {
     public class UnityTypeSpec
     {
-        public static UnityTypeSpec Void = new UnityTypeSpec(PredefinedType.VOID_FQN);
+        public static readonly UnityTypeSpec Void = new(PredefinedType.VOID_FQN);
 
-        public UnityTypeSpec(IClrTypeName typeName, bool isArray = false, IClrTypeName[] typeParameters = null)
+        public UnityTypeSpec(IClrTypeName typeName, bool isArray = false, IClrTypeName[]? typeParameters = null)
         {
-           ClrTypeName = typeName;
-           IsArray = isArray;
-           TypeParameters = typeParameters ?? EmptyArray<IClrTypeName>.Instance;
+            ClrTypeName = typeName;
+            IsArray = isArray;
+            TypeParameters = typeParameters ?? EmptyArray<IClrTypeName>.Instance;
         }
 
         // CLR type name, not C# type name. Mostly the same, but can only represent open generics
@@ -27,7 +28,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
         public IClrTypeName[] TypeParameters { get; }
 
         // TODO: Perhaps this should be an extension method
-        [NotNull]
         public IType AsIType(KnownTypesCache knownTypesCache, IPsiModule module)
         {
             // TODO: It would be nice to also cache the closed generic and array types
@@ -37,7 +37,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
             if (TypeParameters.Length > 0)
             {
                 var typeParameters = new IType[TypeParameters.Length];
-                for (int i = 0; i < TypeParameters.Length; i++)
+                for (var i = 0; i < TypeParameters.Length; i++)
                 {
                     typeParameters[i] = knownTypesCache.GetByClrTypeName(TypeParameters[i], module);
                 }
@@ -46,8 +46,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
                 type = TypeFactory.CreateType(typeElement, typeParameters);
             }
 
-            if (IsArray)
-                type = TypeFactory.CreateArrayType(type, 1);
+            if (IsArray) type = TypeFactory.CreateArrayType(type, 1, NullableAnnotation.Unknown);
 
             return type;
         }

--- a/resharper/resharper-unity/src/Unity/Utils/NamingUtil.cs
+++ b/resharper/resharper-unity/src/Unity/Utils/NamingUtil.cs
@@ -7,6 +7,7 @@ using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Naming.Extentions;
 using JetBrains.ReSharper.Psi.Naming.Impl;
 using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.Util;
 
 #nullable enable
 
@@ -40,7 +41,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Utils
             collectionModifier?.Invoke(namesCollection);
             var suggestionOptions = new SuggestionOptions
             {
-                DefaultName = baseName, UniqueNameContext = node, IsConflictingElement = isConflictingElement
+                DefaultName = baseName,
+                UniqueNameContext = node,
+                IsConflictingElement = isConflictingElement ?? JetFunc<IDeclaredElement>.True
             };
             var namesSuggestion = namesCollection.Prepare(elementKind, ScopeKind.TypeAndNamespace, suggestionOptions);
             return namesSuggestion.FirstName();

--- a/resharper/resharper-unity/src/Unity/Utils/NamingUtil.cs
+++ b/resharper/resharper-unity/src/Unity/Utils/NamingUtil.cs
@@ -1,46 +1,66 @@
 using System;
-using JetBrains.Annotations;
 using JetBrains.Application.Threading;
+using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Naming.Extentions;
 using JetBrains.ReSharper.Psi.Naming.Impl;
 using JetBrains.ReSharper.Psi.Naming.Settings;
-using JetBrains.Util;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Utils
 {
     internal static class NamingUtil
     {
-        [NotNull]
-        public static string GetUniqueName<T>([NotNull] T node, [CanBeNull] string baseName,
-            NamedElementKinds elementKind, Action<INamesCollection> collectionModifier = null, Func<IDeclaredElement, bool> isConflictingElement = null) where T : ICSharpTreeNode
+        public static string GetUniqueName<T>(T node,
+                                              string? baseName,
+                                              NamedElementKinds elementKind,
+                                              Action<INamesCollection>? collectionModifier = null,
+                                              Func<IDeclaredElement, bool>? isConflictingElement = null)
+            where T : ICSharpTreeNode
         {
             node.GetPsiServices().Locks.AssertMainThread();
-            
-            isConflictingElement = isConflictingElement ?? JetFunc<IDeclaredElement>.True;
+
             var namingManager = node.GetPsiServices().Naming;
             var policyProvider = namingManager.Policy.GetPolicyProvider(node.Language, node.GetSourceFile());
             var namingRule = policyProvider.GetPolicy(elementKind).NamingRule;
-            var namesCollection = namingManager.Suggestion.CreateEmptyCollection(PluralityKinds.Unknown, CSharpLanguage.Instance, true, policyProvider);
+            var namesCollection = namingManager.Suggestion.CreateEmptyCollection(PluralityKinds.Unknown,
+                CSharpLanguage.Instance.NotNull("CSharpLanguage.Instance != null"), true, policyProvider);
 
             if (baseName != null)
             {
                 var name = namingManager.Parsing.Parse(baseName, namingRule, policyProvider);
                 var nameRoot = name.GetRootOrDefault(baseName);
-                namesCollection.Add(nameRoot, new EntryOptions(PluralityKinds.Plural, SubrootPolicy.Decompose, emphasis: Emphasis.Good));
+                namesCollection.Add(nameRoot,
+                    new EntryOptions(PluralityKinds.Plural, SubrootPolicy.Decompose, emphasis: Emphasis.Good));
             }
 
             collectionModifier?.Invoke(namesCollection);
             var suggestionOptions = new SuggestionOptions
             {
-                DefaultName = baseName,
-                UniqueNameContext = node,
-                IsConflictingElement = isConflictingElement
+                DefaultName = baseName, UniqueNameContext = node, IsConflictingElement = isConflictingElement
             };
             var namesSuggestion = namesCollection.Prepare(elementKind, ScopeKind.TypeAndNamespace, suggestionOptions);
             return namesSuggestion.FirstName();
+        }
+
+        public static bool IsIdentifier(string name)
+        {
+            if (name.Length == 0)
+                return false;
+            char[] charArray = name.ToCharArray();
+            if (!char.IsLetter(charArray[0]) && charArray[0] != '_')
+                return false;
+            for (int index = 1; index < charArray.Length; ++index)
+            {
+                char c = charArray[index];
+                if (!char.IsLetterOrDigit(c) && c != '_')
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/resharper/resharper-unity/src/Unity/Yaml/Feature/Services/Occurrences/UnityAssetSpecificOccurrenceKinds.cs
+++ b/resharper/resharper-unity/src/Unity/Yaml/Feature/Services/Occurrences/UnityAssetSpecificOccurrenceKinds.cs
@@ -1,17 +1,13 @@
-using JetBrains.Annotations;
 using JetBrains.ReSharper.Feature.Services.Occurrences;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Feature.Services.Occurrences
 {
     public static class UnityAssetSpecificOccurrenceKinds
     {
-        [NotNull] public static readonly OccurrenceKind EventHandler =
-            new OccurrenceKind("Unity event handler", OccurrenceKind.SemanticAxis, false);
-
-        [NotNull] public static readonly OccurrenceKind ComponentUsage =
-            new OccurrenceKind("Unity component usage", OccurrenceKind.SemanticAxis, false);
-        
-        [NotNull] public static readonly OccurrenceKind InspectorUsage =
-            new OccurrenceKind("Inspector values", OccurrenceKind.SemanticAxis, false);
+        public static readonly OccurrenceKind EventHandler = OccurrenceKind.CreateSemantic("Unity event handler");
+        public static readonly OccurrenceKind ComponentUsage = OccurrenceKind.CreateSemantic("Unity component usage");
+        public static readonly OccurrenceKind InspectorUsage = OccurrenceKind.CreateSemantic("Inspector values");
     }
 }

--- a/resharper/resharper-unity/test/src/Unity.Rider.Tests/Unity.Rider.Tests.csproj
+++ b/resharper/resharper-unity/test/src/Unity.Rider.Tests/Unity.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Rider.Tests</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Tests</RootNamespace>
     <LangVersion>9</LangVersion>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <JetTestProject>True</JetTestProject>
     <SignAssembly>False</SignAssembly>
     <!-- Force 32 bit x86 for Windows as we need to load a specific build of the Cpp assembly, and we have X86 defined

--- a/resharper/resharper-unity/test/src/Unity.Tests/Unity.Tests.csproj
+++ b/resharper/resharper-unity/test/src/Unity.Tests/Unity.Tests.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>JetBrains.ReSharper.Plugins.Unity.Tests</AssemblyName>
     <RootNamespace>JetBrains.ReSharper.Plugins.Tests</RootNamespace>
     <LangVersion>9</LangVersion>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <JetTestProject>True</JetTestProject>
     <SignAssembly>False</SignAssembly>
     <!-- Force 32 bit x86 for Windows as we need to load a specific build of the Cpp assembly, and we have X86 defined


### PR DESCRIPTION
Removes the suppression of obsolete warnings, and fixes all obsolete warnings, where possible. Also migrates changed files to a nullable context.

Not all warnings have been fixed, which means that `TreatWarningsAsErrors` has been disabled for `Unity.csproj`, `Unity.Rider.csproj` and `Unity.Shaders.csproj`. The warnings that are still outstanding are:

* `[Obsolete]` usages in `TreeNodeVisitor` classes (the majority of warnings). The methods are marked obsolete so that you'll see a warning when overriding in user code, but the methods are also invoked in the `TreeNodeVisitor` class. These warnings will be suppressed by an SDK update.
* Usages of old APIs for usage statistics. These need to be migrated as part of 221
* An instance of `InterruptableActivityCookie.CheckAndThrow(ProgressIndicator)`. This is an in-progress SDK refactoring. There should be no need to pass the progress indicator, because it _should_ already be part of the interruption set. It is up to the refactoring workflow to ensure this is the case, and then we can remove it. Other refactorings in the product are still calling this overload, too.