### PR TITLE
Fix 'occured' -> 'occurred' typos in MetaFileGuidCache error logs

### DIFF
--- a/resharper/resharper-unity/src/Unity/Yaml/Psi/Caches/MetaFileGuidCache.cs
+++ b/resharper/resharper-unity/src/Unity/Yaml/Psi/Caches/MetaFileGuidCache.cs
@@ -87,7 +87,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             }
             catch (Exception e)
             {
-                myLogger.Error(e, "An error occured during changing guid");
+                myLogger.Error(e, "An error occurred while changing guid");
             }
 
             RemoveFromLocalCache(sourceFile);
@@ -110,7 +110,7 @@ namespace JetBrains.ReSharper.Plugins.Unity.Yaml.Psi.Caches
             }
             catch (Exception e)
             {
-                myLogger.Error(e, "An error occured during changing guid");
+                myLogger.Error(e, "An error occurred while changing guid");
             }
 
             RemoveFromLocalCache(sourceFile);


### PR DESCRIPTION
Two `myLogger.Error` messages in `resharper/resharper-unity/src/Unity/Yaml/Psi/Caches/MetaFileGuidCache.cs` (lines 90 and 113) emitted when meta-file GUID change fails read `An error occured during changing guid`. Updated to `An error occurred while changing guid` (also fixes the awkward 'during changing'). String-literal-only change inside catch blocks.