### PR TITLE
Update Gradle and Gradle plugin versions

### DIFF
--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -195,7 +195,7 @@ tasks {
     }
 
     named<Wrapper>("wrapper") {
-        gradleVersion = "7.2"
+        gradleVersion = "7.4"
         distributionType = Wrapper.DistributionType.BIN
     }
 

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -429,15 +429,6 @@ tasks {
         }
         buildFile.set(backend.resharperHostPluginSolution)
     }
-    val buildUnityEditorPlugin by registering(DotNetBuildTask::class) {
-        group = backendGroup
-        description = "Builds the Unity editor plugin"
-        dependsOn(prepareNuGetConfig, generateModels)
-        onlyIf {
-            skipDotnet.not()
-        }
-        buildFile.set(backend.unityPluginSolution)
-    }
 
     val packReSharperPlugin by registering(com.ullink.NuGetPack::class) {
         group = backendGroup

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -20,9 +20,9 @@ plugins {
     id("com.ullink.nuget") version "2.23"
     id("com.ullink.nunit") version "2.4"
     id("me.filippov.gradle.jvm.wrapper") version "0.10.0"
-    id("org.jetbrains.changelog") version "1.2.1"
+    id("org.jetbrains.changelog") version "1.3.1"
     id("org.jetbrains.intellij") // version in rider/buildSrc/build.gradle.kts
-    id("org.jetbrains.grammarkit") version "2021.1.3"
+    id("org.jetbrains.grammarkit") version "2021.2.1"
     kotlin("jvm") version "1.6.10"
 }
 
@@ -155,8 +155,10 @@ intellij {
 }
 
 configure<ChangelogPluginExtension> {
-    path.set("../CHANGELOG.md")
-    headerParserRegex.set("\\d+\\.\\d+(\\.\\d+)?.*".toRegex())
+    val regex = """^((0|[1-9]\d*)\.(0|[1-9]\d*)(\.\d+)?).*$""".toRegex()
+    version.set(regex.matchEntire(project.version.toString())?.groups?.get(1)?.value)
+    path.set("${project.projectDir}/../CHANGELOG.md")
+    headerParserRegex.set(regex)
 }
 
 logger.lifecycle("Version=$version")

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -571,30 +571,9 @@ See CHANGELOG.md in the JetBrains/resharper-unity GitHub repo for more details a
         }
     }
 
-    // TODO: Remove this!
-    // Workaround for a bug in the SDK which isn't preserving the permissions for lib/ReSharperHost/[macosx|linux]-x64/dotnet/dotnet
-    val fixSdkPermissions by registering {
-        doLast {
-            if (!isWindows) {
-                logger.lifecycle("==============================================================================")
-                logger.lifecycle("Temporary fix for file permissions. Resetting executable permission for:")
-                logger.lifecycle(backend.getDotNetSdkPath().toString() + "/../ReSharperHost/linux-x64/dotnet/dotnet")
-                logger.lifecycle(backend.getDotNetSdkPath().toString() + "/../ReSharperHost/macosx-x64/dotnet/dotnet")
-                logger.lifecycle("==============================================================================")
-
-                project.exec {
-                    commandLine("chmod", "+x", backend.getDotNetSdkPath().toString() + "/../ReSharperHost/linux-x64/dotnet/dotnet")
-                }
-                project.exec {
-                    commandLine("chmod", "+x", backend.getDotNetSdkPath().toString() + "/../ReSharperHost/macos-x64/dotnet/dotnet")
-                }
-            }
-        }
-    }
-
     withType<PrepareSandboxTask> {
         // Default dependsOn includes the standard Java build/jar task
-        dependsOn(buildReSharperHostPlugin, fixSdkPermissions)
+        dependsOn(buildReSharperHostPlugin)
 
         // Have dependent tasks use upToDateWhen { project.buildServer.automatedBuild etc. }
         //inputs.files(buildRiderPlugin.outputs)

--- a/rider/buildSrc/build.gradle.kts
+++ b/rider/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "1.3.1")
+    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "1.4.0")
 }
 
 plugins {

--- a/rider/buildSrc/build.gradle.kts
+++ b/rider/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "1.2.0")
+    implementation("org.jetbrains.intellij.plugins", "gradle-intellij-plugin", "1.3.1")
 }
 
 plugins {

--- a/rider/gradle/wrapper/gradle-wrapper.properties
+++ b/rider/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/rider/gradlew
+++ b/rider/gradlew
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions �$var�, �${var}�, �${var:-default}�, �${var+SET}�,
-#           �${var#prefix}�, �${var%suffix}�, and �$( cmd )�;
-#         * compound commands having a testable exit status, especially �case�;
-#         * various built-in commands including �command�, �set�, and �ulimit�.
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
Primarily, this PR updates `gradle-intellij-plugin` to 1.3.1 and removes the workaround for missing execute file permissions in the downloaded SDK on Mac/Linux. Also updates to latest Gradle and the latest plugins.