### PR TITLE
Update asmdef files when project references are added/removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 - Show preview for target typed new instances of `Color` ([RIDER-64151](https://youtrack.jetbrains.com/issue/RIDER-64151), [#2250](https://github.com/JetBrains/resharper-unity/pull/2250))
 - Update API information to 2022.1.0b7 ([#2276](https://github.com/JetBrains/resharper-unity/pull/2276))
+- Rider: Hide rename solution and manage NuGet packages by default ([RIDER-62297](https://youtrack.jetbrains.com/issue/RIDER-62297), [#2277](https://github.com/JetBrains/resharper-unity/pull/2277))
 - Unity editor: Expand Find Usages editor window by default ([#2239](https://github.com/JetBrains/resharper-unity/pull/2239))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Added
 
+- Add and remove references to `.asmdef` files when project references are modified, including with Remove Unused References refactoring ([#852](https://github.com/JetBrains/resharper-unity/issues/852), [RIDER-48660](https://youtrack.jetbrains.com/issue/RIDER-48660), [#1994](https://github.com/JetBrains/resharper-unity/issues/1994), [#2279](https://github.com/JetBrains/resharper-unity/pull/2279))
 - Add support for `.asmref` files ([#1406](https://github.com/JetBrains/resharper-unity/issues/1406), [#2252](https://github.com/JetBrains/resharper-unity/pull/2252))
 - Add inspection for correct method signature for `MenuItem` attribute ([RIDER-69350](https://youtrack.jetbrains.com/issue/RIDER-69350), [#2266](https://github.com/JetBrains/resharper-unity/pull/2266))
 - Rider: Add new run configuration to run Unity tests in batch mode ([RIDER-70675](https://youtrack.jetbrains.com/issue/RIDER-70675), [#2231](https://github.com/JetBrains/resharper-unity/pull/2231))
@@ -42,7 +43,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix display of unprintable characters in console output when debugging batchmode tests ([RIDER-74056](https://youtrack.jetbrains.com/issue/RIDER-74056), [#2265](https://github.com/JetBrains/resharper-unity/pull/2265))
 - Rider: Fix performance issue displaying long log issues from Unity ([RIDER-70574](https://youtrack.jetbrains.com/issue/RIDER-70574), [#2270](https://github.com/JetBrains/resharper-unity/pull/2270))
 - Rider: Fix showing duplicate project names in Unity Explorer under certain circumstances ([RIDER-67457](https://youtrack.jetbrains.com/issue/RIDER-67457), [#2273](https://github.com/JetBrains/resharper-unity/pull/2273))
-- Rider: Fix root folder of an external package ignoring namespace provider setting ([RIDER-65100](https://youtrack.jetbrains.com/issue/RIDER-65100), [#2274)(https://github.com/JetBrains/resharper-unity/pull/2274))
+- Rider: Fix root folder of an external package ignoring namespace provider setting ([RIDER-65100](https://youtrack.jetbrains.com/issue/RIDER-65100), [#2274](https://github.com/JetBrains/resharper-unity/pull/2274))
 
 
 

--- a/resharper/resharper-json/src/Json/Psi/Parsing/JsonNew.psi
+++ b/resharper/resharper-json/src/Json/Psi/Parsing/JsonNew.psi
@@ -57,16 +57,16 @@ options {
 
 errorhandling jsonNewObject
 :
-  LBRACE
+  LBRACE<LBRACE, LBrace>
   LIST (jsonNewMember<MEMBER, Members>?) SEP COMMA
-  RBRACE
+  RBRACE<RBRACE, RBrace>
 ;
 
 errorhandling jsonNewArray
 :
-  LBRACKET
+  LBRACKET<LBRACKET, LBracket>
   LIST (jsonNewValue<VALUE, Values>?) SEP COMMA
-  RBRACKET
+  RBRACKET<RBRACKET, RBracket>
 ;
 
 errorhandling jsonNewMember

--- a/resharper/resharper-json/src/Json/Psi/Parsing/JsonNewParser.cs
+++ b/resharper/resharper-json/src/Json/Psi/Parsing/JsonNewParser.cs
@@ -31,6 +31,16 @@ namespace JetBrains.ReSharper.Plugins.Json.Psi.Parsing
             return new JsonNewTreeBuilder(myLexer, lifetime);
         }
 
+        public IJsonNewValue ParseValue()
+        {
+            return Lifetime.Using(lifetime =>
+            {
+                var builder = CreateTreeBuilder(lifetime);
+                builder.ParseJsonValue();
+                return (IJsonNewValue) builder.GetTree();
+            });
+        }
+
         public IJsonNewLiteralExpression ParseLiteral()
         {
             return Lifetime.Using(lifetime =>

--- a/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewArray.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewArray.cs
@@ -1,7 +1,11 @@
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree
 {
     public partial interface IJsonNewArray
     {
+        void AddArrayElementBefore(IJsonNewValue value, IJsonNewValue? anchor);
+        void AddArrayElementAfter(IJsonNewValue value, IJsonNewValue? anchor);
         void RemoveArrayElement(IJsonNewValue argument);
     }
 }

--- a/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewObject.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewObject.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree
+{
+    public partial interface IJsonNewObject
+    {
+        IJsonNewMember AddMemberBefore(string key, IJsonNewValue value, IJsonNewMember? anchor);
+        IJsonNewMember AddMemberAfter(string key, IJsonNewValue value, IJsonNewMember? anchor);
+    }
+}

--- a/resharper/resharper-json/src/Json/Psi/Tree/Impl/JsonNewArray.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/Impl/JsonNewArray.cs
@@ -1,14 +1,79 @@
-using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Plugins.Json.Psi.Parsing.TokenNodeTypes;
+using JetBrains.ReSharper.Psi.ExtensionsAPI;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Resources.Shell;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree.Impl
 {
     internal partial class JsonNewArray
     {
-        public void RemoveArrayElement([NotNull] IJsonNewValue argument)
+        public void AddArrayElementBefore(IJsonNewValue value, IJsonNewValue? anchor)
+        {
+            if (anchor == null)
+            {
+                var lastItem = Values.LastOrDefault();
+                if (lastItem != null)
+                {
+                    AddArrayElementAfter(value, lastItem);
+                    return;
+                }
+
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    if (RBracket != null)
+                        ModificationUtil.AddChildBefore(RBracket, value);
+                    else if (LBracket != null)
+                        ModificationUtil.AddChildAfter(LBracket, value);
+                }
+            }
+            else
+            {
+                Assertion.Assert(Values.Contains(anchor));
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    var comma = JsonNewTokenNodeTypes.COMMA.CreateLeafElement();
+                    LowLevelModificationUtil.AddChildBefore(anchor, comma);
+                    ModificationUtil.AddChildBefore(comma, value);
+                }
+            }
+        }
+
+        public void AddArrayElementAfter(IJsonNewValue value, IJsonNewValue? anchor)
+        {
+            if (anchor == null)
+            {
+                var firstItem = ValuesEnumerable.FirstOrDefault();
+                if (firstItem != null)
+                {
+                    AddArrayElementBefore(value, firstItem);
+                    return;
+                }
+
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    if (RBracket != null)
+                        ModificationUtil.AddChildBefore(RBracket, value);
+                    else if (LBracket != null)
+                        ModificationUtil.AddChildAfter(LBracket, value);
+                }
+            }
+            else
+            {
+                Assertion.Assert(Values.Contains(anchor));
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    var comma = JsonNewTokenNodeTypes.COMMA.CreateLeafElement();
+                    LowLevelModificationUtil.AddChildAfter(anchor, comma);
+                    ModificationUtil.AddChildAfter(comma, value);
+                }
+            }
+        }
+
+        public void RemoveArrayElement(IJsonNewValue argument)
         {
             using (WriteLockCookie.Create(IsPhysical()))
             {

--- a/resharper/resharper-json/src/Json/Psi/Tree/Impl/JsonNewObject.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/Impl/JsonNewObject.cs
@@ -1,0 +1,82 @@
+using JetBrains.Diagnostics;
+using JetBrains.ReSharper.Plugins.Json.Psi.Parsing.TokenNodeTypes;
+using JetBrains.ReSharper.Psi.ExtensionsAPI;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Resources.Shell;
+
+#nullable enable
+
+namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree.Impl
+{
+    internal partial class JsonNewObject
+    {
+        public IJsonNewMember AddMemberBefore(string key, IJsonNewValue value, IJsonNewMember? anchor)
+        {
+            if (anchor == null)
+            {
+                var lastItem = Members.LastOrDefault();
+                if (lastItem != null)
+                    return AddMemberAfter(key, value, lastItem);
+
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    var member = CreateMember(key, value);
+                    if (RBrace != null)
+                        ModificationUtil.AddChildBefore(RBrace, member);
+                    else if (LBrace != null)
+                        ModificationUtil.AddChildAfter(LBrace, member);
+                    return member;
+                }
+            }
+
+            Assertion.Assert(Members.Contains(anchor));
+            using (WriteLockCookie.Create(parent.IsPhysical()))
+            {
+                var member = CreateMember(key, value);
+                var comma = JsonNewTokenNodeTypes.COMMA.CreateLeafElement();
+                LowLevelModificationUtil.AddChildBefore(anchor, comma);
+                ModificationUtil.AddChildBefore(comma, member);
+                return member;
+            }
+        }
+
+        public IJsonNewMember AddMemberAfter(string key, IJsonNewValue value, IJsonNewMember? anchor)
+        {
+            if (anchor == null)
+            {
+                var firstItem = MembersEnumerable.FirstOrDefault();
+                if (firstItem != null)
+                    return AddMemberBefore(key, value, firstItem);
+
+                using (WriteLockCookie.Create(parent.IsPhysical()))
+                {
+                    var member = CreateMember(key, value);
+                    if (RBrace != null)
+                        ModificationUtil.AddChildBefore(RBrace, member);
+                    else if (LBrace != null)
+                        ModificationUtil.AddChildAfter(LBrace, member);
+                    return member;
+                }
+            }
+
+            Assertion.Assert(Members.Contains(anchor));
+            using (WriteLockCookie.Create(parent.IsPhysical()))
+            {
+                var member = CreateMember(key, value);
+                var comma = JsonNewTokenNodeTypes.COMMA.CreateLeafElement();
+                LowLevelModificationUtil.AddChildAfter(anchor, comma);
+                ModificationUtil.AddChildAfter(comma, member);
+                return member;
+            }
+        }
+
+        private static IJsonNewMember CreateMember(string key, IJsonNewValue value)
+        {
+            var member = (JsonNewMember)ElementType.JSON_NEW_MEMBER.Create();
+            member.AddChild(JsonNewTokenNodeTypes.DOUBLE_QUOTED_STRING.CreateLeafElement($"\"{key}\""));
+            member.AddChild(JsonNewTokenNodeTypes.COLON.CreateLeafElement());
+            member.AddChild(value);
+            return member;
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Unity.Rider/Integration/Protocol/BackendUnityHost.cs
+++ b/resharper/resharper-unity/src/Unity.Rider/Integration/Protocol/BackendUnityHost.cs
@@ -36,7 +36,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Rider.Integration.Protocol
 
         // Do not use for subscriptions! Should only be used to read values and start tasks.
         // The property's value will be null when the backend/Unity protocol is not available
-        public readonly ViewableProperty<BackendUnityModel?> BackendUnityModel = new(null!);
+        public readonly ViewableProperty<BackendUnityModel?> BackendUnityModel = new(null);
 
         // TODO: Remove FrontendBackendHost. It's too easy to get circular dependencies
         public BackendUnityHost(Lifetime lifetime, ILogger logger,

--- a/resharper/resharper-unity/src/Unity/AsmDef/AsmDefUtils.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/AsmDefUtils.cs
@@ -1,0 +1,11 @@
+using System;
+
+#nullable enable
+
+namespace JetBrains.ReSharper.Plugins.Unity.AsmDef
+{
+    public static class AsmDefUtils
+    {
+        public static string FormatGuidReference(Guid guid) => $"guid:{guid:N}";
+    }
+}

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Occurrences/AsmDefNameOccurrencePresenter.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Occurrences/AsmDefNameOccurrencePresenter.cs
@@ -1,4 +1,3 @@
-using System.Drawing;
 using JetBrains.Application.UI.Controls.JetPopupMenu;
 using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
@@ -11,6 +10,8 @@ using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.UI.Icons;
 using JetBrains.UI.RichText;
 using JetBrains.Util.Media;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Occurrences
 {
@@ -36,7 +37,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Occurrences
                 descriptor.Icon = GetIcon(solution, asmDefNameOccurrence, options);
 
             var fileName = cache.GetAsmDefLocationByAssemblyName(asmDefNameOccurrence.Name);
-            if (fileName != null && !fileName.IsEmpty)
+            if (fileName.IsNotEmpty)
             {
                 var style = TextStyle.FromForeColor(JetSystemColors.GrayText);
                 descriptor.ShortcutText = new RichText($" in {fileName.Name}", style);
@@ -46,9 +47,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Occurrences
             return true;
         }
 
-        private static IconId GetIcon(ISolution solution,
-                                      AsmDefNameOccurrence asmDefNameOccurrence,
-                                      OccurrencePresentationOptions options)
+        private static IconId? GetIcon(ISolution solution,
+                                       AsmDefNameOccurrence asmDefNameOccurrence,
+                                       OccurrencePresentationOptions options)
         {
             var presentationService = asmDefNameOccurrence.SourceFile.GetPsiServices()
                 .GetComponent<PsiSourceFilePresentationService>();

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/QuickFixes/ConvertToGuidReferenceQuickFix.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/QuickFixes/ConvertToGuidReferenceQuickFix.cs
@@ -14,6 +14,8 @@ using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.TextControl;
 
+#nullable enable
+
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
 {
     [QuickFix]
@@ -26,10 +28,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
             myLiteralExpression = warning.LiteralExpression;
         }
 
-        protected override ITreeNode TryGetContextTreeNode() => myLiteralExpression;
+       protected override ITreeNode TryGetContextTreeNode() => myLiteralExpression;
         public override string Text => "To GUID reference";
 
-        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        protected override Action<ITextControl>? ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
         {
             // We should never get null, we check the reference resolves before adding the highlight
             var reference = myLiteralExpression.FindReference<AsmDefNameReference>();
@@ -45,7 +47,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.QuickFixes
                     using (WriteLockCookie.Create())
                     {
                         var factory = JsonNewElementFactory.GetInstance(myLiteralExpression.GetPsiModule());
-                        var newLiteralExpression = factory.CreateStringLiteral($"guid:{guid:N}");
+                        var newLiteralExpression = factory.CreateStringLiteral(AsmDefUtils.FormatGuidReference(guid.Value));
                         ModificationUtil.ReplaceChild(myLiteralExpression, newLiteralExpression);
                     }
                 }

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Caches/AsmDefCache.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Caches/AsmDefCache.cs
@@ -80,10 +80,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Caches
 
         // Note that this is getting the location of a .asmdef file for a given assembly definition name. The name of
         // the file might not match the name of the assembly definition!
-        public VirtualFileSystemPath? GetAsmDefLocationByAssemblyName(string assemblyName)
+        public VirtualFileSystemPath GetAsmDefLocationByAssemblyName(string assemblyName)
         {
             Locks.AssertReadAccessAllowed();
-            return GetSourceFileForAssembly(assemblyName)?.GetLocation();
+            return GetSourceFileForAssembly(assemblyName)?.GetLocation()
+                   ?? VirtualFileSystemPath.GetEmptyPathFor(mySolution.GetInteractionContext());
         }
 
         public IEnumerable<AsmDefVersionDefine> GetVersionDefines(string assemblyName)

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Caches/PreProcessingDirectiveCache.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Caches/PreProcessingDirectiveCache.cs
@@ -98,10 +98,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Caches
         private List<PreProcessingDirective> GetBaseDefines()
         {
             var directives = new List<PreProcessingDirective>();
-            var mainProject = mySolution.GetProjectsByName("Assembly-CSharp").FirstOrDefault();
+            var mainProject = mySolution.GetMainUnityProject();
             if (mainProject == null)
             {
-                myLogger.Warn("Cannot find Assembly-CSharp project!");
+                myLogger.Warn("Cannot find main Unity project! (No Assembly-CSharp.csproj?)");
                 return directives;
             }
 
@@ -172,8 +172,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Caches
 
             projectModelChange.VisitItemDeltasRecursively(change =>
             {
-                if (change.IsPropertiesChanged && change.ProjectItem is IProject project && project.IsAssemblyCSharp())
-                    Invalidate("Properties change for Assembly-CSharp");
+                if (change.IsPropertiesChanged && change.ProjectItem is IProject project && project.IsMainUnityProject())
+                    Invalidate("Properties change for main Unity project");
             });
         }
 
@@ -183,15 +183,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Caches
                 Invalidate("Packages updated");
         }
 
-        private void OnAsmDefCacheUpdated(bool _)
-        {
-            Invalidate("AsmDefCache updated");
-        }
+        private void OnAsmDefCacheUpdated(bool _) => Invalidate("AsmDefCache updated");
 
-        private void OnApplicationVersionChanged(Version _)
-        {
-            Invalidate("Application version changed");
-        }
+        private void OnApplicationVersionChanged(Version _) => Invalidate("Application version changed");
 
         private void Invalidate(string reason)
         {

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Modules/AsmDefModuleReferenceChangeListener.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Modules/AsmDefModuleReferenceChangeListener.cs
@@ -1,0 +1,545 @@
+using System;
+using System.Linq;
+using JetBrains.Application.changes;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Tasks;
+using JetBrains.ReSharper.Plugins.Json.Psi;
+using JetBrains.ReSharper.Plugins.Json.Psi.Tree;
+using JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Caches;
+using JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel;
+using JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Paths;
+using JetBrains.ReSharper.Psi.Transactions;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.Util;
+using JetBrains.Util.dataStructures;
+
+using ProjectExtensions = JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel.ProjectExtensions;
+
+#nullable enable
+
+namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Modules
+{
+    // Listen for a module reference being added or removed, and update the source module's .asmdef file, if possible.
+    // * The source module is the module that is being added to or removed from. It will always be a project, and it
+    //   should have an asmdef file. All generated projects will have an asmdef file apart from the predefined
+    //   Assembly-CSharp* projects, which are at the root of the dependency tree. These predefined projects
+    //   automatically reference any asmdef project that has "autoReferenced" set to true.
+    // * The target module is the module being added or removed. It will most likely/hopefully be an asmdef project, but
+    //   could also be a predefined project (which will be an incorrect add/remove) or a plain DLL, split into external,
+    //   plugin, system or engine DLLs.
+    // * If we're adding/removing an asmdef project, update the "references" node in the source asmdef, or set
+    //   "autoReferenced" true if source is a predefined project (notification?)
+    // * Adding/removing a predefined project is not supported
+    // * If we're adding/removing an engine DLL (UnityEngine* or UnityEditor*), set "noEngineReferences" to true/false
+    // * A plugin DLL is a DLL that lives inside Assets or a package. By default, they're automatically referenced. If
+    //   "overrideReferences" is true, the plugins need to be listed manually
+    // * Adding/removing a system DLL (System* or Microsoft*) is not supported
+    // * Any other DLL is external and is not supported
+    //
+    // * ReSharper will only add a valid module, so we won't get circular references
+    // * If we have Player projects and use Alt+Enter to add a reference from a QF, the reference is only added to the
+    //   current project context. We could update the other context's project?
+    [SolutionComponent]
+    public class AsmDefModuleReferenceChangeListener : IChangeProvider
+    {
+        private readonly UnitySolutionTracker myUnitySolutionTracker;
+        private readonly ChangeManager myChangeManager;
+        private readonly AsmDefCache myAsmDefCache;
+        private readonly MetaFileGuidCache myMetaFileGuidCache;
+        private readonly IPsiServices myPsiServices;
+        private readonly ILogger myLogger;
+
+        public AsmDefModuleReferenceChangeListener(Lifetime lifetime, ISolution solution,
+                                                   UnitySolutionTracker unitySolutionTracker,
+                                                   ChangeManager changeManager,
+                                                   AsmDefCache asmDefCache, MetaFileGuidCache metaFileGuidCache,
+                                                   ISolutionLoadTasksScheduler solutionLoadTasksScheduler,
+                                                   IPsiServices psiServices, ILogger logger)
+        {
+            myUnitySolutionTracker = unitySolutionTracker;
+            myChangeManager = changeManager;
+            myAsmDefCache = asmDefCache;
+            myMetaFileGuidCache = metaFileGuidCache;
+            myPsiServices = psiServices;
+            myLogger = logger;
+
+            solutionLoadTasksScheduler.EnqueueTask(new SolutionLoadTask("RegisterAsmDefReferenceChangeListener",
+                SolutionLoadTaskKinds.Done, () =>
+                {
+                    changeManager.RegisterChangeProvider(lifetime, this);
+                    changeManager.AddDependency(lifetime, this, solution);
+                }));
+        }
+
+        public object? Execute(IChangeMap changeMap)
+        {
+            if (!myUnitySolutionTracker.IsUnityProject.Value)
+                return null;
+
+            var changes = changeMap.GetChanges<SolutionChange>().ToList();
+            if (changes.IsEmpty())
+                return null;
+
+            var collector = new ReferenceChangeCollector();
+            foreach (var solutionChange in changes)
+                solutionChange.Accept(collector);
+
+            collector.RemoveProblematicChangeEvents();
+
+            // We can't make changes to the PSI while we're in a change notification
+            if (!collector.AddedReferences.IsEmpty || !collector.RemovedReferences.IsEmpty)
+                myChangeManager.ExecuteAfterChange(() => HandleReferenceChanges(collector));
+
+            return null;
+        }
+
+        private void HandleReferenceChanges(ReferenceChangeCollector collector)
+        {
+            // TODO: Handle multiple add/removes
+
+            foreach (var addedReference in collector.AddedReferences)
+            {
+                // Note that an asmdef name will usually match the name of the project being added. The only exception
+                // is for player projects. The returned addedAsmDefName here is the asmdef name/non-player project name
+                var ownerProject = addedReference.OwnerModule;
+                var addedReferenceName = addedReference.Name;
+                var (_, ownerAsmDefLocation) = GetAsmDefLocationForProject(ownerProject.Name);
+                var (addedAsmDefName, addedAsmDefLocation) = GetAsmDefLocationForProject(addedReferenceName);
+
+                switch (addedReference)
+                {
+                    case IProjectToProjectReference:
+                        OnAddedProjectReference(ownerProject, addedReferenceName, addedAsmDefName, ownerAsmDefLocation,
+                            addedAsmDefLocation);
+                        break;
+
+                    case IProjectToAssemblyReference:
+                        OnAddedAssemblyReference(ownerProject, addedReferenceName, ownerAsmDefLocation);
+                        break;
+
+                    default:
+                        var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+                        if (ownerProjectKind != ProjectKind.Custom)
+                        {
+                            // This is an unexpected reference modification (COM? SDK? Unresolved assembly?) to either
+                            // a predefined or asmdef project. This change will be lost when Unity next regenerates
+                            myLogger.Warn("Unsupported reference modification: {0}", addedReference);
+
+                            // TODO: Notify the user that a weird/unsupported reference modification has happened
+                        }
+                        break;
+                }
+            }
+
+            foreach (var removedReference in collector.RemovedReferences)
+            {
+                var ownerProject = removedReference.OwnerModule;
+                var removedReferenceName = removedReference.Name;
+                var (_, ownerAsmDefLocation) = GetAsmDefLocationForProject(ownerProject.Name);
+                var (removedAsmDefName, removedAsmDefLocation) = GetAsmDefLocationForProject(removedReferenceName);
+
+                switch (removedReference)
+                {
+                    case IProjectToProjectReference:
+                        OnRemovedProjectReference(ownerProject, removedReferenceName, removedAsmDefName,
+                            ownerAsmDefLocation, removedAsmDefLocation);
+                        break;
+
+                    case IProjectToAssemblyReference:
+                        OnRemovedAssemblyReference(ownerProject, removedReferenceName, ownerAsmDefLocation);
+                        break;
+
+                    default:
+                        var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+                        if (ownerProjectKind != ProjectKind.Custom)
+                        {
+                            // This is an unexpected reference modification (COM? SDK? Unresolved assembly?) to either
+                            // a predefined or asmdef project. This change will be lost when Unity next regenerates
+                            myLogger.Warn("Unsupported reference modification: {0}", removedReference);
+
+                            // TODO: Notify the user that a weird/unsupported reference modification has happened
+                        }
+                        break;
+                }
+            }
+        }
+
+        private void OnAddedProjectReference(IProject ownerProject,
+                                             string addedProjectName,
+                                             string addedAsmDefName,
+                                             VirtualFileSystemPath ownerAsmDefLocation,
+                                             VirtualFileSystemPath addedAsmDefLocation)
+        {
+            var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+            var addedProjectKind = GetProjectKind(addedProjectName, addedAsmDefLocation);
+
+            if (ownerProjectKind == ProjectKind.Custom)
+            {
+                // Unsupported scenario. The user is modifying a custom project. Do nothing - Unity won't regenerate the
+                // project that's being modified, so there will be no data loss, so there's no need to notify the user.
+                // Unity will regenerate teh solution, which will remove the custom project. If we want to notify the
+                // user, it would be better to notify them when initially adding the custom project.
+                myLogger.Info("{0} project {1} added as a reference to {2} project {3}. Ignoring change",
+                    addedProjectKind, addedProjectName, ownerProjectKind, ownerProject.Name);
+                return;
+            }
+
+            if (addedProjectKind == ProjectKind.Custom)
+            {
+                // Unsupported scenario. The user is trying to modify a generated project by adding a reference to a
+                // custom project. Changes will be lost the next time Unity regenerates the projects
+                myLogger.Warn(
+                    "Unsupported reference modification. Added reference to unknown project will be lost when Unity regenerates projects");
+
+                // TODO: Notify user that modifying a generated project will lose changes
+                return;
+            }
+
+            if (addedProjectKind == ProjectKind.Predefined)
+            {
+                // Weird scenario, shouldn't happen
+                myLogger.Warn("Adding {0} project {1} as a reference to {2} project {3}?! Weird!", addedProjectKind,
+                    addedProjectName, ownerProjectKind, ownerProject.Name);
+                return;
+            }
+
+            switch (ownerProjectKind, addedProjectKind)
+            {
+                case (ProjectKind.AsmDef, ProjectKind.AsmDef):
+                    AddAsmDefReference(ownerProject, ownerAsmDefLocation, addedAsmDefName, addedAsmDefLocation);
+                    break;
+
+                case (ProjectKind.Predefined, ProjectKind.AsmDef):
+                    // Predefined projects reference all asmdef projects by default. An asmdef can opt out by setting
+                    // "autoReferenced" to false.
+                    myLogger.Info(
+                        "Adding asmdef reference to predefined project. Should already be referenced. Check 'autoReferenced' value in asmdef");
+
+                    // TODO: Set "autoReferenced" to true
+                    break;
+            }
+        }
+
+        private void AddAsmDefReference(IProject ownerProject, VirtualFileSystemPath ownerAsmDefLocation,
+                                        string addedAsmDefName, VirtualFileSystemPath addedAsmDefLocation)
+        {
+            var sourceFile = ownerProject.GetPsiSourceFileInProject(ownerAsmDefLocation);
+            if (sourceFile?.GetDominantPsiFile<JsonNewLanguage>() is not IJsonNewFile psiFile)
+                return;
+
+            var rootObject = psiFile.GetRootObject();
+            if (rootObject == null)
+                return;
+
+            var guid = myMetaFileGuidCache.GetAssetGuid(addedAsmDefLocation);
+            if (guid == null)
+                myLogger.Warn("Cannot find asset GUID for added asmdef {0}! Can only add as name", addedAsmDefLocation);
+            var addedAsmDefGuid = guid == null ? null : AsmDefUtils.FormatGuidReference(guid.Value);
+
+            var referencesProperty = rootObject.GetFirstPropertyValue<IJsonNewArray>("references");
+            var existingArrayElement =
+                FindReferenceElement(referencesProperty, addedAsmDefName, addedAsmDefGuid, out var useGuids);
+            if (existingArrayElement.Count != 0)
+            {
+                myLogger.Verbose("Reference {0} already exists in asmdef {1}", addedAsmDefName, ownerAsmDefLocation);
+                return;
+            }
+
+            using (new PsiTransactionCookie(myPsiServices, DefaultAction.Commit, "AddAsmDefReference"))
+            {
+                var referenceText = useGuids && addedAsmDefGuid != null ? addedAsmDefGuid : addedAsmDefName;
+                var elementFactory = JsonNewElementFactory.GetInstance(psiFile.GetPsiModule());
+                if (referencesProperty == null)
+                {
+                    referencesProperty =
+                        (IJsonNewArray)elementFactory.CreateValue($"[ \"{referenceText}\" ]");
+                    rootObject.AddMemberBefore("references", referencesProperty, null);
+                }
+                else
+                {
+                    var reference = elementFactory.CreateStringLiteral(referenceText);
+                    referencesProperty.AddArrayElementBefore(reference, null);
+                }
+            }
+        }
+
+        private void OnAddedAssemblyReference(IProject ownerProject, string addedAssemblyName,
+                                              VirtualFileSystemPath ownerAsmDefLocation)
+        {
+            var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+
+            switch (ownerProjectKind)
+            {
+                case ProjectKind.Custom:
+                    // Don't care. The user has added a custom project, and has added a reference to it. The project
+                    // will be removed the next time Unity regenerates the solution, but they won't lose the changes to
+                    // the project. We don't notify about this action - it would be better to notify when the project is
+                    // initially added
+                    myLogger.Info("Adding assembly {0} to custom project {1}. Ignoring change", addedAssemblyName,
+                        ownerProject.Name);
+                    return;
+
+                case ProjectKind.Predefined:
+                    // Unsupported scenario. Custom assemblies should live in Assets and requires regenerating the
+                    // project file
+                    myLogger.Warn(
+                        "Unsupported reference modification. Added assembly reference will be lost when Unity regenerates project files");
+
+                    // TODO: Notify the user
+                    return;
+
+                case ProjectKind.AsmDef:
+                    // AsmDef can only reference custom assemblies if that assembly is a plugin (i.e. it's an asset,
+                    // either in Assets or a package). By default, all asmdef projects will reference all plugin
+                    // assemblies. An asmdef can opt out by setting "overrideReferences" to true and listing each
+                    // plugin individually.
+                    // This is a complex scenario:
+                    // 1. Check addedAssembly is a plugin
+                    // 2. If not, notify user that this is not supported
+                    // 3. If true, check "overrideReferences" (if false, this is a weird scenario)
+                    // 4. If true, add assembly name to "precompiledReferences"
+                    // It might be easier to notify the user to edit assembly references using Unity
+                    // TODO: All of the above ^^
+
+                    myLogger.Warn(
+                        "Unsupported reference modification. Added assembly reference will be lost when Unity regenerates project files");
+                    break;
+            }
+        }
+
+        private void OnRemovedProjectReference(IProject ownerProject,
+                                               string removedProjectName,
+                                               string removedAsmDefName,
+                                               VirtualFileSystemPath ownerAsmDefLocation,
+                                               VirtualFileSystemPath removedAsmDefLocation)
+        {
+            var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+            var removedProjectKind = GetProjectKind(removedProjectName, removedAsmDefLocation);
+
+            if (ownerProjectKind == ProjectKind.Custom)
+            {
+                // Unsupported scenario. The user is modifying a custom project. Do nothing - Unity won't regenerate the
+                // project that's being modified, so there will be no data loss, so there's no need to notify the user.
+                // Unity will regenerate teh solution, which will remove the custom project. If we want to notify the
+                // user, it's best to notify them when initially adding the custom project.
+                myLogger.Info("{0} project {1} removed as a reference from {2} project {3}. Ignoring change",
+                    removedProjectKind, removedProjectName, ownerProjectKind, ownerProject.Name);
+                return;
+            }
+
+            if (removedProjectKind == ProjectKind.Custom)
+            {
+                // Unsupported scenario. The user is trying to modify a generated project by adding a reference to a
+                // custom project.
+                myLogger.Warn(
+                    "Unsupported reference modification. Added assembly reference will be lost when Unity regenerates project files");
+
+                // TODO: Notify user that modifying a generated project will lose changes
+                return;
+            }
+
+            if (removedProjectKind == ProjectKind.Predefined)
+            {
+                // Weird scenario, shouldn't happen
+                myLogger.Warn("Removing {0} project {1} reference from {2} project {3}?! Weird!", removedProjectKind,
+                    removedProjectName, ownerProjectKind, ownerProject.Name);
+                return;
+            }
+
+            switch (ownerProjectKind, removedProjectKind)
+            {
+               case (ProjectKind.AsmDef, ProjectKind.AsmDef):
+                   RemoveAsmDefReference(ownerProject, ownerAsmDefLocation, removedAsmDefName, removedAsmDefLocation);
+                   break;
+
+               case (ProjectKind.Predefined, ProjectKind.AsmDef):
+                   myLogger.Info(
+                       "Removing asmdef reference from predefined project. Check 'autoReferenced' value in asmdef");
+
+                   // TODO: Should set "autoReferenced" to false in the removed asmdef project. Should this prompt?
+                   break;
+            }
+        }
+
+        private void RemoveAsmDefReference(IProject ownerProject, VirtualFileSystemPath ownerAsmDefLocation,
+                                           string removedAsmDefName, VirtualFileSystemPath removedAsmDefLocation)
+        {
+            var sourceFile = ownerProject.GetPsiSourceFileInProject(ownerAsmDefLocation);
+            var psiFile = sourceFile?.GetDominantPsiFile<JsonNewLanguage>() as IJsonNewFile;
+            var rootObject = psiFile?.GetRootObject();
+            if (rootObject == null)
+                return;
+
+            var guid = myMetaFileGuidCache.GetAssetGuid(removedAsmDefLocation);
+            if (guid == null)
+                myLogger.Warn("Cannot find asset for added asmdef {0}! Can only add as name", removedAsmDefLocation);
+            var removedAsmDefGuid = guid == null ? null : AsmDefUtils.FormatGuidReference(guid.Value);
+
+            // "references" might be missing if we've already removed all references and Unity isn't running to refresh
+            // the project files
+            var referencesProperty = rootObject.GetFirstPropertyValue<IJsonNewArray>("references");
+            if (referencesProperty == null)
+            {
+                myLogger.Verbose("Cannot find 'references' property. Nothing to remove");
+                return;
+            }
+
+            var existingArrayElement =
+                FindReferenceElement(referencesProperty, removedAsmDefName, removedAsmDefGuid, out _);
+            if (existingArrayElement.Count == 0)
+            {
+                myLogger.Verbose("Reference {0} already removed from asmdef {1}", removedAsmDefName,
+                    ownerAsmDefLocation);
+                return;
+            }
+
+            using (new PsiTransactionCookie(myPsiServices, DefaultAction.Commit, "AddAsmDefReference"))
+            {
+                foreach (var existingLiteral in existingArrayElement)
+                    referencesProperty.RemoveArrayElement(existingLiteral);
+            }
+        }
+
+        private void OnRemovedAssemblyReference(IProject ownerProject, string removedAssemblyName,
+                                                VirtualFileSystemPath ownerAsmDefLocation)
+        {
+            var ownerProjectKind = GetProjectKind(ownerProject.Name, ownerAsmDefLocation);
+
+            switch (ownerProjectKind)
+            {
+                case ProjectKind.Custom:
+                    // Don't care. The user has added a custom project, and has removed a reference from it. The project
+                    // will be removed the next time Unity regenerates the solution, but they won't lose the changes to
+                    // the project. We don't notify about this action - it would be better to notify when the project is
+                    // initially added
+                    myLogger.Info("Removing assembly {0} to custom project {1}. Ignoring change", removedAssemblyName,
+                        ownerProject.Name);
+                    return;
+
+                case ProjectKind.Predefined:
+                    // Unsupported scenario. Custom assemblies should live in Assets and requires regenerating the
+                    // project file
+                    myLogger.Warn("Unsupported reference modification. Change will be lost when Unity regenerates project files");
+
+                    // TODO: Notify the user
+                    return;
+
+                case ProjectKind.AsmDef:
+                    // Like adding an assembly reference to an asmdef project, removing one is only supported if we're
+                    // removing an explicit plugin reference.
+                    // 1. Check removedAssembly is a plugin
+                    // 2. If not, notify user that this is not supported
+                    // 3. If true, check "overrideReferences" (if false, this is a weird scenario)
+                    // 4. If true, remove assembly name from "precompiledReferences"
+                    // It might be easier to notify the user to edit assembly references using Unity
+                    // TODO: All of the above ^^
+
+                    myLogger.Warn(
+                        "Unsupported reference modification. Changes will be lost when Unity regenerates project files");
+                    break;
+            }
+        }
+
+        private static ProjectKind GetProjectKind(string projectName, VirtualFileSystemPath asmDefLocation)
+        {
+            if (asmDefLocation.IsNotEmpty) return ProjectKind.AsmDef;
+            if (ProjectExtensions.IsOneOfPredefinedUnityProjects(projectName, true)) return ProjectKind.Predefined;
+            return ProjectKind.Custom;
+        }
+
+        private static FrugalLocalList<IJsonNewValue> FindReferenceElement(IJsonNewArray? array, string asmDefName,
+                                                                           string? asmDefGuid, out bool useGuids)
+        {
+            useGuids = false;
+            var count = 0;
+            var guidCount = 0;
+
+            // The user might have added more than one, even though that's an error
+            var results = new FrugalLocalList<IJsonNewValue>();
+            foreach (var literal in array.ValuesAsLiteral())
+            {
+                // TODO: Helper function in JsonNewUtil that doesn't allocate?
+                var text = literal.GetUnquotedText();
+                if (text.Equals(asmDefName, StringComparison.OrdinalIgnoreCase))
+                    results.Add(literal);
+                else if (asmDefGuid != null && text.Equals(asmDefGuid))
+                    results.Add(literal);
+
+                count++;
+                if (text.StartsWith("guid:", StringComparison.OrdinalIgnoreCase))
+                    guidCount++;
+            }
+
+            // Prefer GUIDs, unless everything else is non-guid
+            if (count == 0 || guidCount > 0)
+                useGuids = true;
+
+            return results;
+        }
+
+        private (string, VirtualFileSystemPath) GetAsmDefLocationForProject(string projectName)
+        {
+            // Assembly name and project name are the same for asmdef projects, unless it's a .Player project. We want
+            // to return the actual name of the asmdef reference we'll be adding
+            var location = myAsmDefCache.GetAsmDefLocationByAssemblyName(projectName);
+            if (location.IsNotEmpty)
+                return (projectName, location);
+            projectName = ProjectExtensions.StripPlayerSuffix(projectName);
+            return (projectName, myAsmDefCache.GetAsmDefLocationByAssemblyName(projectName));
+        }
+
+        private class ReferenceChangeCollector : RecursiveProjectModelChangeDeltaVisitor
+        {
+            public FrugalLocalList<IProjectToModuleReference> AddedReferences;
+            public FrugalLocalList<IProjectToModuleReference> RemovedReferences;
+
+            public override void VisitProjectReferenceDelta(ProjectReferenceChange change)
+            {
+                if (change.IsClosingSolution || change.IsOpeningSolution)
+                    return;
+
+                if (change.IsAdded)
+                    AddedReferences.Add(change.ProjectToModuleReference);
+                else if (change.IsRemoved) RemovedReferences.Add(change.ProjectToModuleReference);
+            }
+
+            public void RemoveProblematicChangeEvents()
+            {
+                // We will be notified of reference changes when projects are reloaded after Unity regenerates the
+                // project files. If we added a reference to a .Player project (the "Add reference" QF might arbitrarily
+                // pick this) then Unity will regenerate the project files with the correct reference, and we'll see
+                // both a removal of the .Player and an addition of the proper project. Since we always add the correct
+                // asmdef reference even for .Player references, make sure we don't process this removal!
+                // We could also post process this list to remove any notifications for .Player projects if there are
+                // also notifications for non-player projects.
+                var toRemove = new FrugalLocalList<IProjectToModuleReference>();
+                foreach (var removedReference in RemovedReferences)
+                {
+                    if (ProjectExtensions.IsPlayerProjectName(removedReference.Name))
+                    {
+                        var nonPlayerProjectName = ProjectExtensions.StripPlayerSuffix(removedReference.Name);
+                        foreach (var addedReference in AddedReferences)
+                        {
+                            if (addedReference.Name.Equals(nonPlayerProjectName, StringComparison.OrdinalIgnoreCase))
+                                toRemove.Add(removedReference);
+                        }
+                    }
+                }
+
+                foreach (var reference in toRemove)
+                    RemovedReferences.Remove(reference);
+            }
+        }
+
+        private enum ProjectKind
+        {
+            Predefined,
+            AsmDef,
+            Custom
+        }
+    }
+}

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Search/GuidReferenceUsageSearchFactory.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Search/GuidReferenceUsageSearchFactory.cs
@@ -67,7 +67,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Search
                                        MetaFileGuidCache metaFileGuidCache)
         {
             var asmDefLocation = asmDefCache.GetAsmDefLocationByAssemblyName(element.ShortName);
-            if (asmDefLocation != null)
+            if (asmDefLocation.IsNotEmpty)
             {
                 var assetGuid = metaFileGuidCache.GetAssetGuid(asmDefLocation);
                 if (assetGuid.HasValue)

--- a/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Feature/Services/LiveTemplates/Scope/UnityProjectScopeProvider.cs
@@ -72,9 +72,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Feature.Services.LiveTemplate
                 }
             }
 
-            if (!project.IsOneOfPredefinedUnityProjects())
+            if (!project.IsOneOfPredefinedUnityProjects(true))
             {
-                // For a project with UNITY_EDITOR define we have to allow Editor Templates 
+                // For a project with UNITY_EDITOR define we have to allow Editor Templates
                 if (project != null && project.ProjectProperties.ActiveConfigurations.Configurations
                     .OfType<IManagedProjectConfiguration>()
                     .Select(configuration => configuration.DefineConstants)

--- a/resharper/resharper-unity/src/Unity/Core/ProjectModel/ProjectExtensions.cs
+++ b/resharper/resharper-unity/src/Unity/Core/ProjectModel/ProjectExtensions.cs
@@ -1,6 +1,8 @@
-using JetBrains.Annotations;
+using System;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel.Properties.Flavours;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
 {
@@ -11,7 +13,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
         public const string ProjectSettingsFolder = "ProjectSettings";
         public const string LibraryFolder = "Library";
 
-        public static bool HasUnityReference([NotNull] this ISolution solution)
+        public static bool HasUnityReference(this ISolution solution)
         {
             var tracker = solution.GetComponent<UnitySolutionTracker>();
             return tracker.HasUnityReference.Value;
@@ -20,29 +22,28 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
         /// <summary>
         ///  Checks that specific project unity reference or specific unity guid
         /// </summary>
-        public static bool IsUnityProject([CanBeNull] this IProject project)
+        public static bool IsUnityProject(this IProject? project)
         {
             if (project == null || !project.IsValid())
                 return false;
+
             // Only VSTU adds the Unity project flavour. Unity + Rider don't, so we have to look at references
             if (HasUnityFlavour(project))
                 return true;
 
+            // Quicker than calling GetComponent
             var referenceTracker = project.GetData(UnityReferencesTracker.UnityReferencesTrackerKey);
-            if (referenceTracker == null)
-                return false;
-
-            return referenceTracker.IsUnityProject(project);
+            return referenceTracker != null && referenceTracker.IsUnityProject(project);
         }
 
-        public static bool IsPlayerProject([CanBeNull] this IProject project)
+        public static bool IsPlayerProject(this IProject? project)
         {
             if (project == null || !project.IsValid())
                 return false;
             return project.Name.EndsWith(".Player");
         }
 
-        public static bool IsUnityGeneratedProject([CanBeNull] this IProject project)
+        public static bool IsUnityGeneratedProject(this IProject? project)
         {
             if (project == null)
                 return false;
@@ -56,35 +57,54 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
             return project.HasSubItems(AssetsFolder) && IsUnityProject(project);
         }
 
-        public static bool HasUnityFlavour([CanBeNull] this IProject project)
+        public static bool HasUnityFlavour(this IProject? project) =>
+            project != null && project.HasFlavour<UnityProjectFlavor>();
+
+        public static bool IsOneOfPredefinedUnityProjects(this IProject? project, bool includePlayerProjects = false)
         {
-            return project != null && project.HasFlavour<UnityProjectFlavor>();
+            // Editor projects obviously don't have player projects
+            return project.IsAssemblyCSharp(includePlayerProjects)
+                   || project.IsAssemblyCSharpEditor()
+                   || project.IsAssemblyCSharpFirstpass(includePlayerProjects)
+                   || project.IsAssemblyCSharpFirstpassEditor();
         }
 
-        public static bool IsOneOfPredefinedUnityProjects([CanBeNull] this IProject project)
+        public static bool IsMainUnityProject(this IProject? project)
         {
-            return project != null && project.IsAssemblyCSharp() || project.IsAssemblyCSharpEditor() ||
-                   project.IsAssemblyCSharpFirstpass() || project.IsAssemblyCSharpFirstpassEditor();
+            // TODO: The main project might be named anything if a user puts a .asmdef in the root of the Assets folder!
+            return project.IsAssemblyCSharp(false);
         }
 
-        public static bool IsAssemblyCSharp([CanBeNull] this IProject project)
+        public static bool IsAssemblyCSharp(this IProject? project, bool includePlayerProject)
         {
-            return project != null && project.Name == "Assembly-CSharp";
+            if (project == null) return false;
+            if (project.Name.Equals("Assembly-CSharp", StringComparison.OrdinalIgnoreCase)) return true;
+            return includePlayerProject && project.Name.Equals("Assembly-CSharp.Player", StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool IsAssemblyCSharpEditor([CanBeNull] this IProject project)
+        public static bool IsAssemblyCSharpFirstpass(this IProject? project, bool includePlayerProject)
         {
-            return project != null && project.Name == "Assembly-CSharp-Editor";
+            if (project == null) return false;
+            if (project.Name.Equals("Assembly-CSharp-firstpass", StringComparison.OrdinalIgnoreCase)) return true;
+            return includePlayerProject && project.Name.Equals("Assembly-CSharp-firstpass.Player", StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool IsAssemblyCSharpFirstpass([CanBeNull] this IProject project)
+        public static bool IsAssemblyCSharpEditor(this IProject? project) => project is { Name: "Assembly-CSharp-Editor" };
+        public static bool IsAssemblyCSharpFirstpassEditor(this IProject? project) => project is { Name: "Assembly-CSharp-Editor-firstpass" };
+
+        public static IProject? GetMainUnityProject(this ISolution solution)
         {
-            return project != null && project.Name == "Assembly-CSharp-firstpass";
+            // TODO: If a .asmdef file is placed in the root of Assets, no Assembly-CSharp project will be generated!
+            // If this returns null, find which project owns Assets/*.asmdef
+            return solution.GetAssemblyCSharpProject();
         }
 
-        public static bool IsAssemblyCSharpFirstpassEditor([CanBeNull] this IProject project)
-        {
-            return project != null && project.Name == "Assembly-CSharp-Editor-firstpass";
-        }
+        /// <summary>
+        /// Returns the Assembly-CSharp project. Can return null even in Unity projects!
+        /// </summary>
+        /// <param name="solution"></param>
+        /// <returns></returns>
+        public static IProject? GetAssemblyCSharpProject(this ISolution solution) =>
+            solution.GetProjectByName("Assembly-CSharp");
     }
 }

--- a/resharper/resharper-unity/src/Unity/Core/ProjectModel/UnityReferencesTracker.cs
+++ b/resharper/resharper-unity/src/Unity/Core/ProjectModel/UnityReferencesTracker.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using JetBrains.Application.changes;
 using JetBrains.Collections;
 using JetBrains.Diagnostics;
@@ -11,6 +10,8 @@ using JetBrains.ProjectModel.Assemblies.Impl;
 using JetBrains.ProjectModel.Tasks;
 using JetBrains.Util;
 using JetBrains.Util.Reflection;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
 {
@@ -35,7 +36,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
         // UnityEngine.ShaderInternalsModule.dll
         // Unity 2020.2 similarly splits UnityEditor.dll, primarily to allow packages to override implementations, such
         // as UIElements.
-        private static readonly JetHashSet<string> ourUnityReferenceNames = new JetHashSet<string>
+        private static readonly JetHashSet<string> ourUnityReferenceNames = new()
         {
             "UnityEngine",
             "UnityEngine.CoreModule",
@@ -55,7 +56,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
         private readonly ICollection<IUnityReferenceChangeHandler> myHandlers;
         private readonly Dictionary<IProject, Lifetime> myAllProjectLifetimes;
         private readonly HashSet<IProject> myUnityProjects;
-        
+
         private bool myHasUnityReference;
 
         static UnityReferencesTracker()
@@ -137,14 +138,14 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
             }
         }
 
-        object IChangeProvider.Execute(IChangeMap changeMap)
+        object? IChangeProvider.Execute(IChangeMap changeMap)
         {
             var projectModelChange = changeMap.GetChange<ProjectModelChange>(mySolution);
             if (projectModelChange == null)
                 return null;
 
             var changes = ReferencedAssembliesService.TryGetAssemblyReferenceChanges(projectModelChange,
-                ourUnityReferenceNameInfos, myLogger.Trace());
+                ourUnityReferenceNameInfos, LogEx.WhenTrace(myLogger));
 
             var newUnityProjects = new List<KeyValuePair<IProject, Lifetime>>();
             foreach (var change in changes)
@@ -177,7 +178,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
             return null;
         }
 
-        public bool IsUnityProject([CanBeNull] IProject project)
+        public bool IsUnityProject(IProject? project)
         {
             if (project == null || !project.IsValid())
                 return false;
@@ -188,10 +189,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel
             return myUnityProjects.Contains(project);
         }
 
-        private static bool HasUnityReferenceOrFlavour([NotNull] IProject project)
-        {
-            return project.HasUnityFlavour() || ReferencesUnity(project);
-        }
+        private static bool HasUnityReferenceOrFlavour(IProject project) =>
+            project.HasUnityFlavour() || ReferencesUnity(project);
 
         private static bool ReferencesUnity(IProject project)
         {

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Packages/PackageManager.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Packages/PackageManager.cs
@@ -804,7 +804,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
 
         private JetSemanticVersion GetMinimumVersion(string id)
         {
-            if (myGlobalManifest?.Packages.TryGetValue(id, out var editorPackageDetails) == true
+            // Note: do not inline this into the TryGetValue call, because net5's C# compiler complains, and that's what
+            // we use for CI. Presumably this because it would not be initialised if myGlobalManifest is null. net6's
+            // compiler doesn't complain.
+            // error CS0165: Use of unassigned local variable 'editorPackageDetails'
+            EditorPackageDetails? editorPackageDetails = null;
+            if (myGlobalManifest?.Packages.TryGetValue(id, out editorPackageDetails) == true
                 && JetSemanticVersion.TryParse(editorPackageDetails?.MinimumVersion, out var version))
             {
                 return version;

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Packages/PackageManager.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Packages/PackageManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using JetBrains.Annotations;
 using JetBrains.Application.changes;
 using JetBrains.Application.FileSystemTracker;
 using JetBrains.Collections;
@@ -17,6 +16,8 @@ using JetBrains.ReSharper.Plugins.Unity.Core.ProjectModel;
 using JetBrains.Threading;
 using JetBrains.Util;
 using JetBrains.Util.Logging;
+
+#nullable enable
 
 namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
 {
@@ -69,8 +70,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
         private readonly VirtualFileSystemPath myManifestPath;
         private readonly VirtualFileSystemPath myLocalPackageCacheFolder;
 
-        [CanBeNull] private VirtualFileSystemPath myLastReadGlobalManifestPath;
-        [CanBeNull] private EditorManifestJson myGlobalManifest;
+        private VirtualFileSystemPath? myLastReadGlobalManifestPath;
+        private EditorManifestJson? myGlobalManifest;
 
         public PackageManager(Lifetime lifetime, ISolution solution, ILogger logger,
                               UnitySolutionTracker unitySolutionTracker,
@@ -117,20 +118,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
 
         public Property<bool?> Updating { get; }
 
-        public ViewableProperty<bool> IsInitialUpdateFinished { get; } = new ViewableProperty<bool>(false);
+        public ViewableProperty<bool> IsInitialUpdateFinished { get; } = new(false);
 
         // DictionaryEvents uses locks internally, so this is thread safe. It gets updated from the guarded reentrancy
         // context, so all callbacks also happen within the guarded reentrancy context
         public IReadonlyCollectionEvents<KeyValuePair<string, PackageData>> Packages => myPackagesById;
 
-        [CanBeNull]
-        public PackageData GetPackageById(string id)
-        {
-            return myPackagesById.TryGetValue(id, out var packageData) ? packageData : null;
-        }
+        public PackageData? GetPackageById(string id) =>
+            myPackagesById.TryGetValue(id, out var packageData) ? packageData : null;
 
-        [CanBeNull]
-        public PackageData GetOwningPackage(VirtualFileSystemPath path)
+        public PackageData? GetOwningPackage(VirtualFileSystemPath path)
         {
             foreach (var packageData in myPackagesById.Values)
             {
@@ -261,18 +258,16 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
                 lifetimeDefinition.Terminate();
         }
 
-        [CanBeNull]
-        private List<PackageData> GetPackages()
+        private List<PackageData>? GetPackages()
         {
-            return myLogger.Verbose().DoCalculation("GetPackages", null,
+            return LogEx.WhenVerbose(myLogger).DoCalculation("GetPackages", null,
                 () => GetPackagesFromPackagesLockJson() ?? GetPackagesFromManifestJson(),
                 p => p != null ? $"{p.Count} packages" : "Null list of packages. Something went wrong");
         }
 
         // Introduced officially in 2019.4, but available behind a switch in manifest.json in 2019.3
         // https://forum.unity.com/threads/add-an-option-to-auto-update-packages.730628/#post-4931882
-        [CanBeNull]
-        private List<PackageData> GetPackagesFromPackagesLockJson()
+        private List<PackageData>? GetPackagesFromPackagesLockJson()
         {
             if (!myPackagesLockPath.ExistsFile)
             {
@@ -304,8 +299,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             });
         }
 
-        [CanBeNull]
-        private List<PackageData> GetPackagesFromManifestJson()
+        private List<PackageData>? GetPackagesFromManifestJson()
         {
             if (!myManifestPath.ExistsFile)
             {
@@ -425,7 +419,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             }
         }
 
-        [NotNull]
         private EditorManifestJson SafelyReadGlobalManifestFile(VirtualFileSystemPath globalManifestPath)
         {
             try
@@ -440,13 +433,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             }
         }
 
-        [NotNull]
         private PackageData GetPackageData(string id, PackagesLockDependency details,
                                            VirtualFileSystemPath builtInPackagesFolder)
         {
             try
             {
-                PackageData packageData = null;
+                PackageData? packageData = null;
                 switch (details.Source)
                 {
                     case "embedded":
@@ -480,7 +472,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
 
         private PackageData GetPackageData(string id, string version, string registry,
                                            VirtualFileSystemPath builtInPackagesFolder,
-                                           [CanBeNull] ManifestLockDetails lockDetails)
+                                           ManifestLockDetails? lockDetails)
         {
             // Order is important here. A package can be listed in manifest.json, but if it also exists in Packages,
             // that embedded copy takes precedence. We look for an embedded folder with the same name, but it can be
@@ -504,8 +496,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             }
         }
 
-        [CanBeNull]
-        private PackageData GetEmbeddedPackage(string id, string filePath)
+        private PackageData? GetEmbeddedPackage(string id, string filePath)
         {
             // Embedded packages live in the Packages folder. When reading from manifest.json, filePath is the same as
             // ID. When reading from packages-lock.json, we already know it's an embedded folder, and use the version,
@@ -514,8 +505,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             return GetPackageDataFromFolder(id, packageFolder, PackageSource.Embedded);
         }
 
-        [CanBeNull]
-        private PackageData GetRegistryPackage(string id, string version, string registryUrl)
+        private PackageData? GetRegistryPackage(string id, string version, string registryUrl)
         {
             // When parsing manifest.json, version might be a version, or it might even be a URL for a git package
             var cacheFolder = RelativePath.TryParse($"{id}@{version}");
@@ -539,8 +529,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             return GetPackageDataFromFolder(id, packageFolder, PackageSource.Registry);
         }
 
-        [CanBeNull]
-        private PackageData GetBuiltInPackage(string id, string version, VirtualFileSystemPath builtInPackagesFolder)
+        private PackageData? GetBuiltInPackage(string id, string version, VirtualFileSystemPath builtInPackagesFolder)
         {
             // Starting with Unity 2020.3, modules are copied into the local package cache, and compiled from there.
             // This behaviour has been backported to 2019.4 LTS. Make sure we use the cached files, or breakpoints won't
@@ -569,9 +558,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
                 : null;
         }
 
-        [CanBeNull]
-        private PackageData GetGitPackage(string id, string version, [CanBeNull] string hash,
-                                          [CanBeNull] string revision = null)
+        private PackageData? GetGitPackage(string id, string version, string? hash,
+                                           string? revision = null)
         {
             // For older Unity versions, manifest.json will have a hash for any git based package. For newer Unity
             // versions, this is stored in packages-lock.json. If the lock file is disabled, then we don't get a hash
@@ -615,8 +603,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
                     url.AbsolutePath.EndsWith(".git", StringComparison.InvariantCultureIgnoreCase));
         }
 
-        [CanBeNull]
-        private PackageData GetLocalPackage(string id, string version)
+        private PackageData? GetLocalPackage(string id, string version)
         {
             // If the version doesn't start with "file:" we know it's not a local package
             if (!version.StartsWith("file:"))
@@ -639,8 +626,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             }
         }
 
-        [CanBeNull]
-        private PackageData GetLocalTarballPackage(string id, string version)
+        private PackageData? GetLocalTarballPackage(string id, string version)
         {
             if (!version.StartsWith("file:"))
                 return null;
@@ -678,12 +664,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             }
         }
 
-        [CanBeNull]
-        private PackageData GetPackageDataFromFolder([CanBeNull] string id,
-                                                     [NotNull] VirtualFileSystemPath packageFolder,
-                                                     PackageSource packageSource,
-                                                     [CanBeNull] GitDetails gitDetails = null,
-                                                     [CanBeNull] VirtualFileSystemPath tarballLocation = null)
+        private PackageData? GetPackageDataFromFolder(string? id,
+                                                      VirtualFileSystemPath packageFolder,
+                                                      PackageSource packageSource,
+                                                      GitDetails? gitDetails = null,
+                                                      VirtualFileSystemPath? tarballLocation = null)
         {
             if (packageFolder.ExistsDirectory)
             {
@@ -712,21 +697,20 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
         private static string GetMd5OfString(string value)
         {
             // Use input string to calculate MD5 hash
-            using (var md5 = MD5.Create())
-            {
-                var inputBytes = Encoding.UTF8.GetBytes(value);
-                var hashBytes = md5.ComputeHash(inputBytes);
+            using var md5 = MD5.Create();
 
-                // Convert the byte array to hexadecimal string
-                var sb = new StringBuilder();
-                foreach (var t in hashBytes)
-                    sb.Append(t.ToString("X2"));
+            var inputBytes = Encoding.UTF8.GetBytes(value);
+            var hashBytes = md5.ComputeHash(inputBytes);
 
-                return sb.ToString().PadLeft(32, '0');
-            }
+            // Convert the byte array to hexadecimal string
+            var sb = new StringBuilder();
+            foreach (var t in hashBytes)
+                sb.Append(t.ToString("X2"));
+
+            return sb.ToString().PadLeft(32, '0');
         }
 
-        private List<PackageData> GetPackagesFromDependencies([NotNull] string registry,
+        private List<PackageData> GetPackagesFromDependencies(string registry,
                                                               Dictionary<string, PackageData> resolvedPackages,
                                                               List<PackageData> packagesToProcess)
         {
@@ -751,13 +735,13 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
                 }
             }
 
-            ICollection<VirtualFileSystemPath> cachedPackages = null;
+            ICollection<VirtualFileSystemPath>? cachedPackages = null;
             var newPackages = new List<PackageData>();
             foreach (var (id, version) in dependencies)
             {
                 if (version > GetResolvedVersion(id, resolvedPackages))
                 {
-                    if (cachedPackages == null) cachedPackages = myLocalPackageCacheFolder.GetChildDirectories();
+                    cachedPackages ??= myLocalPackageCacheFolder.GetChildDirectories();
 
                     // We know this is a registry package, so try to get it from the local cache. It might be missing:
                     // 1) the cache hasn't been built yet
@@ -770,7 +754,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
                     // 1) Check for the exact version in the local cache
                     // 2) Check for any version in the local cache
                     // 3) Check for the exact version in the global cache
-                    PackageData packageData = null;
+                    PackageData? packageData = null;
                     var exact = $"{id}@{version}";
                     var prefix = $"{id}@";
                     foreach (var packageFolder in cachedPackages)
@@ -820,8 +804,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
 
         private JetSemanticVersion GetMinimumVersion(string id)
         {
-            EditorPackageDetails editorPackageDetails = null;
-            if (myGlobalManifest?.Packages.TryGetValue(id, out editorPackageDetails) == true
+            if (myGlobalManifest?.Packages.TryGetValue(id, out var editorPackageDetails) == true
                 && JetSemanticVersion.TryParse(editorPackageDetails?.MinimumVersion, out var version))
             {
                 return version;
@@ -841,9 +824,6 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Packages
             return JetSemanticVersion.Empty;
         }
 
-        private static JetSemanticVersion Max(JetSemanticVersion v1, JetSemanticVersion v2)
-        {
-            return v1 > v2 ? v1 : v2;
-        }
+        private static JetSemanticVersion Max(JetSemanticVersion v1, JetSemanticVersion v2) => v1 > v2 ? v1 : v2;
     }
 }


### PR DESCRIPTION
This PR will:

* Automatically update a `.asmdef` file when a reference to another `.asmdef` based project is added or removed. Fixes #852 (and [RIDER-48660](https://youtrack.jetbrains.com/issue/RIDER-48660))
* Remove references from `.asmdef` file if a reference is removed from a `.csproj` file. This means the `.asmdef` file will be updated when e.g. the Remove Unused References refactoring is used. Fixes #1994
* Project references are added as GUID based references, unless existing name based references are being used.
* Asmdef references are correctly handled when modifying or adding/removing `.Player` projects. However, the reference change is not automatically propagated to the Player/non-player project until Unity regenerates the project files.

This PR does not currently handle reference modifications other than asmdef based changes. References to custom assemblies, or plugin assemblies (DLLs that are assets) are currently ignored. It might be best to notify the user that changes like this will be lost the next time Unity regenerates the project. 

Similarly, it does not update the `"autoReferenced"` property. This is `true` by default, and means all predefined assemblies (e.g. `Assembly-CSharp`) reference all `.asmdef` projects. If a reference to a `.asmdef` project is added to a predefined project, it would imply this flag is set to `false`. We can update this in this circumstance. However, it is unclear what we should do if a `.asmdef` project is removed from a predefined project. Should we automatically set the flag to `false`, or prompt first? We would also have to update any other references in predefined projects to be consistent.
