### PR TITLE
fix DEXP-608179 One of the handlers for the BeforeAcquiringReadLock h…

### DIFF
--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/UnityVersion.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/UnityVersion.cs
@@ -122,7 +122,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration
             if (mySolution.IsVirtualSolution())
                 return VirtualFileSystemPath.GetEmptyPathFor(InteractionContext.SolutionContext);
 
-            if (myActualAppPathForSolution.HasValue())
+            if (myActualAppPathForSolution.HasValue() && !myActualAppPathForSolution.Value.IsNullOrEmpty())
                 return myActualAppPathForSolution.Value;
 
             ourLogger.Verbose(


### PR DESCRIPTION
…as failed. The execution context must be guarded from reentrancy in order to execute this action.