### PR TITLE
Disable API verification for Unity.Shaders.dll

### DIFF
--- a/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
+++ b/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
   <!-- ********** -->
   <ItemGroup Label="Cg">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>JetBrains_ApiVerification</_Parameter1>
+      <_Parameter2>disabled</_Parameter2>
+    </AssemblyAttribute>
     <PsiLanguageNames Include="Cg">
       <Visible>False</Visible>
     </PsiLanguageNames>


### PR DESCRIPTION
Unity.Shaders is a pluggable part of Unity plugin. The Unity plugin can
be used without installed ReSharper C++, but ReSharper's API verifier
doesn't know that and report an error during installation. To workaround
this issue disable API verification for Unity.Shaders explicitly.

Please note, that I targeted this PR to net222, but this change also required in net223.