### PR TITLE
Fix colour highlighting for target typed new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 * [Commits](https://github.com/JetBrains/resharper-unity/compare/net213...net221)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/50?closed=1)
 
+### Added
+
+- Rider: Add new run configuration to run Unity tests in batch mode ([RIDER-70675](https://youtrack.jetbrains.com/issue/RIDER-70675), [#2231](https://github.com/JetBrains/resharper-unity/pull/2231))
+
+### Changed
+
+- Show preview for target typed new instances of `Color` ([RIDER-64151](https://youtrack.jetbrains.com/issue/RIDER-64151), [#2250](https://github.com/JetBrains/resharper-unity/pull/2250))
+- Unity editor: Expand Find Usages editor window by default ([#2239](https://github.com/JetBrains/resharper-unity/pull/2239))
+
 ### Fixed
 
 - Rider: Fix incorrectly showing both Unity and Unity DLL project action groups ([#2219](https://github.com/JetBrains/resharper-unity/pull/2219))
 - Rider: Fix incorrectly showing "switch to full UI" action when already in full UI ([RIDER-71185](https://youtrack.jetbrains.com/issue/RIDER-71185), [#2220](https://github.com/JetBrains/resharper-unity/pull/2220))
 - Rider: Fix debugging unit test when debugger is already attached to the editor ([RIDER-70660](https://youtrack.jetbrains.com/issue/RIDER-70660), [#2232](https://github.com/JetBrains/resharper-unity/pull/2232))
+- Rider: Fix issues displaying the "advanced integration unavailable" notification ([#73086](https://youtrack.jetbrains.com/issue/RIDER-73086), [#2240](https://github.com/JetBrains/resharper-unity/pull/2240))
+- Rider: Fix exception when showing Quick Doc tooltip ([DEXP-619767](https://youtrack.jetbrains.com/issue/DEXP-619767), [#2240](https://github.com/JetBrains/resharper-unity/pull/2240))
 
 
 

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color.cs
@@ -24,6 +24,10 @@ namespace UnityTest
       var c12 = Color.HSVToRGB(0, 1, 1, false);
 
       var c13 = Color.HSVToRGB(0, 1, 1, 1, 1);
+
+      Color c14 = new(1, 0, 0);
+      Color c15 = new(0, 1, 1, 0.5f);
+      Color c16 = new(10, 20, -2);
     }
   }
 }

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color.cs.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color.cs.gold
@@ -24,6 +24,10 @@ namespace UnityTest
       var c12 = Color.HSVToRGB(|0, 1, 1, false|(9));
 
       var c13 = Color.HSVToRGB(0, 1, 1, 1, 1);
+
+      Color c14 = new(|1, 0, 0|(10));
+      Color c15 = new(|0, 1, 1, 0.5f|(11));
+      Color c16 = new(10, 20, -2);
     }
   }
 }
@@ -59,3 +63,9 @@ HEX:  FF, 7F, 7F, 7F' (E) ''
 (9): : (T) '|   | 
 ARGB:  255, 255, 0, 0
 HEX:  FF, FF, 0, 0' (E) ''
+(10): : (T) '|   | 
+ARGB:  255, 255, 0, 0
+HEX:  FF, FF, 0, 0' (E) ''
+(11): : (T) '|   | 
+ARGB:  127, 0, 255, 255
+HEX:  7F, 0, FF, FF' (E) ''

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color32.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color32.cs
@@ -6,12 +6,16 @@ namespace UnityTest
   {
     public Class1()
     {
+      // Color32 doesn't have an overload that takes 3 parameters, but we recognise it because it's the same as Color(r,g,b)
       var c1 = new Color32(255, 0, 0);
       var c2 = new Color32(0, 255, 255, 127);
       var c3 = new Color32(10, 20, -2);
 
       var c4 = new Color32(255, 0, 0, 0, 0);
       var c5 = new Color32(0xFF / 2, 128, 128);
+
+      Color32 c6 = new(200, 180, 190, 255);
+      Color32 c7 = new(1, 3, 0.5f, 0.8f);
     }
   }
 }

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color32.cs.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Colors/Color32.cs.gold
@@ -6,12 +6,16 @@ namespace UnityTest
   {
     public Class1()
     {
+      // Color32 doesn't have an overload that takes 3 parameters, but we recognise it because it's the same as Color(r,g,b)
       var c1 = new Color32(|255, 0, 0|(0));
       var c2 = new Color32(|0, 255, 255, 127|(1));
       var c3 = new Color32(10, 20, -2);
 
       var c4 = new Color32(255, 0, 0, 0, 0);
       var c5 = new Color32(|0xFF / 2, 128, 128|(2));
+
+      Color32 c6 = new(|200, 180, 190, 255|(3));
+      Color32 c7 = new(1, 3, 0.5f, 0.8f);
     }
   }
 }
@@ -26,3 +30,6 @@ HEX:  7F, 0, FF, FF' (E) ''
 (2): : (T) '|   | 
 ARGB:  255, 127, 128, 128
 HEX:  FF, 7F, 80, 80' (E) ''
+(3): : (T) '|   | 
+ARGB:  255, 200, 180, 190
+HEX:  FF, C8, B4, BE' (E) ''

--- a/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/Stages/Color/UnityColorHighlightingTest.cs
+++ b/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/Stages/Color/UnityColorHighlightingTest.cs
@@ -1,11 +1,14 @@
 ﻿using JetBrains.ReSharper.Daemon.VisualElements;
 using JetBrains.ReSharper.Plugins.Tests.Unity.CSharp.Daemon.Stages.Analysis;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.TestFramework;
 using NUnit.Framework;
 
 namespace JetBrains.ReSharper.Plugins.Tests.Unity.CSharp.Daemon.Stages.Color
 {
     [Category("ColorHighlighting")]
     [TestUnity]
+    [CSharpLanguageLevel(CSharpLanguageLevel.CSharp90)]
     public class UnityColorHighlightingTest : CSharpHighlightingTestBase<ColorHighlighting>
     {
         protected override bool ColorIdentifiers => true;


### PR DESCRIPTION
Show colour preview when creating an instance of `Color` with target typed new.

Fixes [RIDER-64151](https://youtrack.jetbrains.com/issue/RIDER-64151)