### PR TITLE
Fix complilation of UnityYamlMerge tool

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt
@@ -10,6 +10,7 @@ import com.intellij.diff.merge.MergeResult
 import com.intellij.diff.merge.ThreesideMergeRequest
 import com.intellij.diff.merge.external.AutomaticExternalMergeTool
 import com.intellij.diff.tools.external.ExternalDiffSettings
+import com.intellij.diff.tools.external.ExternalDiffSettings.ExternalToolGroup.MERGE_TOOL
 import com.intellij.diff.tools.external.ExternalDiffToolUtil
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -35,8 +36,9 @@ class UnityYamlAutomaticExternalMergeTool: AutomaticExternalMergeTool {
     override fun show(project: Project?, request: MergeRequest) {
         project ?: return
 
-        val settings = ExternalDiffSettings()
-        settings.isMergeTrustExitCode = true
+        val externalMergeTool = ExternalDiffSettings.ExternalTool()
+        externalMergeTool.isMergeTrustExitCode = true
+        externalMergeTool.groupName = MERGE_TOOL
         val appDataPath = UnityInstallationFinder.getInstance(project).getApplicationContentsPath() ?: return
         val extension = when {
             SystemInfo.isWindows -> ".exe"
@@ -48,17 +50,17 @@ class UnityYamlAutomaticExternalMergeTool: AutomaticExternalMergeTool {
         val premergedRight = Paths.get(tempDir).resolve("premergedRight_" + request.hashCode())
 
         try {
-            settings.isMergeTrustExitCode = true
-            settings.mergeExePath = appDataPath.resolve("Tools/UnityYAMLMerge" + extension).toString()
+            externalMergeTool.isMergeTrustExitCode = true
+            externalMergeTool.programPath = appDataPath.resolve("Tools/UnityYAMLMerge" + extension).toString()
             val mergeParameters = project.solution.frontendBackendModel.backendSettings.mergeParameters.valueOrThrow
             if (mergeParameters.contains(" -p "))
-                settings.mergeParameters = "$mergeParameters $premergedBase $premergedRight"
+                externalMergeTool.argumentPattern = "$mergeParameters $premergedBase $premergedRight"
             else
-                settings.mergeParameters = mergeParameters
+                externalMergeTool.argumentPattern = mergeParameters
 
-            myLogger.info("PreMerge with ${settings.mergeExePath} ${settings.mergeParameters}")
+            myLogger.info("PreMerge with ${externalMergeTool.programPath} ${externalMergeTool.argumentPattern}")
 
-            if (!tryExecuteMerge(project, settings, request as ThreesideMergeRequest)) {
+            if (!tryExecuteMerge(project, externalMergeTool, request as ThreesideMergeRequest)) {
                 if (premergedBase.exists() && premergedRight.exists()) {
                     myLogger.info("PreMerge partially successful. Call ShowMergeBuiltin on pre-merged.")
                     val output: VirtualFile = (request.outputContent as FileContent).file
@@ -78,15 +80,16 @@ class UnityYamlAutomaticExternalMergeTool: AutomaticExternalMergeTool {
         }
     }
 
-    private fun tryExecuteMerge(project: Project?, settings: ExternalDiffSettings, request: ThreesideMergeRequest): Boolean {
+    private fun tryExecuteMerge(project: Project?, externalMergeTool: ExternalDiffSettings.ExternalTool, request: ThreesideMergeRequest): Boolean {
         // see reference impl "com.intellij.diff.tools.external.ExternalDiffToolUtil#executeMerge"
         request.onAssigned(true)
         try {
-            if (ExternalDiffToolUtil.tryExecuteMerge(project, settings, request, null)) {
+            if (ExternalDiffToolUtil.tryExecuteMerge(project, externalMergeTool, request, null)) {
                 myLogger.info("Merge with external tool was fully successful. Apply result.")
                 request.applyResult(MergeResult.RESOLVED)
                 return true
             }
+
             return false
         } catch (e: Exception) {
             myLogger.error("UnityYamlMerge failed.", e)


### PR DESCRIPTION
Adjust code for the new API from IDEA and fix compilation errors.
Now multiple external merge tools are allowwed in the settings, so we
have to handle this for UnityYamlMerge too.

```
Options for KOTLIN DAEMON:
IncrementalCompilationOptions(super=CompilationOptions(compilerMode=INCREMENTAL_COMPILER,
targetPlatform=JVM, reportCategories=[0], reportSeverity=2,
requestedCompilationResults=[0]kotlinScriptExtensions=[kt, kts, java]),
areFileChangesKnown=false, modifiedFiles=null, deletedFiles=null,
classpathChanges=org.jetbrains.kotlin.incremental.ClasspathChanges$NotAvailable$ClasspathSnapshotIsDisabled@4532cfa5,
workingDir=/opt/buildAgent/work/227d632b77ca8a8e/rider/build/kotlin/compileKotlin,
multiModuleICSettings=MultiModuleICSettings(buildHistoryFile=/opt/buildAgent/work/227d632b77ca8a8e/rider/build/kotlin/compileKotlin/build-history.bin,
useModuleDetection=false),
usePreciseJavaTracking=trueoutputFiles=[/opt/buildAgent/work/227d632b77ca8a8e/rider/build/classes/kotlin/main,
/opt/buildAgent/work/227d632b77ca8a8e/rider/build/kotlin/compileKotlin])
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(39, 18): Unresolved reference: isMergeTrustExitCode
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(51, 22): Unresolved reference: isMergeTrustExitCode
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(52, 22): Unresolved reference: mergeExePath
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(55, 26): Unresolved reference: mergeParameters
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(57, 26): Unresolved reference: mergeParameters
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(59, 53): Unresolved reference: mergeExePath
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(59, 78): Unresolved reference: mergeParameters
e:
/opt/buildAgent/work/227d632b77ca8a8e/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/diff/UnityYamlAutomaticExternalMergeTool.kt:
(85, 63): Type mismatch: inferred type is ExternalDiffSettings but
ExternalDiffSettings.ExternalTool was expected
Restoring task outputs to pre-compilation state
```