### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,17 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 - Show preview for target typed new instances of `Color` ([RIDER-64151](https://youtrack.jetbrains.com/issue/RIDER-64151), [#2250](https://github.com/JetBrains/resharper-unity/pull/2250))
 - Update API information to 2022.1.0b7 ([#2276](https://github.com/JetBrains/resharper-unity/pull/2276))
+- Rider: Treat animation files as YAML ([#2283](https://github.com/JetBrains/resharper-unity/pull/2283))
 - Rider: Hide rename solution and manage NuGet packages by default ([RIDER-62297](https://youtrack.jetbrains.com/issue/RIDER-62297), [#2277](https://github.com/JetBrains/resharper-unity/pull/2277))
+- Rider: Updates to handling of hidden assets in Unity Explorer ([#2280](https://github.com/JetBrains/resharper-unity/pull/2280))
+- Rider: Improve notification when opening a Unity project as a folder ([#2286](https://github.com/JetBrains/resharper-unity/pull/2286))
 - Unity editor: Expand Find Usages editor window by default ([#2239](https://github.com/JetBrains/resharper-unity/pull/2239))
 
 ### Fixed
 
 - Fix massive performance issue when opening very large projects on certain file systems ([RIDER-53358](https://youtrack.jetbrains.com/issue/RIDER-53358), [#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
 - Fix excessive memory traffic when opening very large projects ([#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
+- Fix incorrect redundant attribute warning for `FormerlySerializedAs` attribute on property backing field ([#2285](https://github.com/JetBrains/resharper-unity/issues/2285), [#2289](https://github.com/JetBrains/resharper-unity/pull/2289))
 - Rider: Fix incorrectly showing both Unity and Unity DLL project action groups ([#2219](https://github.com/JetBrains/resharper-unity/pull/2219))
 - Rider: Fix incorrectly showing "switch to full UI" action when already in full UI ([RIDER-71185](https://youtrack.jetbrains.com/issue/RIDER-71185), [#2220](https://github.com/JetBrains/resharper-unity/pull/2220))
 - Rider: Fix debugging unit test when debugger is already attached to the editor ([RIDER-70660](https://youtrack.jetbrains.com/issue/RIDER-70660), [#2232](https://github.com/JetBrains/resharper-unity/pull/2232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix massive performance issue when opening very large projects on certain file systems ([RIDER-53358](https://youtrack.jetbrains.com/issue/RIDER-53358), [#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
 - Fix excessive memory traffic when opening very large projects ([#2271](https://github.com/JetBrains/resharper-unity/pull/2271))
 - Fix incorrect redundant attribute warning for `FormerlySerializedAs` attribute on property backing field ([#2285](https://github.com/JetBrains/resharper-unity/issues/2285), [#2289](https://github.com/JetBrains/resharper-unity/pull/2289))
+- Fix incorrect name shown for method usages by an animation controller ([RIDER-71268](https://youtrack.jetbrains.com/issue/RIDER-71268), [#2267](https://github.com/JetBrains/resharper-unity/pull/2267))
+- Fix incorrect usages shown when referencing an overridden virtual method from a Unity event ([RIDER-71269](https://youtrack.jetbrains.com/issue/RIDER-71269), [#2267](https://github.com/JetBrains/resharper-unity/pull/2267))
 - Rider: Fix incorrectly showing both Unity and Unity DLL project action groups ([#2219](https://github.com/JetBrains/resharper-unity/pull/2219))
 - Rider: Fix incorrectly showing "switch to full UI" action when already in full UI ([RIDER-71185](https://youtrack.jetbrains.com/issue/RIDER-71185), [#2220](https://github.com/JetBrains/resharper-unity/pull/2220))
 - Rider: Fix debugging unit test when debugger is already attached to the editor ([RIDER-70660](https://youtrack.jetbrains.com/issue/RIDER-70660), [#2232](https://github.com/JetBrains/resharper-unity/pull/2232))
@@ -49,6 +51,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Rider: Fix performance issue displaying long log issues from Unity ([RIDER-70574](https://youtrack.jetbrains.com/issue/RIDER-70574), [#2270](https://github.com/JetBrains/resharper-unity/pull/2270))
 - Rider: Fix showing duplicate project names in Unity Explorer under certain circumstances ([RIDER-67457](https://youtrack.jetbrains.com/issue/RIDER-67457), [#2273](https://github.com/JetBrains/resharper-unity/pull/2273))
 - Rider: Fix root folder of an external package ignoring namespace provider setting ([RIDER-65100](https://youtrack.jetbrains.com/issue/RIDER-65100), [#2274](https://github.com/JetBrains/resharper-unity/pull/2274))
+- Rider: Fix incorrectly showing gutter icons for implicit usages when setting is "never" ([RIDER-75000](https://youtrack.jetbrains.com/issue/RIDER-75000), [#2267](https://github.com/JetBrains/resharper-unity/pull/2267))
 
 
 

--- a/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewArray.cs
+++ b/resharper/resharper-json/src/Json/Psi/Tree/IJsonNewArray.cs
@@ -4,8 +4,8 @@ namespace JetBrains.ReSharper.Plugins.Json.Psi.Tree
 {
     public partial interface IJsonNewArray
     {
-        void AddArrayElementBefore(IJsonNewValue value, IJsonNewValue? anchor);
-        void AddArrayElementAfter(IJsonNewValue value, IJsonNewValue? anchor);
+        IJsonNewValue AddArrayElementBefore(IJsonNewValue value, IJsonNewValue? anchor);
+        IJsonNewValue AddArrayElementAfter(IJsonNewValue value, IJsonNewValue? anchor);
         void RemoveArrayElement(IJsonNewValue argument);
     }
 }

--- a/resharper/resharper-unity/src/Unity/AsmDef/AsmDefUtils.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/AsmDefUtils.cs
@@ -6,6 +6,17 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef
 {
     public static class AsmDefUtils
     {
-        public static string FormatGuidReference(Guid guid) => $"guid:{guid:N}";
+        // Unity serialises with uppercase "GUID:", but will read either case. The GUID itself is formatted in lowercase
+        public static string FormatGuidReference(Guid guid) => $"GUID:{guid:N}";
+
+        public static bool IsGuidReference(string reference) =>
+            reference.StartsWith("GUID:", StringComparison.OrdinalIgnoreCase);
+
+        public static bool TryParseGuidReference(string reference, out Guid guid)
+        {
+            guid = Guid.Empty;
+            // Skip the 5 chars of "GUID:"
+            return IsGuidReference(reference) && Guid.TryParse(reference[5..], out guid);
+        }
     }
 }

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/ContextActions/ConvertToNamedReferenceContextAction.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/ContextActions/ConvertToNamedReferenceContextAction.cs
@@ -45,7 +45,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.ContextActio
 
         protected override bool IsAvailable(IJsonNewLiteralExpression literalExpression)
         {
-            if (!literalExpression.GetUnquotedText().StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase))
+            if (!AsmDefUtils.IsGuidReference(literalExpression.GetUnquotedText()))
                 return false;
 
             var reference = literalExpression.FindReference<AsmDefNameReference>();

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/GuidReferenceInfoAnalyzer.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/GuidReferenceInfoAnalyzer.cs
@@ -30,7 +30,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Daemon
                                     IHighlightingConsumer consumer)
         {
             if ((element.IsReferencesArrayEntry() || element.IsReferencePropertyValue())
-                && element.GetUnquotedText().StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase))
+                && AsmDefUtils.IsGuidReference(element.GetUnquotedText()))
             {
                 var reference = element.FindReference<AsmDefNameReference>();
                 var declaredElement = reference?.Resolve().DeclaredElement;

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/PreferGuidReferenceProblemAnalyzer.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/PreferGuidReferenceProblemAnalyzer.cs
@@ -23,7 +23,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Daemon
         {
             // Unity prefers GUID references when creating a new file, to guard against accidentally changing the name
             if ((element.IsReferencesArrayEntry() || element.IsReferencePropertyValue())
-                && !element.GetUnquotedText().StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase))
+                && !AsmDefUtils.IsGuidReference(element.GetUnquotedText()))
             {
                 var reference = element.FindReference<AsmDefNameReference>();
                 if (reference != null && reference.Resolve().Info.ResolveErrorType == ResolveErrorType.OK)

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Modules/AsmDefModuleReferenceChangeListener.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Modules/AsmDefModuleReferenceChangeListener.cs
@@ -466,11 +466,11 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Modules
                 var text = literal.GetUnquotedText();
                 if (text.Equals(asmDefName, StringComparison.OrdinalIgnoreCase))
                     results.Add(literal);
-                else if (asmDefGuid != null && text.Equals(asmDefGuid))
+                else if (asmDefGuid != null && text.Equals(asmDefGuid, StringComparison.OrdinalIgnoreCase))
                     results.Add(literal);
 
                 count++;
-                if (text.StartsWith("guid:", StringComparison.OrdinalIgnoreCase))
+                if (AsmDefUtils.IsGuidReference(text))
                     guidCount++;
             }
 

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Resolve/AsmDefNameReference.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Resolve/AsmDefNameReference.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.Json.Psi;
 using JetBrains.ReSharper.Plugins.Json.Psi.Tree;
@@ -33,8 +32,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Resolve
                 return resolveResultWithInfo;
 
             var name = GetName();
-            if (name.StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase) &&
-                Guid.TryParse(name[5..], out var guid))
+            if (AsmDefUtils.TryParseGuidReference(name, out var guid))
             {
                 var metaFileCache = myOwner.GetSolution().GetComponent<MetaFileGuidCache>();
                 var asmDefCache = myOwner.GetSolution().GetComponent<AsmDefCache>();
@@ -86,8 +84,8 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Resolve
 
         public override IReference BindTo(IDeclaredElement element)
         {
-            // Don't rename a guid: reference
-            if (myOwner.GetUnquotedText().StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase))
+            // Don't rename a GUID: reference
+            if (AsmDefUtils.IsGuidReference(myOwner.GetUnquotedText()))
                 return this;
 
             var factory = JsonNewElementFactory.GetInstance(myOwner.GetPsiModule());

--- a/resharper/resharper-unity/src/Unity/AsmDef/Psi/Search/GuidReferenceUsageSearchFactory.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Psi/Search/GuidReferenceUsageSearchFactory.cs
@@ -143,7 +143,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Psi.Search
             }
 
             protected override bool PreFilterReference(IReference reference) => reference is AsmDefNameReference &&
-                reference.GetName().StartsWith("guid:", StringComparison.InvariantCultureIgnoreCase);
+                AsmDefUtils.IsGuidReference(reference.GetName());
 
             protected override bool SubTreeContainsText(ITreeNode node)
             {

--- a/resharper/resharper-unity/src/Unity/Core/Psi/Modules/UnityExternalFilesPsiModule.cs
+++ b/resharper/resharper-unity/src/Unity/Core/Psi/Modules/UnityExternalFilesPsiModule.cs
@@ -61,8 +61,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.Psi.Modules
 
         public bool ContainsFile(IPsiSourceFile sourceFile)
         {
-            // Note that UnityExternalPsiSourceFile.IsValid will call ContainsPath(sf.Location)
-            return sourceFile is UnityExternalPsiSourceFile && sourceFile.IsValid();
+            // This method is called by sourceFile.IsValid, which will be called A LOT for very large projects. Make
+            // sure to keep it quick and allocation free. And don't call sourceFile.IsValid
+            return sourceFile is UnityExternalPsiSourceFile && mySourceFiles.Contains(sourceFile);
         }
 
         public bool ContainsPath(VirtualFileSystemPath path) => mySourceFileTrie.Contains(path);

--- a/resharper/resharper-unity/src/Unity/Core/Psi/Modules/UnityExternalPsiSourceFileFactory.cs
+++ b/resharper/resharper-unity/src/Unity/Core/Psi/Modules/UnityExternalPsiSourceFileFactory.cs
@@ -32,7 +32,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Core.Psi.Modules
                                                                   CachedFileSystemData fileSystemData)
         {
             return new UnityExternalPsiSourceFile(path, psiModule, projectFileType,
-                file1 => psiModule.ContainsPath(file1.Location), _ => properties,
+                psiModule.ContainsFile, _ => properties,
                 myProjectFileExtensions, myProjectFileTypeCoordinator, myDocumentManager,
                 UniversalModuleReferenceContext.Instance, fileSystemData);
         }

--- a/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/Test01.asmdef.gold
+++ b/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/Test01.asmdef.gold
@@ -1,4 +1,4 @@
 ﻿{
   "name": "Test01",
-  "references": [ "guid:7d9f6c8edad14{caret}e1593fde9cc75764047" ]
+  "references": [ "GUID:7d9f6c8edad14{caret}e1593fde9cc75764047" ]
 }

--- a/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/TestAsmRef01.asmref.gold
+++ b/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/TestAsmRef01.asmref.gold
@@ -1,3 +1,3 @@
 ﻿{
-  "reference": "guid:7d9f6c8edad14{caret}e1593fde9cc75764047"
+  "reference": "GUID:7d9f6c8edad14{caret}e1593fde9cc75764047"
 }

--- a/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/TestExecuteInScope.asmdef.gold
+++ b/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ConvertToGuidReference/TestExecuteInScope.asmdef.gold
@@ -1,4 +1,4 @@
 ﻿{
   "name": "Test01",
-  "references": [ "guid:7d9f6c8edad14e1593fde9cc75764047", "guid:7d9f6c8edad14{caret}e1593fde9cc75764047", "guid:7d9f6c8edad14e1593fde9cc75764047", "guid:7d9f6c8edad14e1593fde9cc75764047", "guid:7d9f6c8edad14e1593fde9cc75764047" ]
+  "references": [ "GUID:7d9f6c8edad14e1593fde9cc75764047", "GUID:7d9f6c8edad14{caret}e1593fde9cc75764047", "GUID:7d9f6c8edad14e1593fde9cc75764047", "GUID:7d9f6c8edad14e1593fde9cc75764047", "GUID:7d9f6c8edad14e1593fde9cc75764047" ]
 }

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Analysis/FormerlySerializedAsAttribute/RedundantFormerlySerializedAs.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Analysis/FormerlySerializedAsAttribute/RedundantFormerlySerializedAs.cs
@@ -11,4 +11,8 @@ public class Test01
 public class Test02 : MonoBehaviour
 {
     [FormerlySerializedAs("myValue"), FormerlySerializedAs("foo")] public int myValue;
+
+    // Both attributes are NOT redundant. They apply to the backing field and do not match the generated field's name
+    [field: FormerlySerializedAs("foo"), FormerlySerializedAs("Value2")]
+    public string Value2 { get; set; }
 }

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Analysis/FormerlySerializedAsAttribute/RedundantFormerlySerializedAs.cs.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/Stages/Analysis/FormerlySerializedAsAttribute/RedundantFormerlySerializedAs.cs.gold
@@ -11,6 +11,10 @@ public class Test01
 public class Test02 : MonoBehaviour
 {
     [|FormerlySerializedAs("myValue")|(3), FormerlySerializedAs("foo")] public int myValue;
+
+    // Both attributes are NOT redundant. They apply to the backing field and do not match the generated field's name
+    [field: FormerlySerializedAs("foo"), FormerlySerializedAs("Value2")]
+    public string Value2 { get; set; }
 }
 
 ---------------------------------------------------------


### PR DESCRIPTION
This PR fixes a couple of issues:

* Stop adding duplicate GUID based references to `.asmdef` files ([RIDER-75001](https://youtrack.jetbrains.com/issue/RIDER-75001))
* Add naive formatting when adding references in `.asmdef` file, by simply copying the leading whitespace of the preceding reference
* Simplify `IsValid` for `UnityExternalPsiSourceFile`. This is called very frequently, and can have a noticeable impact for very large projects
* Fix incorrect redundant `FormerlySerializedAs` attribute warning when applied to the backing field of a property