### PR TITLE
Net223 rider-79869 IBaker Usage inscpection suppression

### DIFF
--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -56,7 +56,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 {
                     AddUnityTypeHighlighting(consumer, element, "Unity type", "Custom Unity type", context);
                 }
-                else if (UnityApi.IsDotsSystemType(typeElement))
+                else if (UnityApi.IsDotsType(typeElement))
                 {
                     //TODO obsolete
                     AddUnityECSHighlighting(consumer, element, "ECS system", "Unity entities system",

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/Stages/Highlightings/IconsProviders/TypeDetector.cs
@@ -56,7 +56,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.Stages.Highlightings.I
                 {
                     AddUnityTypeHighlighting(consumer, element, "Unity type", "Custom Unity type", context);
                 }
-                else if (UnityApi.IsDotsType(typeElement))
+                else if (UnityApi.IsDotsImplicitlyUsedType(typeElement))
                 {
                     //TODO obsolete
                     AddUnityECSHighlighting(consumer, element, "ECS system", "Unity entities system",

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -59,7 +59,10 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
                                      IsUxmlFactory(cls):
                     flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
                     return true;
-
+                case IStruct @struct when unityApi.IsUnityType(@struct) ||
+                                     UnityApi.IsDotsSystemType(@struct) :
+                    flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
+                    return true;
                 case ITypeElement typeElement when unityApi.IsSerializableTypeDeclaration(typeElement):
                     // TODO: We should only really mark it as in use if it's actually used somewhere
                     // That is, it should be used as a field in a Unity type, or another serializable type

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -55,12 +55,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
             switch (element)
             {
                 case IClass cls when unityApi.IsUnityType(cls) ||
-                                     UnityApi.IsDotsSystemType(cls) ||
+                                     UnityApi.IsDotsType(cls) ||
                                      IsUxmlFactory(cls):
                     flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
                     return true;
                 case IStruct @struct when unityApi.IsUnityType(@struct) ||
-                                     UnityApi.IsDotsSystemType(@struct) :
+                                     UnityApi.IsDotsType(@struct) :
                     flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
                     return true;
                 case ITypeElement typeElement when unityApi.IsSerializableTypeDeclaration(typeElement):

--- a/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
+++ b/resharper/resharper-unity/src/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressor.cs
@@ -55,12 +55,12 @@ namespace JetBrains.ReSharper.Plugins.Unity.CSharp.Daemon.UsageChecking
             switch (element)
             {
                 case IClass cls when unityApi.IsUnityType(cls) ||
-                                     UnityApi.IsDotsType(cls) ||
+                                     UnityApi.IsDotsImplicitlyUsedType(cls) ||
                                      IsUxmlFactory(cls):
                     flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
                     return true;
                 case IStruct @struct when unityApi.IsUnityType(@struct) ||
-                                     UnityApi.IsDotsType(@struct) :
+                                     UnityApi.IsDotsImplicitlyUsedType(@struct) :
                     flags = ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature;
                     return true;
                 case ITypeElement typeElement when unityApi.IsSerializableTypeDeclaration(typeElement):

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/KnownTypes.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/KnownTypes.cs
@@ -106,6 +106,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
         // ECS/DOTS
         public static readonly IClrTypeName ComponentSystemBase = new ClrTypeName("Unity.Entities.ComponentSystemBase");
         public static readonly IClrTypeName ISystem = new ClrTypeName("Unity.Entities.ISystem");
+        public static readonly IClrTypeName IBaker = new ClrTypeName("Unity.Entities.IBaker");
 
         // Burst
         public static readonly IClrTypeName BurstCompiler = new ClrTypeName("Unity.Burst.BurstCompiler");

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
@@ -54,7 +54,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
         public bool IsUnityType([NotNullWhen(true)] ITypeElement? type) =>
             type != null && myUnityTypeCache.IsUnityType(type);
 
-        public static bool IsDotsSystemType([NotNullWhen(true)] ITypeElement? typeElement) =>
+        public static bool IsDotsType([NotNullWhen(true)] ITypeElement? typeElement) =>
             typeElement.DerivesFrom(KnownTypes.ComponentSystemBase) 
             || typeElement.DerivesFrom(KnownTypes.ISystem)
             || typeElement.DerivesFrom(KnownTypes.IBaker);

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
@@ -54,7 +54,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
         public bool IsUnityType([NotNullWhen(true)] ITypeElement? type) =>
             type != null && myUnityTypeCache.IsUnityType(type);
 
-        public static bool IsDotsType([NotNullWhen(true)] ITypeElement? typeElement) =>
+        public static bool IsDotsImplicitlyUsedType([NotNullWhen(true)] ITypeElement? typeElement) =>
             typeElement.DerivesFrom(KnownTypes.ComponentSystemBase) 
             || typeElement.DerivesFrom(KnownTypes.ISystem)
             || typeElement.DerivesFrom(KnownTypes.IBaker);

--- a/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
+++ b/resharper/resharper-unity/src/Unity/UnityEditorIntegration/Api/UnityApi.cs
@@ -55,7 +55,9 @@ namespace JetBrains.ReSharper.Plugins.Unity.UnityEditorIntegration.Api
             type != null && myUnityTypeCache.IsUnityType(type);
 
         public static bool IsDotsSystemType([NotNullWhen(true)] ITypeElement? typeElement) =>
-            typeElement.DerivesFrom(KnownTypes.ComponentSystemBase) || typeElement.DerivesFrom(KnownTypes.ISystem);
+            typeElement.DerivesFrom(KnownTypes.ComponentSystemBase) 
+            || typeElement.DerivesFrom(KnownTypes.ISystem)
+            || typeElement.DerivesFrom(KnownTypes.IBaker);
 
         // A serialised field cannot be abstract or generic, but a type declaration that will be serialised can be. This
         // method differentiates between a type declaration and a type usage. Consider renaming if we ever need to

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityDotsBacker.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityDotsBacker.cs
@@ -1,0 +1,36 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace UnityEngine
+{
+    public class MonoBehaviour
+    {}
+}
+
+namespace Unity.Entities
+{
+    // ReSharper disable once InconsistentNaming
+    public abstract class IBaker
+    {
+    }
+
+    public class Baker<T> : IBaker
+    {
+        // ReSharper disable once UnusedMember.Global
+        // ReSharper disable once UnusedParameter.Global
+        public virtual void Bake(T authoring)
+        {
+        }
+    }
+}
+
+internal class CannonBallAuthoring : MonoBehaviour
+{
+}
+
+internal class CannonBallBaker : Baker<CannonBallAuthoring>
+{
+    public override void Bake(CannonBallAuthoring authoring)
+    {
+    }
+}

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityDotsBacker.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityDotsBacker.gold
@@ -1,0 +1,38 @@
+﻿using Unity.Entities;
+using UnityEngine;
+
+namespace UnityEngine
+{
+    public class MonoBehaviour
+    {}
+}
+
+namespace Unity.Entities
+{
+    // ReSharper disable once InconsistentNaming
+    public abstract class IBaker
+    {
+    }
+
+    public class Baker<T> : IBaker
+    {
+        // ReSharper disable once UnusedMember.Global
+        // ReSharper disable once UnusedParameter.Global
+        public virtual void Bake(T authoring)
+        {
+        }
+    }
+}
+
+internal class CannonBallAuthoring : MonoBehaviour
+{
+}
+
+internal class CannonBallBaker : Baker<CannonBallAuthoring>
+{
+    public override void Bake(CannonBallAuthoring authoring)
+    {
+    }
+}
+---------------------------------------------------------
+

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemClass.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemClass.cs
@@ -1,0 +1,13 @@
+using Unity.Entities;
+
+
+namespace Unity.Entities
+{
+    public interface ISystem {}
+}
+
+
+public class UnityEcsSystemClass : ISystem
+{
+    
+}

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemClass.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemClass.gold
@@ -1,0 +1,15 @@
+﻿using Unity.Entities;
+
+
+namespace Unity.Entities
+{
+    public interface ISystem {}
+}
+
+
+public class UnityEcsSystemClass : ISystem
+{
+    
+}
+---------------------------------------------------------
+

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemStruct.cs
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemStruct.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+
+namespace Unity.Entities
+{
+    public interface ISystem {}
+}
+
+public struct UnityEcsSystemStruct : ISystem
+{
+    
+}

--- a/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemStruct.gold
+++ b/resharper/resharper-unity/test/data/Unity/CSharp/Daemon/UsageChecking/UnityEcsSystemStruct.gold
@@ -1,0 +1,13 @@
+﻿using Unity.Entities;
+
+namespace Unity.Entities
+{
+    public interface ISystem {}
+}
+
+public struct UnityEcsSystemStruct : ISystem
+{
+    
+}
+---------------------------------------------------------
+

--- a/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
+++ b/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
@@ -25,6 +25,7 @@ namespace JetBrains.ReSharper.Plugins.Tests.Unity.CSharp.Daemon.UsageChecking
         [Test] public void MethodWithAttributeWithRequiredSignature() { DoNamedTest(); }
         [Test] public void UnityEcsSystemClass() { DoNamedTest(); }
         [Test] public void UnityEcsSystemStruct() { DoNamedTest(); }
+        [Test] public void UnityDotsBacker() { DoNamedTest(); }
 
         protected override void DoTest(Lifetime lifetime, IProject project)
         {

--- a/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
+++ b/resharper/resharper-unity/test/src/Unity.Tests/Unity/CSharp/Daemon/UsageChecking/UsageInspectionsSuppressorTest.cs
@@ -23,6 +23,8 @@ namespace JetBrains.ReSharper.Plugins.Tests.Unity.CSharp.Daemon.UsageChecking
         [Test] public void PreprocessBuildInterface01() { DoNamedTest(); }
         [Test] public void PreprocessBuildInterface02() { DoNamedTest(); }
         [Test] public void MethodWithAttributeWithRequiredSignature() { DoNamedTest(); }
+        [Test] public void UnityEcsSystemClass() { DoNamedTest(); }
+        [Test] public void UnityEcsSystemStruct() { DoNamedTest(); }
 
         protected override void DoTest(Lifetime lifetime, IProject project)
         {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/RIDER-84159/Class-derived-from-Baker-should-be-marked-as-used

```
using Unity.Entities;
using Unity.Rendering;

class CannonBallAuthoring : UnityEngine.MonoBehaviour
{
}

class CannonBallBaker : Baker<CannonBallAuthoring>
{
    public override void Bake(CannonBallAuthoring authoring)
    {
        // By default, components are zero-initialized.
        // So in this case, the Speed field in CannonBall will be float3.zero.
        AddComponent<CannonBall>();
        AddComponent<URPMaterialPropertyBaseColor>();
    }
}
```