### PR TITLE
Allow customizing "Start Unity" action by "Start Unity" run-configuration

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/AttachToUnityEditorAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/AttachToUnityEditorAction.kt
@@ -1,0 +1,30 @@
+package com.jetbrains.rider.plugins.unity.actions
+
+import com.intellij.execution.Executor
+import com.intellij.execution.RunManager
+import com.intellij.execution.executors.DefaultDebugExecutor
+import com.intellij.execution.runners.ExecutionUtil
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.DumbAwareAction
+import com.jetbrains.rider.plugins.unity.run.DefaultRunConfigurationGenerator
+import com.jetbrains.rider.plugins.unity.run.configurations.UnityDebugConfigurationType
+
+class AttachUnityEditorAction: DumbAwareAction() {
+    private val logger = Logger.getInstance(AttachUnityEditorAction::class.java)
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        val runManager = RunManager.getInstance(project)
+        val settings = runManager.findConfigurationByTypeAndName(
+                UnityDebugConfigurationType.id, DefaultRunConfigurationGenerator.ATTACH_CONFIGURATION_NAME)
+
+        if (settings != null) {
+            ExecutionUtil.runConfiguration(settings,
+                Executor.EXECUTOR_EXTENSION_NAME.extensionList.single { it is DefaultDebugExecutor })
+        } else {
+            logger.warn("Have not found run-configuration ${DefaultRunConfigurationGenerator.ATTACH_CONFIGURATION_NAME}.")
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/StartUnityAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/StartUnityAction.kt
@@ -3,10 +3,9 @@ package com.jetbrains.rider.plugins.unity.actions
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
-import com.jetbrains.rider.plugins.unity.model.frontendBackend.frontendBackendModel
 import com.jetbrains.rider.plugins.unity.isConnectedToEditor
+import com.jetbrains.rider.plugins.unity.model.frontendBackend.frontendBackendModel
 import com.jetbrains.rider.plugins.unity.util.getUnityArgs
-import com.jetbrains.rider.plugins.unity.util.withDebugCodeOptimization
 import com.jetbrains.rider.plugins.unity.util.withProjectPath
 import com.jetbrains.rider.plugins.unity.util.withRiderPath
 import com.jetbrains.rider.projectView.solution

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/StartUnityAction.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/actions/StartUnityAction.kt
@@ -1,14 +1,23 @@
 package com.jetbrains.rider.plugins.unity.actions
 
+import com.intellij.execution.RunManager
+import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsSafe
 import com.jetbrains.rider.plugins.unity.isConnectedToEditor
 import com.jetbrains.rider.plugins.unity.model.frontendBackend.frontendBackendModel
+import com.jetbrains.rider.plugins.unity.run.DefaultRunConfigurationGenerator
+import com.jetbrains.rider.plugins.unity.run.configurations.unityExe.UnityExeConfiguration
+import com.jetbrains.rider.plugins.unity.run.configurations.unityExe.UnityExeConfigurationType
 import com.jetbrains.rider.plugins.unity.util.getUnityArgs
 import com.jetbrains.rider.plugins.unity.util.withProjectPath
 import com.jetbrains.rider.plugins.unity.util.withRiderPath
 import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.run.createEmptyConsoleCommandLine
+import com.jetbrains.rider.run.withRawParameters
 
 
 open class StartUnityAction : DumbAwareAction() {
@@ -20,29 +29,48 @@ open class StartUnityAction : DumbAwareAction() {
 
     override fun update(e: AnActionEvent) {
         val model = e.project?.solution?.frontendBackendModel
+        @NlsSafe
         val version = model?.unityApplicationData?.valueOrNull?.applicationVersion
 
         if (version != null)
-            e.presentation.text = "Start Unity ($version)"
+            e.presentation.text = UnityPluginActionsBundle.message("action.start.unity.text", version)
 
         e.presentation.isEnabled = version != null && !e.project.isConnectedToEditor()
         super.update(e)
     }
 
     companion object {
-        fun startUnity(project: Project, vararg args: String): Process? {
-            val processBuilderArgs = getUnityArgs(project).withProjectPath(project).withRiderPath()
-            processBuilderArgs.addAll(args)
-            return startUnity(processBuilderArgs)
+        private val logger = Logger.getInstance(StartUnityAction::class.java)
+        fun startUnity(project: Project): Process? {
+            val runManager = RunManager.getInstance(project)
+            val settings =
+                runManager.findConfigurationByTypeAndName(UnityExeConfigurationType.id, DefaultRunConfigurationGenerator.RUN_DEBUG_START_UNITY_CONFIGURATION_NAME)
+
+            if (settings != null){
+                val exeConfiguration = settings.configuration as UnityExeConfiguration
+                val runCommandLine = createEmptyConsoleCommandLine(exeConfiguration.parameters.useExternalConsole)
+                    .withEnvironment(exeConfiguration.parameters.envs)
+                    .withParentEnvironmentType(if (exeConfiguration.parameters.isPassParentEnvs) {
+                        GeneralCommandLine.ParentEnvironmentType.CONSOLE
+                    } else {
+                        GeneralCommandLine.ParentEnvironmentType.NONE
+                    })
+                    .withExePath(exeConfiguration.parameters.exePath)
+                    .withWorkDirectory(exeConfiguration.parameters.workingDirectory)
+                    .withRawParameters(exeConfiguration.parameters.programParameters)
+
+                return runCommandLine.toProcessBuilder().start()
+            }
+            else {
+                logger.warn("UnityExeConfiguration ${DefaultRunConfigurationGenerator.RUN_DEBUG_START_UNITY_CONFIGURATION_NAME} was not found.")
+                val processBuilderArgs = getUnityArgs(project).withProjectPath(project).withRiderPath()
+                return startUnity(processBuilderArgs)
+            }
         }
 
         fun startUnity(args: MutableList<String>): Process? {
             val processBuilder = ProcessBuilder(args)
             return processBuilder.start()
-        }
-
-        fun startUnityAndRider(project: Project) {
-            startUnity(project, "-executeMethod", "JetBrains.Rider.Unity.Editor.RiderMenu.MenuOpenProject")
         }
     }
 }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
@@ -78,9 +78,7 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
             }
 
             // create it, if it doesn't exist, to advertise the feature
-            project.solution.frontendBackendModel.unityProjectSettings.buildLocation.adviseNotNull(
-                projectComponentLifetime
-            ) {
+            project.solution.frontendBackendModel.unityProjectSettings.buildLocation.adviseNotNull(lt) {
                 createOrUpdateUnityExeRunConfiguration(
                     RUN_DEBUG_STANDALONE_CONFIGURATION_NAME,
                     it,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
@@ -31,7 +31,7 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
     }
 
     init {
-        project.solution.frontendBackendModel.hasUnityReference.whenTrue(projectComponentLifetime) {
+        project.solution.frontendBackendModel.hasUnityReference.whenTrue(projectComponentLifetime) { lt ->
             val runManager = RunManager.getInstance(project)
             // Clean up the renamed "attach and play" configuration from 2018.2 EAP1-3
             // (Was changed from a separate configuration type to just another factory under "Attach to Unity")
@@ -58,7 +58,7 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
                 runManager.addConfiguration(runConfiguration)
             }
 
-            project.solution.frontendBackendModel.unityApplicationData.adviseNotNull(projectComponentLifetime) {
+            project.solution.frontendBackendModel.unityApplicationData.adviseNotNull(lt) {
                 val exePath = UnityInstallationFinder.getOsSpecificPath(Paths.get(it.applicationPath))
                 if (exePath.toFile().isFile) {
                     val config = runManager.allSettings.firstOrNull { s -> s.type is UnityExeConfigurationType

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
@@ -29,6 +29,7 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
         const val ATTACH_AND_PLAY_CONFIGURATION_NAME = "Attach to Unity Editor & Play"
         const val RUN_DEBUG_STANDALONE_CONFIGURATION_NAME = "Standalone Player"
         const val RUN_DEBUG_BATCH_MODE_UNITTESTS_CONFIGURATION_NAME = "UnitTests (batch mode)"
+        const val RUN_DEBUG_START_UNITY_CONFIGURATION_NAME = "Start Unity"
     }
 
     private val logger = Logger.getInstance(DefaultRunConfigurationGenerator::class.java)
@@ -65,18 +66,24 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
                 val exePath = UnityInstallationFinder.getOsSpecificPath(Paths.get(it.applicationPath))
                 if (exePath.toFile().isFile) {
                     createOrUpdateUnityExeRunConfiguration(
+                        RUN_DEBUG_START_UNITY_CONFIGURATION_NAME,
+                        exePath.toFile().canonicalPath,
+                        project.solutionDirectory.canonicalPath,
+                        mutableListOf<String>().withProjectPath(project).withDebugCodeOptimization().toProgramParameters(),
+                        runManager)
+
+                    createOrUpdateUnityExeRunConfiguration(
                         RUN_DEBUG_BATCH_MODE_UNITTESTS_CONFIGURATION_NAME,
                         exePath.toFile().canonicalPath,
                         project.solutionDirectory.canonicalPath,
                         mutableListOf<String>().withRunTests().withBatchMode()
                             .withProjectPath(project).withTestResults(project)
                             .withTestPlatform().withDebugCodeOptimization().toProgramParameters(),
-                        runManager
-                    )
+                        runManager)
                 } else
-                    logger.warn("Unexpected: $exePath is not a file.")
+                    logger.trace("exePath: $exePath is not a file.")
             }
-            
+
             project.solution.frontendBackendModel.unityProjectSettings.buildLocation.adviseNotNull(lt) {
                 createOrUpdateUnityExeRunConfiguration(
                     RUN_DEBUG_STANDALONE_CONFIGURATION_NAME,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/run/DefaultRunConfigurationGenerator.kt
@@ -76,8 +76,7 @@ class DefaultRunConfigurationGenerator(project: Project) : ProtocolSubscribedPro
                 } else
                     logger.warn("Unexpected: $exePath is not a file.")
             }
-
-            // create it, if it doesn't exist, to advertise the feature
+            
             project.solution.frontendBackendModel.unityProjectSettings.buildLocation.adviseNotNull(lt) {
                 createOrUpdateUnityExeRunConfiguration(
                     RUN_DEBUG_STANDALONE_CONFIGURATION_NAME,

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityUtils.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/unity/util/UnityUtils.kt
@@ -16,10 +16,9 @@ fun addPlayModeArguments(args : MutableList<String>) {
     args.add("JetBrains.Rider.Unity.Editor.StartUpMethodExecutor.EnterPlayMode")
 }
 
-fun getUnityArgs(project: Project):MutableList<String>
-{
+fun getUnityArgs(project: Project):MutableList<String> {
     val executable = UnityInstallationFinder.getInstance(project).getApplicationExecutablePath().toString()
-    return mutableListOf<String>(executable)
+    return mutableListOf(executable)
 }
 
 fun MutableList<String>.withRiderPath() : MutableList<String> {

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -264,6 +264,7 @@
       </group>
 
       <group id="UnityDllShowImportantAction" popup="true" class="com.jetbrains.rider.plugins.unity.ui.UnityDllImportantActions" text="Important Unity Related Actions">
+        <reference ref="StartUnityAction" />
         <reference ref="AttachToUnityProcessAction" />
         <reference ref="ShowUnitySettingsInRider" />
       </group>

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -188,9 +188,16 @@
     <action id="AttachToUnityProcessAction"
             class="com.jetbrains.rider.plugins.unity.actions.AttachToUnityProcessAction"
             text="Attach to Unity Process&#8230;"
-            description="Attach debugger to Unity Editor process"
+            description="Attach debugger to Unity process"
             icon="UnityIcons.Actions.AttachToUnity">
       <add-to-group group-id="XDebugger.AttachGroup" anchor="after" relative-to-action="com.jetbrains.rider.debugger.actions.RiderAttachToRemoteProcessAction" />
+    </action>
+
+    <action id="AttachToUnityEditorAction"
+            class="com.jetbrains.rider.plugins.unity.actions.AttachUnityEditorAction"
+            text="Attach to Unity Editor"
+            description="Attach debugger to Unity Editor process"
+            icon="UnityIcons.Actions.AttachToUnity">
     </action>
 
     <action id="ShowUnitySettingsInRider"
@@ -246,6 +253,7 @@
                 text="Start Unity"
                 description="Start Unity with current project"
                 icon="UnityIcons.Actions.StartUnity" />
+        <reference ref="AttachToUnityEditorAction" />
         <reference ref="AttachToUnityProcessAction" />
         <reference ref="ShowUnitySettingsInRider" />
         <action id="ShowUnityLogInRiderAction"

--- a/rider/src/main/resources/messages/UnityPluginActionsBundle.properties
+++ b/rider/src/main/resources/messages/UnityPluginActionsBundle.properties
@@ -2,3 +2,5 @@ action.show.tilde.folders.text=Show Folders Ending With '~'
 action.show.project.names.text=Show Project Names
 action.show.project.names.description=Show names of owning projects next to folders
 action.show.all.files.description=Show all files, including .meta files
+
+action.start.unity.text=Start Unity ({0})


### PR DESCRIPTION
Fix for:
https://youtrack.jetbrains.com/issue/RIDER-78619/Ability-to-set-custom-environment-variables-when-starting-Unity-from-Rider
https://youtrack.jetbrains.com/issue/RIDER-77371/Support-custom-Unity-command-line-arguments-in-Start-Unity-Rider-action

We are not removing the action only because it is not possible to assign shortcut for just run-configration.
https://youtrack.jetbrains.com/issue/IDEA-69968/Add-option-to-assign-keyboard-shortcut-to-RunDebug-configurations