### PR TITLE
Mute InputSystem tests

### DIFF
--- a/rider/src/test/kotlin/markup/InputSystemTest.kt
+++ b/rider/src/test/kotlin/markup/InputSystemTest.kt
@@ -6,6 +6,7 @@ import com.jetbrains.rdclient.daemon.util.backendAttributeIdOrThrow
 import com.jetbrains.rdclient.util.idea.waitAndPump
 import com.jetbrains.rider.plugins.unity.model.frontendBackend.frontendBackendModel
 import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.test.annotations.Mute
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.framework.executeWithGold
 import com.jetbrains.rider.test.scriptingApi.*
@@ -13,7 +14,7 @@ import org.testng.annotations.Test
 import java.io.File
 import java.time.Duration
 
-
+@Mute("RIDER-84142")
 class InputSystemTest : BaseTestWithSolution() {
     override fun getSolutionDirectoryName(): String {
         return "InputSystemTestData"

--- a/rider/src/test/kotlin/markup/InputSystemUnityEventModeTest.kt
+++ b/rider/src/test/kotlin/markup/InputSystemUnityEventModeTest.kt
@@ -7,6 +7,7 @@ import com.jetbrains.rdclient.util.idea.toIOFile
 import com.jetbrains.rdclient.util.idea.waitAndPump
 import com.jetbrains.rider.plugins.unity.model.frontendBackend.frontendBackendModel
 import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.test.annotations.Mute
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.framework.combine
 import com.jetbrains.rider.test.framework.executeWithGold
@@ -24,6 +25,7 @@ class InputSystemUnityEventModeTest : BaseTestWithSolution() {
     override fun preprocessTempDirectory(tempDir: File) {
         prepareAssemblies(activeSolutionDirectory)
     }
+    @Mute("RIDER-84142")
     @Test
     fun usedCodeTest() {
         val projectLifetime = project.lifetime


### PR DESCRIPTION
We need to investigate what causes "Should not add/remove to packages without setting packagesUpdating" exception. Not to block other work, tests are temporaly muted.

See [RIDER-84142](https://youtrack.jetbrains.com/issue/RIDER-84142).