### PR TITLE
Disable API verification for Unity.Shaders.dll

### DIFF
--- a/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
+++ b/resharper/resharper-unity/src/Unity.Shaders/Unity.Shaders.csproj
@@ -48,6 +48,12 @@
   <ItemGroup Label="ProjectReference">
     <ProjectReference Include="..\Unity\Unity.csproj" />
   </ItemGroup>
+  <ItemGroup Label="ApiVerifier">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>JetBrains_ApiVerification</_Parameter1>
+      <_Parameter2>disabled</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup Label="ShaderLab">
     <PsiLanguageNames Include="ShaderLab">
       <Visible>False</Visible>


### PR DESCRIPTION
Similar to https://github.com/JetBrains/resharper-unity/pull/2346, but it was added to the wrong section in csproj and therefore accidentally removed. 

Unity.Shaders is a pluggable part of Unity plugin. The Unity plugin can be used without installed ReSharper C++, but ReSharper's API verifier doesn't know that and report an error during installation. To workaround this issue disable API verification for Unity.Shaders explicitly.