### PR TITLE
Ensure Unity Explorer project names are distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Fixed
 
-- Rider: Fix massive performance issue when opening very large projects on certain file systems ([RIDER-53358](https://youtrack.jetbrains.com/issue/RIDER-53358), [#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
+- Fix massive performance issue when opening very large projects on certain file systems ([RIDER-53358](https://youtrack.jetbrains.com/issue/RIDER-53358), [#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
+- Fix excessive memory traffic when opening very large projects ([#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
 - Rider: Fix incorrectly showing both Unity and Unity DLL project action groups ([#2219](https://github.com/JetBrains/resharper-unity/pull/2219))
 - Rider: Fix incorrectly showing "switch to full UI" action when already in full UI ([RIDER-71185](https://youtrack.jetbrains.com/issue/RIDER-71185), [#2220](https://github.com/JetBrains/resharper-unity/pull/2220))
 - Rider: Fix debugging unit test when debugger is already attached to the editor ([RIDER-70660](https://youtrack.jetbrains.com/issue/RIDER-70660), [#2232](https://github.com/JetBrains/resharper-unity/pull/2232))
@@ -39,6 +40,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix loss of connection to Unity editor after refreshing assets ([RIDER-73901](https://youtrack.jetbrains.com/issue/RIDER-73901), [#2262](https://github.com/JetBrains/resharper-unity/pull/2262)) 
 - Rider: Fix display of unprintable characters in console output when debugging batchmode tests ([RIDER-74056](https://youtrack.jetbrains.com/issue/RIDER-74056), [#2265](https://github.com/JetBrains/resharper-unity/pull/2265))
 - Rider: Fix performance issue displaying long log issues from Unity ([RIDER-70574](https://youtrack.jetbrains.com/issue/RIDER-70574), [#2270](https://github.com/JetBrains/resharper-unity/pull/2270))
+- Rider: Fix showing duplicate project names in Unity Explorer under certain circumstances ([RIDER-67457](https://youtrack.jetbrains.com/issue/RIDER-67457), [#2273](https://github.com/JetBrains/resharper-unity/pull/2273))
 
 
 

--- a/resharper/resharper-unity/src/Unity/Yaml/ProjectModel/MetaProjectFileType.cs
+++ b/resharper/resharper-unity/src/Unity/Yaml/ProjectModel/MetaProjectFileType.cs
@@ -15,7 +15,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.ProjectModel
         [UsedImplicitly] public new static MetaProjectFileType? Instance { get; private set; }
 
         public MetaProjectFileType()
-            : base(Name, "Unity Yaml", new[] { UnityFileExtensions.MetaFileExtensionWithDot })
+            : base(Name, "Unity Meta File", new[] { UnityFileExtensions.MetaFileExtensionWithDot })
         {
         }
     }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorer.kt
@@ -26,6 +26,8 @@ class UnityExplorer(project: Project) : SolutionViewPaneBase(project, createRoot
         const val ShowTildeFoldersOption = "show-tilde-folders"
         const val DefaultProjectPrefix = "Assembly-CSharp"
 
+        val DefaultProjectPrefixRegex = ("$DefaultProjectPrefix[.-]?").toRegex()
+
         val Icon = UnityIcons.ToolWindows.UnityExplorer
         val IgnoredExtensions = hashSetOf("meta", "tmp")
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerFileSystemNode.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/explorer/UnityExplorerFileSystemNode.kt
@@ -123,10 +123,11 @@ open class UnityExplorerFileSystemNode(project: Project,
 
     protected fun addProjects(presentation: PresentationData) {
         val projectNames = entities   // One node for each project that this directory is part of
-                .mapNotNull { containingProjectNode(it) }
-                .map(::stripDefaultProjectPrefix)
-                .filter { it.isNotEmpty() }
-                .sortedWith(String.CASE_INSENSITIVE_ORDER)
+            .mapNotNull { containingProjectNode(it) }
+            .map(::stripDefaultProjectPrefix)
+            .filter { it.isNotEmpty() }
+            .sortedWith(String.CASE_INSENSITIVE_ORDER)
+            .distinct()
         if (projectNames.any()) {
             var description = projectNames.take(3).joinToString(", ")
             if (projectNames.count() > 3) {
@@ -144,7 +145,7 @@ open class UnityExplorerFileSystemNode(project: Project,
         // Assembly-CSharp => ""
         // Assembly-CSharp-Editor => Editor
         // Assembly-CSharp.Player => Player
-        return it.name.removePrefix(UnityExplorer.DefaultProjectPrefix).removePrefix("-").removePrefix(".")
+        return it.name.replace(UnityExplorer.DefaultProjectPrefixRegex, "")
     }
 
     private fun containingProjectNode(entity: ProjectModelEntity): ProjectModelEntity? {


### PR DESCRIPTION
Fixes [RIDER-67457](https://youtrack.jetbrains.com/issue/RIDER-67457), but I have no idea how to recreate.