### PR TITLE
Disable removing references from asmdef files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This plugin has functionality that is common to both ReSharper and Rider. It als
 Since 2018.1, the version numbers and release cycle match Rider's versions and release dates. The plugin is always bundled with Rider, but is released for ReSharper separately. Sometimes the ReSharper version isn't released. This is usually because the changes are not applicable to ReSharper, but also by mistake.
 
 ## 2022.1.0
-* [Commits](https://github.com/JetBrains/resharper-unity/compare/net213...net221)
+* [Commits](https://github.com/JetBrains/resharper-unity/compare/net213...net221-rtm-2022.1.0)
 * [Milestone](https://github.com/JetBrains/resharper-unity/milestone/50?closed=1)
 
 ### Added
@@ -37,6 +37,8 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 - Fix incorrect redundant attribute warning for `FormerlySerializedAs` attribute on property backing field ([#2285](https://github.com/JetBrains/resharper-unity/issues/2285), [#2289](https://github.com/JetBrains/resharper-unity/pull/2289))
 - Fix incorrect name shown for method usages by an animation controller ([RIDER-71268](https://youtrack.jetbrains.com/issue/RIDER-71268), [#2267](https://github.com/JetBrains/resharper-unity/pull/2267))
 - Fix incorrect usages shown when referencing an overridden virtual method from a Unity event ([RIDER-71269](https://youtrack.jetbrains.com/issue/RIDER-71269), [#2267](https://github.com/JetBrains/resharper-unity/pull/2267))
+- Rider: Fix showing dialog asking to run Unity when continuous testing is enabled ([#2293](https://github.com/JetBrains/resharper-unity/pull/2293))
+- Rider: Fix showing run Unity dialog multiple times when running tests in multiple projects ([#2293](https://github.com/JetBrains/resharper-unity/pull/2293))
 - Rider: Fix incorrectly showing both Unity and Unity DLL project action groups ([#2219](https://github.com/JetBrains/resharper-unity/pull/2219))
 - Rider: Fix incorrectly showing "switch to full UI" action when already in full UI ([RIDER-71185](https://youtrack.jetbrains.com/issue/RIDER-71185), [#2220](https://github.com/JetBrains/resharper-unity/pull/2220))
 - Rider: Fix debugging unit test when debugger is already attached to the editor ([RIDER-70660](https://youtrack.jetbrains.com/issue/RIDER-70660), [#2232](https://github.com/JetBrains/resharper-unity/pull/2232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Added
 
-- Add and remove references to `.asmdef` files when project references are modified, including with Remove Unused References refactoring ([#852](https://github.com/JetBrains/resharper-unity/issues/852), [RIDER-48660](https://youtrack.jetbrains.com/issue/RIDER-48660), [#1994](https://github.com/JetBrains/resharper-unity/issues/1994), [#2279](https://github.com/JetBrains/resharper-unity/pull/2279))
+- Add references to `.asmdef` files when adding a project reference via Alt+Enter quick fix ([#852](https://github.com/JetBrains/resharper-unity/issues/852), [RIDER-48660](https://youtrack.jetbrains.com/issue/RIDER-48660), [#1994](https://github.com/JetBrains/resharper-unity/issues/1994), [#2279](https://github.com/JetBrains/resharper-unity/pull/2279))
 - Add support for `.asmref` files ([#1406](https://github.com/JetBrains/resharper-unity/issues/1406), [#2252](https://github.com/JetBrains/resharper-unity/pull/2252))
 - Add inspection for correct method signature for `MenuItem` attribute ([RIDER-69350](https://youtrack.jetbrains.com/issue/RIDER-69350), [#2266](https://github.com/JetBrains/resharper-unity/pull/2266))
 - Rider: Add new run configuration to run Unity tests in batch mode ([RIDER-70675](https://youtrack.jetbrains.com/issue/RIDER-70675), [#2231](https://github.com/JetBrains/resharper-unity/pull/2231))
@@ -22,6 +22,7 @@ Since 2018.1, the version numbers and release cycle match Rider's versions and r
 
 ### Changed
 
+- Change unknown assembly reference in `.asmdef` file from an error to a warning ([#2297](https://github.com/JetBrains/resharper-unity/pull/2297))
 - Show preview for target typed new instances of `Color` ([RIDER-64151](https://youtrack.jetbrains.com/issue/RIDER-64151), [#2250](https://github.com/JetBrains/resharper-unity/pull/2250))
 - Update API information to 2022.1.0b7 ([#2276](https://github.com/JetBrains/resharper-unity/pull/2276))
 - Rider: Treat animation files as YAML ([#2283](https://github.com/JetBrains/resharper-unity/pull/2283))

--- a/resharper/resharper-unity/src/Unity/AsmDef/Daemon/Errors/AsmDefErrors.xml
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Daemon/Errors/AsmDefErrors.xml
@@ -10,6 +10,7 @@
 
   <StaticSeverityGroups>
     <Group name="AsmDef Errors" key="AsmDefErrors" />
+    <Group name="AsmDef Warnings" key="AsmDefWarnings" />
   </StaticSeverityGroups>
 
   <SeverityConfiguration>
@@ -74,12 +75,12 @@
     <Behavour attributeID="ERROR" overlapResolvePolicy="ERROR" />
   </Error>
 
-  <Error name="UnresolvedProjectReference" staticGroup="AsmDefErrors">
+  <Warning name="UnresolvedProjectReference" staticGroup="AsmDefWarnings">
     <Parameter type="IReference" name="reference" />
-    <Message value="Unknown project reference '{0}'">
+    <Message value="Missing assembly reference '{0}'. Assembly will not be referenced during compilation">
       <Argument>Reference.GetName()</Argument>
     </Message>
     <Range>Reference.GetDocumentRange()</Range>
-    <Behavour attributeID="UNRESOLVED_ERROR" overlapResolvePolicy="UNRESOLVED_ERROR" />
-  </Error>
+    <Behavour attributeID="DEADCODE" overlapResolvePolicy="DEADCODE" />
+  </Warning>
 </Errors>

--- a/resharper/resharper-unity/src/Unity/AsmDef/Daemon/Errors/RegisterStaticHighlightingsGroups.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Daemon/Errors/RegisterStaticHighlightingsGroups.cs
@@ -6,4 +6,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Daemon.Errors
     public class AsmDefErrors
     {
     }
+
+    [RegisterStaticHighlightingsGroup("AsmDef Warnings", true)]
+    public class AsmDefWarnings
+    {
+    }
 }

--- a/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/UnresolvedReferenceHandler.cs
+++ b/resharper/resharper-unity/src/Unity/AsmDef/Feature/Services/Daemon/UnresolvedReferenceHandler.cs
@@ -9,9 +9,9 @@ using JetBrains.ReSharper.Psi.Resolve;
 namespace JetBrains.ReSharper.Plugins.Unity.AsmDef.Feature.Services.Daemon
 {
     [Language(typeof(JsonNewLanguage))]
-    public class UnresolvedReferenceErrorHandler : IResolveProblemHighlighter
+    public class UnresolvedReferenceHandler : IResolveProblemHighlighter
     {
-        public IHighlighting Run(IReference reference) => new UnresolvedProjectReferenceError(reference);
+        public IHighlighting Run(IReference reference) => new UnresolvedProjectReferenceWarning(reference);
 
         public IEnumerable<ResolveErrorType> ErrorTypes =>
             new[] { AsmDefResolveErrorType.UNRESOLVED_REFERENCED_ASMDEF_ERROR };

--- a/resharper/resharper-unity/test/data/Unity/AsmDef/Daemon/Stages/Resolve/UnresolvedProject/Test01.asmdef.gold
+++ b/resharper/resharper-unity/test/data/Unity/AsmDef/Daemon/Stages/Resolve/UnresolvedProject/Test01.asmdef.gold
@@ -4,4 +4,4 @@
 }
 
 ---------------------------------------------------------
-(0): ReSharper Error Highlighting: Unknown project reference 'unresolvedAsm'
+(0): ReSharper Dead Code: Missing assembly reference 'unresolvedAsm'. Assembly will not be referenced during compilation

--- a/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ReferencingSelf/Availability/Test01.asmdef.gold
+++ b/resharper/resharper-unity/test/data/Unity/AsmDef/Intentions/QuickFixes/ReferencingSelf/Availability/Test01.asmdef.gold
@@ -4,7 +4,7 @@
 }
 
 ------------------------------------------------
-0: Unknown project reference 'Unresolved'
+0: Missing assembly reference 'Unresolved'. Assembly will not be referenced during compilation
 NO QUICKFIXES
 1: Cannot reference self
 QUICKFIXES:

--- a/resharper/resharper-unity/test/src/Unity.Tests/Unity/AsmDef/Feature/Services/Daemon/UnresolvedReferenceHighlightingTests.cs
+++ b/resharper/resharper-unity/test/src/Unity.Tests/Unity/AsmDef/Feature/Services/Daemon/UnresolvedReferenceHighlightingTests.cs
@@ -8,7 +8,7 @@ namespace JetBrains.ReSharper.Plugins.Tests.Unity.AsmDef.Feature.Services.Daemon
 {
     [TestUnity]
     [TestFileExtension(".asmdef")]
-    public class UnresolvedReferenceHighlightingTests : JsonNewHighlightingTestBase<UnresolvedProjectReferenceError>
+    public class UnresolvedReferenceHighlightingTests : JsonNewHighlightingTestBase<UnresolvedProjectReferenceWarning>
     {
         protected override PsiLanguageType CompilerIdsLanguage => JsonNewLanguage.Instance;
         protected override string RelativeTestDataPath => @"AsmDef\Daemon\Stages\Resolve\UnresolvedProject";


### PR DESCRIPTION
This PR will disables the automatic removal of references from a `.asmdef` file when the project model changes. For example, unloading a project would be treated the same as deleting a project reference and would remove the reference from the `.asmdef` file. Similarly, if a `.asmdef` file is disabled by editing a define constraint, then the project is regenerated without any references. Rider would interpret that as all references being removed and would delete all references from the `.asmdef` file. Support for updating the `.asmdef` file when a reference is added is still in place. We should reimplement support for removing references in 222.

Secondly, this PR changes the severity of an unknown project reference in a `.asmdef` file. Previously, this was displayed as red code, as an unresolved symbol. However, it is valid to include a reference to another `.asmdef` that is not included in the project. If the assembly isn't available, it is simply not included in compilation. The `.asmdef` file can create a define constraint that will define a symbol if the containing package is available, and use this to conditionally compile support if the package and referenced assembly is available.